### PR TITLE
Keycloak does not deal well when URLs containing the port 80

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        quarkus-version: ["1.13.3.Final", "2.0.0.Alpha2"]
+        quarkus-version: ["1.13.4.Final", "2.0.0.Alpha2"]
         java: [ 11 ]
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        quarkus-version: ["1.13.3.Final", "2.0.0.Alpha2"]
+        quarkus-version: ["1.13.4.Final", "2.0.0.Alpha2"]
         java: [ 11 ]
     steps:
       - uses: actions/checkout@v1

--- a/quarkus-test-service-keycloak/src/main/java/io/quarkus/test/bootstrap/KeycloakService.java
+++ b/quarkus-test-service-keycloak/src/main/java/io/quarkus/test/bootstrap/KeycloakService.java
@@ -11,6 +11,7 @@ public class KeycloakService extends BaseService<KeycloakService> {
 
     private static final String USER = "admin";
     private static final String PASSWORD = "admin";
+    private static final int HTTP_80 = 80;
 
     private final String realm;
 
@@ -26,7 +27,13 @@ public class KeycloakService extends BaseService<KeycloakService> {
     }
 
     public String getRealmUrl() {
-        return String.format("%s:%s/auth/realms/%s", getHost(), getPort(), realm);
+        String url = getHost();
+        // SMELL: Keycloak does not validate Token Issuers when URL contains the port 80.
+        if (getPort() != HTTP_80) {
+            url += ":" + getPort();
+        }
+
+        return String.format("%s/auth/realms/%s", url, realm);
     }
 
     public AuthzClient createAuthzClient(String clientId, String clientSecret) {


### PR DESCRIPTION
When using token, we might get:
```
 [keycloak] 05:36:26,827 ERROR [org.keycloak.services] (default task-1) KC-SERVICES0025: Error when validating client assertion: java.lang.RuntimeException: Token audience doesn't match domain. Realm issuer is 'http://keycloak-ts-alnohanwix.apps.ocp46.dynamic.quarkus/auth/realms/test-realm' but audience from token is '[http://keycloak-ts-alnohanwix.apps.ocp46.dynamic.quarkus:80/auth/realms/test-realm]'
```