### PR TITLE
Quarkus source S2I strategy

### DIFF
--- a/examples/external-applications/pom.xml
+++ b/examples/external-applications/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus.qe</groupId>
+        <artifactId>quarkus-test-parent</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+        <relativePath>../../</relativePath>
+    </parent>
+    <artifactId>examples-external-applications</artifactId>
+    <name>Quarkus - Test Framework - Examples - External Applications</name>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus.qe</groupId>
+            <artifactId>quarkus-test-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus.qe</groupId>
+            <artifactId>quarkus-test-containers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus.qe</groupId>
+            <artifactId>quarkus-test-openshift</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftS2iQuickstartIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftS2iQuickstartIT.java
@@ -1,0 +1,25 @@
+package io.quarkus.qe;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
+import io.quarkus.test.scenarios.OpenShiftScenario;
+import io.quarkus.test.services.QuarkusApplication;
+
+@OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.QuarkusS2IBuild)
+public class OpenShiftS2iQuickstartIT {
+
+    @QuarkusApplication(sourceS2iRepositoryUri = "https://github.com/quarkusio/quarkus-quickstarts.git", sourceS2iGitRef = "1.11", sourceS2iContextDir = "getting-started")
+    static final RestService app = new RestService();
+
+    @Test
+    public void test() {
+        app.given()
+                .get("/hello")
+                .then()
+                .statusCode(HttpStatus.SC_OK);
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -310,6 +310,7 @@
                 <module>examples/amq-tcp</module>
                 <module>examples/amq-amqp</module>
                 <module>examples/jaeger</module>
+                <module>examples/external-applications</module>
             </modules>
         </profile>
         <profile>

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/QuarkusApplication.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/QuarkusApplication.java
@@ -21,4 +21,13 @@ public @interface QuarkusApplication {
      * `quarkus.http.ssl.certificate.key-store-password` to be set.
      */
     boolean ssl() default false;
+
+    String sourceS2iRepositoryUri() default "";
+
+    String sourceS2iGitRef() default "";
+
+    String sourceS2iContextDir() default "";
+
+    String[] sourceS2iEnvVars() default {};
+
 }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusApplicationManagedResourceBuilder.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusApplicationManagedResourceBuilder.java
@@ -61,6 +61,11 @@ public class QuarkusApplicationManagedResourceBuilder implements ManagedResource
     private boolean selectedAppClasses = true;
     private QuarkusManagedResource managedResource;
     private Map<String, String> propertiesSnapshot;
+    private String sourceS2iRepositoryUri;
+    private String sourceS2iGitRef;
+    private String sourceS2iContextDir;
+    private String[] sourceS2iEnvVars;
+    private Map<String, String> envVars;
 
     protected LaunchMode getLaunchMode() {
         return launchMode;
@@ -86,6 +91,22 @@ public class QuarkusApplicationManagedResourceBuilder implements ManagedResource
         return sslEnabled;
     }
 
+    protected String getSourceS2iRepositoryUri() {
+        return sourceS2iRepositoryUri;
+    }
+
+    protected String getSourceS2iGitRef() {
+        return sourceS2iGitRef;
+    }
+
+    protected String[] getSourceS2iEnvVars() {
+        return sourceS2iEnvVars;
+    }
+
+    protected String getSourceS2iContextDir() {
+        return sourceS2iContextDir;
+    }
+
     @Override
     public void init(Annotation annotation) {
         QuarkusApplication metadata = (QuarkusApplication) annotation;
@@ -95,6 +116,10 @@ public class QuarkusApplicationManagedResourceBuilder implements ManagedResource
             appClasses = ClassPathUtils.findAllClassesFromSource();
             selectedAppClasses = false;
         }
+        sourceS2iRepositoryUri = metadata.sourceS2iRepositoryUri();
+        sourceS2iGitRef = metadata.sourceS2iGitRef();
+        sourceS2iContextDir = metadata.sourceS2iContextDir();
+        sourceS2iEnvVars = metadata.sourceS2iEnvVars();
     }
 
     @Override

--- a/quarkus-test-core/src/main/java/io/quarkus/test/utils/ClassPathUtils.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/utils/ClassPathUtils.java
@@ -22,6 +22,9 @@ public final class ClassPathUtils {
         List<Class<?>> classes = new LinkedList<>();
         try {
             Path classesPathInSources = Path.of(SOURCE_CLASSES_LOCATION);
+            if (!Files.exists(classesPathInSources)) {
+                return new Class<?>[0];
+            }
             try (Stream<Path> stream = Files.walk(classesPathInSources)) {
                 stream.map(Path::toString).filter(s -> s.endsWith(CLASS_SUFFIX)).map(ClassPathUtils::normalizeClassName)
                         .forEach(className -> {

--- a/quarkus-test-core/src/main/java/io/quarkus/test/utils/FileUtils.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/utils/FileUtils.java
@@ -4,10 +4,12 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -100,4 +102,15 @@ public final class FileUtils {
 
         return Optional.empty();
     }
+
+    public static Path copyResourceIntoTempFile(String resourceFileName) {
+        try (InputStream resources = FileUtils.class.getClassLoader().getResourceAsStream(resourceFileName)) {
+            Path tempFile = Files.createTempFile(resourceFileName.split("\\.")[0], "." + resourceFileName.split("\\.")[1]);
+            Files.copy(resources, tempFile, StandardCopyOption.REPLACE_EXISTING);
+            return tempFile;
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
 }

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
@@ -7,6 +7,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -34,6 +35,7 @@ import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
 import io.fabric8.kubernetes.client.dsl.ExecListener;
 import io.fabric8.kubernetes.client.dsl.ExecWatch;
 import io.fabric8.kubernetes.client.utils.Serialization;
+import io.fabric8.openshift.api.model.BuildConfig;
 import io.fabric8.openshift.api.model.DeploymentConfig;
 import io.fabric8.openshift.api.model.ImageStream;
 import io.fabric8.openshift.api.model.Route;
@@ -189,6 +191,14 @@ public final class OpenShiftClient {
         }
     }
 
+    public void followBuildConfigLogs(String buildConfigName) {
+        try {
+            new Command(OC, "logs", "bc/" + buildConfigName, "--follow").runAndWait();
+        } catch (Exception e) {
+            fail("Log retrieval from bc failed. Caused by " + e.getMessage());
+        }
+    }
+
     /**
      * readyReplicas retrieve the number of ready replicas to the given service.
      *
@@ -276,7 +286,7 @@ public final class OpenShiftClient {
         try {
             List<HasMetadata> objs = loadYaml(Files.readString(file));
             for (HasMetadata obj : objs) {
-                if (obj instanceof ImageStream
+                if ((obj instanceof ImageStream)
                         && !StringUtils.equals(obj.getMetadata().getName(), service.getName())) {
                     ImageStream is = (ImageStream) obj;
                     Awaitility.await().atMost(TIMEOUT_MINUTES, TimeUnit.MINUTES)
@@ -320,7 +330,7 @@ public final class OpenShiftClient {
 
     /**
      * Returns whether the service name is a serverless (knative) service.
-     * 
+     *
      * @param serviceName
      * @return
      */
@@ -388,6 +398,77 @@ public final class OpenShiftClient {
         return template;
     }
 
+    public String addGitRefToBuildConfig(String buildConfigName, String gitRef, String template) {
+        List<HasMetadata> objs = loadYaml(template);
+        for (HasMetadata obj : objs) {
+            if (obj instanceof BuildConfig && StringUtils.equals(obj.getMetadata().getName(), buildConfigName)) {
+                BuildConfig bc = (BuildConfig) obj;
+                bc.getSpec().getSource().getGit().setRef(gitRef);
+            }
+        }
+
+        KubernetesList list = new KubernetesList();
+        list.setItems(objs);
+        try {
+            ByteArrayOutputStream os = new ByteArrayOutputStream();
+            Serialization.yamlMapper().writeValue(os, list);
+            template = new String(os.toByteArray());
+        } catch (IOException e) {
+            fail("Failed adding properties into OpenShift template. Caused by " + e.getMessage());
+        }
+
+        return template;
+    }
+
+    public String addContextDirToBuildConfig(String buildConfigName, String contextDir, String template) {
+        List<HasMetadata> objs = loadYaml(template);
+        for (HasMetadata obj : objs) {
+            if (obj instanceof BuildConfig && StringUtils.equals(obj.getMetadata().getName(), buildConfigName)) {
+                BuildConfig bc = (BuildConfig) obj;
+                bc.getSpec().getSource().setContextDir(contextDir);
+            }
+        }
+
+        KubernetesList list = new KubernetesList();
+        list.setItems(objs);
+        try {
+            ByteArrayOutputStream os = new ByteArrayOutputStream();
+            Serialization.yamlMapper().writeValue(os, list);
+            template = new String(os.toByteArray());
+        } catch (IOException e) {
+            fail("Failed adding properties into OpenShift template. Caused by " + e.getMessage());
+        }
+
+        return template;
+    }
+
+    public String addEnvVarsToDeploymentConfig(String deploymentConfigName, String[] envVars, String template) {
+        List<EnvVar> deploymentContainerEnv = new ArrayList<>();
+        for (String envVar : envVars) {
+            deploymentContainerEnv.add(new EnvVar(envVar.split("=")[0], envVar.split("=")[1], null));
+        }
+
+        List<HasMetadata> objs = loadYaml(template);
+        for (HasMetadata obj : objs) {
+            if (obj instanceof DeploymentConfig && StringUtils.equals(obj.getMetadata().getName(), deploymentConfigName)) {
+                DeploymentConfig dc = (DeploymentConfig) obj;
+                dc.getSpec().getTemplate().getSpec().getContainers().get(0).setEnv(deploymentContainerEnv);
+            }
+        }
+
+        KubernetesList list = new KubernetesList();
+        list.setItems(objs);
+        try {
+            ByteArrayOutputStream os = new ByteArrayOutputStream();
+            Serialization.yamlMapper().writeValue(os, list);
+            template = new String(os.toByteArray());
+        } catch (IOException e) {
+            fail("Failed adding properties into OpenShift template. Caused by " + e.getMessage());
+        }
+
+        return template;
+    }
+
     private EnvVar getEnvVarByKey(String key, Container container) {
         return container.getEnv().stream().filter(env -> StringUtils.equals(key, env.getName())).findFirst().orElse(null);
     }
@@ -433,7 +514,8 @@ public final class OpenShiftClient {
     }
 
     private boolean hasImageStreamTags(ImageStream is) {
-        return !masterClient.imageStreams().withName(is.getMetadata().getName()).get().getSpec().getTags().isEmpty();
+        return (!masterClient.imageStreams().withName(is.getMetadata().getName()).get().getSpec().getTags().isEmpty()
+                || !masterClient.imageStreams().withName(is.getMetadata().getName()).get().getStatus().getTags().isEmpty());
     }
 
     private boolean isPodRunning(Pod pod) {

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/scenarios/OpenShiftDeploymentStrategy.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/scenarios/OpenShiftDeploymentStrategy.java
@@ -5,6 +5,7 @@ import io.quarkus.test.services.quarkus.ContainerRegistryOpenShiftQuarkusApplica
 import io.quarkus.test.services.quarkus.ExtensionOpenShiftQuarkusApplicationManagedResource;
 import io.quarkus.test.services.quarkus.ExtensionOpenShiftUsingDockerBuildStrategyQuarkusApplicationManagedResource;
 import io.quarkus.test.services.quarkus.OpenShiftQuarkusApplicationManagedResource;
+import io.quarkus.test.services.quarkus.QuarkusSourceS2iBuildApplicationManagedResource;
 
 /**
  * OpenShift Deployment strategies.
@@ -14,6 +15,11 @@ public enum OpenShiftDeploymentStrategy {
      * Will push the artifacts into OpenShift and build the image that will be used to run the pods.
      */
     Build(BuildOpenShiftQuarkusApplicationManagedResource.class),
+    /**
+     * This build strategy will use the source S2I build strategy to build the container with the running Quarkus
+     * application.
+     */
+    QuarkusS2IBuild(QuarkusSourceS2iBuildApplicationManagedResource.class),
     /**
      * Will build the Quarkus app image and push it into a Container Registry to be accessed by OpenShift to deploy the app.
      */

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/QuarkusSourceS2iBuildApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/QuarkusSourceS2iBuildApplicationManagedResource.java
@@ -1,0 +1,114 @@
+package io.quarkus.test.services.quarkus;
+
+import static java.util.regex.Pattern.quote;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.nio.file.Path;
+
+import org.codehaus.plexus.util.StringUtils;
+
+import io.quarkus.test.utils.FileUtils;
+
+public class QuarkusSourceS2iBuildApplicationManagedResource extends OpenShiftQuarkusApplicationManagedResource {
+
+    private static final String QUARKUS_SOURCE_S2I_BASE_IMAGE_FILENAME = "openjdk-11.yml";
+    private static final String QUARKUS_SOURCE_S2I_BUILD_TEMPLATE_FILENAME = "quarkus-s2i-source-build-template.yml";
+    private static final String QUARKUS_SOURCE_S2I_SETTINGS_MVN_FILENAME = "settings-mvn.yml";
+
+    private static final String QUARKUS_HTTP_PORT_PROPERTY = "quarkus.http.port";
+    private static final int INTERNAL_PORT_DEFAULT = 8080;
+
+    private Path tmpQuarkusSourceS2iBaseImageFileName;
+    private Path tmpQuarkusSourceS2iBuildTemplateFileName;
+    private Path tmpQuarkusSourceS2iSettingsMvnFilename;
+
+    public QuarkusSourceS2iBuildApplicationManagedResource(QuarkusApplicationManagedResourceBuilder model) {
+        super(model);
+    }
+
+    /**
+     * - Apply base image stream (resources/openjdk-11.yml).
+     * - Wait for base image stream (resources/openjdk-11.yml).
+     * - Express parameters in S2I build application (resources/quarkus-s2i-source-build-template.yml).
+     * - Add environment variables to deployment config in S2I build application
+     * (resources/quarkus-s2i-source-build-template.yml).
+     * - Enrich deployment config for purposes of the test suite in S2I build application
+     * (resources/quarkus-s2i-source-build-template.yml).
+     * - Apply the resulting OpenShift yml file.
+     * - Wait for build config to have a complete build.
+     * - Wait for deployment to be ready.
+     */
+    @Override
+    protected void doInit() {
+        waitForBaseImage();
+        createMavenSettings();
+        applyTemplate();
+        client.followBuildConfigLogs(model.getContext().getName());
+        waitForQuarkusApplication();
+    }
+
+    @Override
+    protected void doUpdate() {
+        applyTemplate();
+    }
+
+    @Override
+    protected boolean needsBuildArtifact() {
+        return false;
+    }
+
+    @Override
+    public void validate() {
+        super.validate();
+
+        if (model.isSelectedAppClasses()) {
+            fail("Custom source classes as @QuarkusApplication(classes = ...) is not supported by Quarkus source S2I build.");
+        }
+
+        if (StringUtils.isEmpty(model.getSourceS2iRepositoryUri())) {
+            fail("Source S2I build requires a remote Git repository with a Quarkus application!");
+        }
+    }
+
+    private void waitForBaseImage() {
+        tmpQuarkusSourceS2iBaseImageFileName = FileUtils.copyResourceIntoTempFile(QUARKUS_SOURCE_S2I_BASE_IMAGE_FILENAME);
+        client.apply(model.getContext().getOwner(), tmpQuarkusSourceS2iBaseImageFileName);
+        client.awaitFor(model.getContext().getOwner(), tmpQuarkusSourceS2iBaseImageFileName);
+    }
+
+    private void createMavenSettings() {
+        tmpQuarkusSourceS2iSettingsMvnFilename = FileUtils.copyResourceIntoTempFile(QUARKUS_SOURCE_S2I_SETTINGS_MVN_FILENAME);
+        client.apply(model.getContext().getOwner(), tmpQuarkusSourceS2iSettingsMvnFilename);
+    }
+
+    private void waitForQuarkusApplication() {
+        client.awaitFor(model.getContext().getOwner(), tmpQuarkusSourceS2iBuildTemplateFileName);
+    }
+
+    private void applyTemplate() {
+        tmpQuarkusSourceS2iBuildTemplateFileName = FileUtils
+                .copyResourceIntoTempFile(QUARKUS_SOURCE_S2I_BUILD_TEMPLATE_FILENAME);
+        client.applyServicePropertiesUsingTemplate(model.getContext().getOwner(),
+                "/" + QUARKUS_SOURCE_S2I_BUILD_TEMPLATE_FILENAME,
+                this::replaceDeploymentContent,
+                tmpQuarkusSourceS2iBuildTemplateFileName);
+    }
+
+    private String replaceDeploymentContent(String content) {
+        String result = content.replaceAll(quote("${APP_NAME}"), model.getContext().getOwner().getName())
+                .replaceAll(quote("${GIT_URI}"), model.getSourceS2iRepositoryUri());
+        if (StringUtils.isNotEmpty(model.getSourceS2iContextDir())) {
+            result = client.addContextDirToBuildConfig(model.getContext().getOwner().getName(), model.getSourceS2iContextDir(),
+                    result);
+        }
+        if (StringUtils.isNotEmpty(model.getSourceS2iGitRef())) {
+            result = client.addGitRefToBuildConfig(model.getContext().getOwner().getName(), model.getSourceS2iGitRef(), result);
+        }
+        if (model.getSourceS2iEnvVars().length > 0) {
+            result = client.addEnvVarsToDeploymentConfig(model.getContext().getOwner().getName(), model.getSourceS2iEnvVars(),
+                    result);
+        }
+        return result;
+    }
+
+}

--- a/quarkus-test-openshift/src/main/resources/openjdk-11.yml
+++ b/quarkus-test-openshift/src/main/resources/openjdk-11.yml
@@ -1,0 +1,12 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: openjdk-11
+spec:
+  lookupPolicy:
+    local: false
+  tags:
+    - name: latest
+      from:
+        kind: DockerImage
+        name: registry.access.redhat.com/ubi8/openjdk-11:latest

--- a/quarkus-test-openshift/src/main/resources/quarkus-s2i-source-build-template.yml
+++ b/quarkus-test-openshift/src/main/resources/quarkus-s2i-source-build-template.yml
@@ -1,0 +1,95 @@
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: image.openshift.io/v1
+    kind: ImageStream
+    metadata:
+      name: ${APP_NAME}
+    spec:
+      lookupPolicy:
+        local: false
+
+  - apiVersion: build.openshift.io/v1
+    kind: BuildConfig
+    metadata:
+      name: ${APP_NAME}
+    spec:
+      output:
+        to:
+          kind: ImageStreamTag
+          name: ${APP_NAME}:latest
+      source:
+        git:
+          uri: ${GIT_URI}
+        type: Git
+        configMaps:
+          - configMap:
+              name: settings-mvn
+            destinationDir: "/configuration"
+      strategy:
+        type: Source
+        sourceStrategy:
+          env:
+            - name: ARTIFACT_COPY_ARGS
+              value: -p -r *-runner.jar
+            - name: MAVEN_ARGS
+              value: -s /configuration/settings.xml -Dquarkus.package.type=uber-jar -Dquarkus.version=${version.plugin.quarkus} -DskipTests=true
+          from:
+            kind: ImageStreamTag
+            name: openjdk-11:latest
+      triggers:
+        - type: ConfigChange
+        - type: ImageChange
+          imageChange: {}
+
+  - apiVersion: apps.openshift.io/v1
+    kind: DeploymentConfig
+    metadata:
+      name: ${APP_NAME}
+    spec:
+      replicas: 1
+      selector:
+        name: ${APP_NAME}
+      template:
+        metadata:
+          labels:
+            name: ${APP_NAME}
+        spec:
+          containers:
+            - name: ${APP_NAME}
+              image: ${APP_NAME}:latest
+              ports:
+                - containerPort: 8080
+                  protocol: TCP
+      test: false
+      triggers:
+        - type: ConfigChange
+        - type: ImageChange
+          imageChangeParams:
+            automatic: true
+            containerNames:
+              - ${APP_NAME}
+            from:
+              kind: ImageStreamTag
+              name: ${APP_NAME}:latest
+
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: ${APP_NAME}
+    spec:
+      ports:
+        - name: 8080-tcp
+          port: 8080
+          protocol: TCP
+          targetPort: 8080
+      selector:
+        name: ${APP_NAME}
+
+  - apiVersion: route.openshift.io/v1
+    kind: Route
+    metadata:
+      name: ${APP_NAME}
+    spec:
+      to:
+        name: ${APP_NAME}

--- a/quarkus-test-openshift/src/main/resources/settings-mvn.yml
+++ b/quarkus-test-openshift/src/main/resources/settings-mvn.yml
@@ -1,0 +1,55 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: settings-mvn
+data:
+  settings.xml: |
+    <?xml version="1.0" encoding="UTF-8"?>
+    <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+        <profiles>
+            <profile>
+                <id>redhat</id>
+                <repositories>
+                    <repository>
+                        <id>redhat</id>
+                        <name>Repository for Redhat dependencies</name>
+                        <url>https://maven.repository.redhat.com/ga/</url>
+                    </repository>
+                </repositories>
+                <pluginRepositories>
+                    <pluginRepository>
+                        <id>redhat</id>
+                        <name>Repository for Redhat dependencies</name>
+                        <url>https://maven.repository.redhat.com/ga/</url>
+                    </pluginRepository>
+                </pluginRepositories>
+            </profile>
+            <profile>
+                <id>customRemoteRepository</id>
+                <repositories>
+                    <repository>
+                        <id>ts.s2i.maven.remote.repository</id>
+                        <url>${ts.s2i.maven.remote.repository}</url>
+                        <snapshots>
+                            <enabled>false</enabled>
+                        </snapshots>
+                    </repository>
+                </repositories>
+                <pluginRepositories>
+                    <pluginRepository>
+                        <id>ts.s2i.maven.remote.repository</id>
+                        <url>${ts.s2i.maven.remote.repository}</url>
+                        <snapshots>
+                            <enabled>false</enabled>
+                        </snapshots>
+                    </pluginRepository>
+                </pluginRepositories>
+            </profile>
+        </profiles>
+        <activeProfiles>
+            <activeProfile>customRemoteRepository</activeProfile>
+            <activeProfile>redhat</activeProfile>
+        </activeProfiles>
+    </settings>


### PR DESCRIPTION
* Adding Quarkus source S2I strategy. This strategy utilises OpenShift
  objects generated by the following oc commands:

   ```
   oc import-image --confirm ubi8/openjdk-11 --from=registry.access.redhat.com/ubi8/openjdk-11
   oc new-app ubi8/openjdk-11 <git_path> --context-dir=<context_dir> --name=<project_name>
   ```

  There are additional enhancements, like adding environment variables,
  which are not available from `oc new-app` command.