### PR TITLE
Enabling automatic release after close

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -459,7 +459,7 @@
                         <configuration>
                             <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
                             <serverId>ossrh</serverId>
-                            <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
                             <stagingProgressTimeoutMinutes>60</stagingProgressTimeoutMinutes>
                         </configuration>
                     </plugin>


### PR DESCRIPTION
* Setting Sonatype stage plugin to automatic promote of Maven
  repostitory from staging after it has been pushed.

Depends on #33 

Also on resolution of https://issues.sonatype.org/browse/OSSRH-68850 after first release has been promoted.