### PR TITLE
Support Operators

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -86,7 +86,7 @@
         <module name="EmptyForIteratorPad"/>
         <!-- <module name="GenericWhitespace"/> -->
         <module name="MethodParamPad"/>
-        <module name="NoWhitespaceAfter"/>
+        <!-- <module name="NoWhitespaceAfter"/> -->
         <module name="NoWhitespaceBefore"/>
         <module name="OperatorWrap"/>
         <module name="ParenPad"/>

--- a/examples/kafka/src/test/java/io/quarkus/qe/StrimziOperatorKafkaWithoutRegistryMessagingIT.java
+++ b/examples/kafka/src/test/java/io/quarkus/qe/StrimziOperatorKafkaWithoutRegistryMessagingIT.java
@@ -1,0 +1,33 @@
+package io.quarkus.qe;
+
+import java.time.Duration;
+
+import org.apache.http.HttpStatus;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.OpenShiftScenario;
+import io.quarkus.test.services.Operator;
+import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.test.services.operator.KafkaInstance;
+
+@OpenShiftScenario
+public class StrimziOperatorKafkaWithoutRegistryMessagingIT {
+
+    @Operator(name = "strimzi-kafka-operator")
+    static final KafkaInstance kafka = new KafkaInstance();
+
+    @QuarkusApplication
+    static final RestService app = new RestService()
+            .withProperty("kafka.bootstrap.servers", kafka.getBootstrapUrl());
+
+    @Test
+    public void checkUserResourceByNormalUser() {
+        Awaitility.await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+            app.given().get("/prices/poll")
+                    .then()
+                    .statusCode(HttpStatus.SC_OK);
+        });
+    }
+}

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/OperatorService.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/OperatorService.java
@@ -1,0 +1,29 @@
+package io.quarkus.test.bootstrap;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.fabric8.kubernetes.client.CustomResource;
+import io.quarkus.test.services.operator.model.CustomResourceDefinition;
+import io.quarkus.test.services.operator.model.CustomResourceSpec;
+import io.quarkus.test.services.operator.model.CustomResourceStatus;
+
+public class OperatorService<T extends Service> extends BaseService<T> {
+
+    private List<CustomResourceDefinition> crds = new ArrayList<>();
+
+    public List<CustomResourceDefinition> getCrds() {
+        return crds;
+    }
+
+    public OperatorService<T> withCrd(String name, String crdFile) {
+        crds.add(new CustomResourceDefinition(name, crdFile));
+        return this;
+    }
+
+    public OperatorService<T> withCrd(String name, String crdFile,
+            Class<? extends CustomResource<CustomResourceSpec, CustomResourceStatus>> type) {
+        crds.add(new CustomResourceDefinition(name, crdFile, type));
+        return this;
+    }
+}

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/scenarios/OpenShiftScenario.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/scenarios/OpenShiftScenario.java
@@ -9,6 +9,7 @@ import java.lang.annotation.Target;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import io.quarkus.test.bootstrap.QuarkusScenarioBootstrap;
+import io.quarkus.test.services.Operator;
 
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
@@ -16,4 +17,6 @@ import io.quarkus.test.bootstrap.QuarkusScenarioBootstrap;
 @Inherited
 public @interface OpenShiftScenario {
     OpenShiftDeploymentStrategy deployment() default OpenShiftDeploymentStrategy.Build;
+
+    Operator[] operators() default {};
 }

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/Operator.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/Operator.java
@@ -1,0 +1,18 @@
+package io.quarkus.test.services;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ ElementType.TYPE, ElementType.FIELD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Operator {
+    String name();
+
+    String channel() default "stable";
+
+    String source() default "community-operators";
+
+    String sourceNamespace() default "openshift-marketplace";
+}

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/operator/OperatorAnnotationBinding.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/operator/OperatorAnnotationBinding.java
@@ -1,0 +1,23 @@
+package io.quarkus.test.services.operator;
+
+import java.lang.reflect.Field;
+
+import io.quarkus.test.bootstrap.AnnotationBinding;
+import io.quarkus.test.bootstrap.ManagedResourceBuilder;
+import io.quarkus.test.services.Operator;
+
+public class OperatorAnnotationBinding implements AnnotationBinding {
+    @Override
+    public boolean isFor(Field field) {
+        return field.isAnnotationPresent(Operator.class);
+    }
+
+    @Override
+    public ManagedResourceBuilder createBuilder(Field field) {
+        Operator metadata = field.getAnnotation(Operator.class);
+
+        ManagedResourceBuilder builder = new OperatorManagedResourceBuilder();
+        builder.init(metadata);
+        return builder;
+    }
+}

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/operator/OperatorManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/operator/OperatorManagedResource.java
@@ -1,0 +1,95 @@
+package io.quarkus.test.services.operator;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import io.quarkus.test.bootstrap.ManagedResource;
+import io.quarkus.test.bootstrap.OpenShiftExtensionBootstrap;
+import io.quarkus.test.bootstrap.OperatorService;
+import io.quarkus.test.bootstrap.Protocol;
+import io.quarkus.test.bootstrap.ServiceContext;
+import io.quarkus.test.bootstrap.inject.OpenShiftClient;
+import io.quarkus.test.services.operator.model.CustomResourceDefinition;
+import io.quarkus.test.utils.FileUtils;
+
+public class OperatorManagedResource implements ManagedResource {
+
+    private final OperatorManagedResourceBuilder model;
+    private final OpenShiftClient client;
+
+    private boolean running;
+    private List<CustomResourceDefinition> crdsToWatch = new ArrayList<>();
+
+    public OperatorManagedResource(OperatorManagedResourceBuilder model) {
+        this.model = model;
+        this.client = model.getContext().get(OpenShiftExtensionBootstrap.CLIENT);
+    }
+
+    @Override
+    public void start() {
+        if (!running) {
+            installOperator();
+            applyCRDs();
+
+            running = true;
+        }
+    }
+
+    @Override
+    public void stop() {
+        // Stop method in operators is not supported yet
+    }
+
+    @Override
+    public boolean isRunning() {
+        return running && customResourcesAreReady();
+    }
+
+    @Override
+    public String getHost(Protocol protocol) {
+        // Operator does not expose services.
+        return null;
+    }
+
+    @Override
+    public int getPort(Protocol protocol) {
+        // Operator does not expose services.
+        return 0;
+    }
+
+    @Override
+    public List<String> logs() {
+        // Logs in operators is not supported yet
+        return Collections.emptyList();
+    }
+
+    private void applyCRDs() {
+        if (model.getContext().getOwner() instanceof OperatorService) {
+            OperatorService service = (OperatorService) model.getContext().getOwner();
+            for (Object crd : service.getCrds()) {
+                applyCRD((CustomResourceDefinition) crd);
+            }
+        }
+    }
+
+    private void applyCRD(CustomResourceDefinition crd) {
+        ServiceContext serviceContext = model.getContext();
+        String content = FileUtils.loadFile(crd.getFile());
+
+        client.apply(serviceContext.getOwner(),
+                FileUtils.copyContentTo(content, serviceContext.getServiceFolder().resolve(crd.getName())));
+
+        if (crd.getType().isPresent()) {
+            crdsToWatch.add(crd);
+        }
+    }
+
+    private boolean customResourcesAreReady() {
+        return crdsToWatch.stream().allMatch(crd -> client.isCustomResourceReady(crd.getName(), crd.getType().get()));
+    }
+
+    private void installOperator() {
+        client.installOperator(model.getName(), model.getChannel(), model.getSource(), model.getSourceNamespace());
+    }
+}

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/operator/OperatorManagedResourceBuilder.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/operator/OperatorManagedResourceBuilder.java
@@ -1,0 +1,52 @@
+package io.quarkus.test.services.operator;
+
+import java.lang.annotation.Annotation;
+
+import io.quarkus.test.bootstrap.ManagedResource;
+import io.quarkus.test.bootstrap.ManagedResourceBuilder;
+import io.quarkus.test.bootstrap.ServiceContext;
+import io.quarkus.test.services.Operator;
+
+public class OperatorManagedResourceBuilder implements ManagedResourceBuilder {
+
+    private ServiceContext context;
+    private String name;
+    private String channel;
+    private String source;
+    private String sourceNamespace;
+
+    protected String getName() {
+        return name;
+    }
+
+    protected String getChannel() {
+        return channel;
+    }
+
+    protected String getSource() {
+        return source;
+    }
+
+    protected String getSourceNamespace() {
+        return sourceNamespace;
+    }
+
+    protected ServiceContext getContext() {
+        return context;
+    }
+
+    @Override
+    public void init(Annotation annotation) {
+        Operator metadata = (Operator) annotation;
+        name = metadata.name();
+        channel = metadata.channel();
+        source = metadata.source();
+        sourceNamespace = metadata.sourceNamespace();
+    }
+
+    @Override
+    public ManagedResource build(ServiceContext context) {
+        this.context = context;
+        return new OperatorManagedResource(this);
+    }
+}

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/operator/model/CustomResourceDefinition.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/operator/model/CustomResourceDefinition.java
@@ -1,0 +1,34 @@
+package io.quarkus.test.services.operator.model;
+
+import java.util.Optional;
+
+import io.fabric8.kubernetes.client.CustomResource;
+
+public class CustomResourceDefinition {
+    private final String name;
+    private final String file;
+    private final Optional<Class<? extends CustomResource<CustomResourceSpec, CustomResourceStatus>>> type;
+
+    public CustomResourceDefinition(String name, String file) {
+        this(name, file, null);
+    }
+
+    public CustomResourceDefinition(String name, String file,
+            Class<? extends CustomResource<CustomResourceSpec, CustomResourceStatus>> type) {
+        this.name = name;
+        this.file = file;
+        this.type = Optional.ofNullable(type);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getFile() {
+        return file;
+    }
+
+    public Optional<Class<? extends CustomResource<CustomResourceSpec, CustomResourceStatus>>> getType() {
+        return type;
+    }
+}

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/operator/model/CustomResourceSpec.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/operator/model/CustomResourceSpec.java
@@ -1,0 +1,7 @@
+package io.quarkus.test.services.operator.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CustomResourceSpec {
+}

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/operator/model/CustomResourceStatus.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/operator/model/CustomResourceStatus.java
@@ -1,0 +1,19 @@
+package io.quarkus.test.services.operator.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CustomResourceStatus {
+    private List<CustomResourceStatusCondition> conditions = new ArrayList<>();
+
+    public List<CustomResourceStatusCondition> getConditions() {
+        return conditions;
+    }
+
+    public void setConditions(List<CustomResourceStatusCondition> conditions) {
+        this.conditions = conditions;
+    }
+}

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/operator/model/CustomResourceStatusCondition.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/operator/model/CustomResourceStatusCondition.java
@@ -1,0 +1,25 @@
+package io.quarkus.test.services.operator.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CustomResourceStatusCondition {
+    private String status;
+    private String type;
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+}

--- a/quarkus-test-openshift/src/main/resources/META-INF/services/io.quarkus.test.bootstrap.AnnotationBinding
+++ b/quarkus-test-openshift/src/main/resources/META-INF/services/io.quarkus.test.bootstrap.AnnotationBinding
@@ -1,0 +1,1 @@
+io.quarkus.test.services.operator.OperatorAnnotationBinding

--- a/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/operator/KafkaInstance.java
+++ b/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/operator/KafkaInstance.java
@@ -1,0 +1,26 @@
+package io.quarkus.test.services.operator;
+
+import io.quarkus.test.bootstrap.OperatorService;
+import io.quarkus.test.services.operator.model.KafkaInstanceCustomResource;
+
+public class KafkaInstance extends OperatorService<KafkaInstance> {
+
+    private static final String BOOTSTRAP_URL = "%s-kafka-bootstrap:9092";
+    private static final String KAFKA_INSTANCE_NAME_DEFAULT = "kafka-instance";
+    private static final String KAFKA_INSTANCE_TEMPLATE_DEFAULT = "/strimzi-operator-kafka-instance.yaml";
+
+    private final String name;
+
+    public KafkaInstance() {
+        this(KAFKA_INSTANCE_NAME_DEFAULT, KAFKA_INSTANCE_TEMPLATE_DEFAULT);
+    }
+
+    public KafkaInstance(String name, String crdFile) {
+        this.name = name;
+        withCrd(name, crdFile, KafkaInstanceCustomResource.class);
+    }
+
+    public String getBootstrapUrl() {
+        return String.format(BOOTSTRAP_URL, name);
+    }
+}

--- a/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/operator/model/KafkaInstanceCustomResource.java
+++ b/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/operator/model/KafkaInstanceCustomResource.java
@@ -1,0 +1,15 @@
+package io.quarkus.test.services.operator.model;
+
+import io.fabric8.kubernetes.api.model.Namespaced;
+import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.model.annotation.Group;
+import io.fabric8.kubernetes.model.annotation.Kind;
+import io.fabric8.kubernetes.model.annotation.Version;
+
+@Version("v1beta2")
+@Group("kafka.strimzi.io")
+@Kind("Kafka")
+public class KafkaInstanceCustomResource
+        extends CustomResource<CustomResourceSpec, CustomResourceStatus>
+        implements Namespaced {
+}

--- a/quarkus-test-service-kafka/src/main/resources/strimzi-operator-kafka-instance.yaml
+++ b/quarkus-test-service-kafka/src/main/resources/strimzi-operator-kafka-instance.yaml
@@ -1,0 +1,38 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: Kafka
+metadata:
+  name: kafka-instance
+spec:
+  kafka:
+    version: 2.6.0
+    replicas: 1
+    listeners:
+      - name: plain
+        port: 9092
+        type: internal
+        tls: false
+      - name: tls
+        port: 9093
+        type: internal
+        tls: true
+    config:
+      offsets.topic.replication.factor: 1
+      transaction.state.log.replication.factor: 1
+      transaction.state.log.min.isr: 1
+      log.message.format.version: "2.6"
+    storage:
+      type: jbod
+      volumes:
+        - id: 0
+          type: persistent-claim
+          size: 100Mi
+          deleteClaim: true
+  zookeeper:
+    replicas: 1
+    storage:
+      type: persistent-claim
+      size: 100Mi
+      deleteClaim: true
+  entityOperator:
+    topicOperator: {}
+    userOperator: {}


### PR DESCRIPTION
#### Operators

The OpenShift scenarios support Operator based test cases. There are two ways to deal with Operators:

- Installing the Operators as part of the `OpenShiftScenario`:

```java
@OpenShiftScenario(
        operators = @Operator(name = "strimzi-kafka-operator")
)
public class StrimziOperatorKafkaWithoutRegistryMessagingIT {
    // We can now use the new Operator CRDs manually
}
```

- Installing and managing Custom Resource Definitions as services

First, we need to create our Custom Resource YAML file, for example, for Kafka:

```yaml
apiVersion: kafka.strimzi.io/v1beta2
kind: Kafka
metadata:
  name: kafka-instance
spec:
  ...
```

Now, we can create an OperatorService to load this YAML as part of an Operator installation:

```java
@OpenShiftScenario
public class OperatorExampleIT {

    @Operator(name = "my-operator", source = "...")
    static final OperatorService operator = new OperatorService().withCrd("kafka-instance", "/my-crd.yaml");

    @QuarkusApplication
    static final RestService app = new RestService();

    // ...
}
```

The framework will install the operator and load the YAML file by you.

Note that the framework will wait for the operator to be installed before loading the CRD yaml files, but will not wait for the CRDs to be ready. If you are working with CRDs that update conditions, then we can ease this for you by providing the custom resource definition:

```java
@Version("v1beta2")
@Group("kafka.strimzi.io")
@Kind("Kafka")
public class KafkaInstanceCustomResource
        extends CustomResource<CustomResourceSpec, CustomResourceStatus>
        implements Namespaced {
}
```

And then registering the CRD with this type:

```java
@OpenShiftScenario
public class OperatorExampleIT {

    @Operator(name = "my-operator", source = "...")
    static final OperatorService operator = new OperatorService().withCrd("kafka-instance", "/my-crd.yaml", KafkaInstanceCustomResource.class);

    @QuarkusApplication
    static final RestService app = new RestService();

    // ...
}
```

Now, the framework will wait for the operator to be installed and the custom resource named `kafka-instance` to be with a condition "Ready" as "True".

Fix https://github.com/quarkus-qe/quarkus-test-framework/issues/31