### PR TITLE
Support of DEV mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,42 @@ public class OnlyOnJvmIT {
 }
 ```
 
+### Dev mode
+
+The test framework supports bare metal testing of DEV mode Quarkus testing. Example:
+
+```java
+@QuarkusScenario
+public class DevModeGreetingResourceIT {
+    @DevModeQuarkusApplication
+    static DevModeQuarkusService app = new DevModeQuarkusService();
+}
+```
+
+The application will start on DEV mode and will have enabled all the live coding features.
+
+This feature includes a new `DevModeQuarkusService` service with the next functionality:
+
+- `enableContinuousTesting` - to enable continuous testing
+
+```java
+app.enableContinuousTesting();
+```
+
+Internally, the framework will load the DEV UI and enable the continuous testing by clicking on the HTML element.
+
+- `modifyFile` - to modify a Java source or resources file:
+
+```java
+app.modifyFile("src/main/java/io/quarkus/qe/GreetingResource.java",content -> content.replace("victor", "manuel"));
+```
+
+- `copyFile` - to copy a Java source or resources file from one source to a destination. Note that the framework will overwrite the destination file if it exists:
+
+```java
+app.copyFile("src/test/resources/jose.properties", "src/main/resources/application.properties");
+```
+
 ### Disable Tests on a Concrete Quarkus version
 
 ```java
@@ -759,6 +795,25 @@ public class GreetingResourceIT {
 
 
 ## More Features
+
+- Log verifications
+
+All the services provide the logs of the running container or Quarkus application. Example of usage:
+
+```java
+@QuarkusScenario
+public class DevModeMySqlDatabaseIT {
+
+    @DevModeQuarkusApplication
+    static RestService app = new RestService();
+
+    @Test
+    public void verifyLogsToAssertDevMode() {
+        app.logs().assertContains("Profile dev activated. Live Coding activated");
+        // or app.getLogs() to get the full list of logs.
+    }
+}
+```
 
 - Discovery of build time properties to build Quarkus applications
 

--- a/examples/database-mysql/src/test/java/io/quarkus/ts/openshift/sqldb/DevModeMySqlDatabaseIT.java
+++ b/examples/database-mysql/src/test/java/io/quarkus/ts/openshift/sqldb/DevModeMySqlDatabaseIT.java
@@ -1,0 +1,27 @@
+package io.quarkus.ts.openshift.sqldb;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.DevModeQuarkusApplication;
+
+/**
+ * Running Quarkus on DEV mode will spin up a Database instance automatically.
+ */
+@QuarkusScenario
+public class DevModeMySqlDatabaseIT extends AbstractSqlDatabaseIT {
+
+    @DevModeQuarkusApplication
+    static RestService app = new RestService();
+
+    @Override
+    protected RestService getApp() {
+        return app;
+    }
+
+    @Test
+    public void verifyLogsToAssertDevMode() {
+        app.logs().assertContains("Profile DevModeMySqlDatabaseIT activated. Live Coding activated");
+    }
+}

--- a/examples/greetings/src/main/resources/application.properties
+++ b/examples/greetings/src/main/resources/application.properties
@@ -1,1 +1,3 @@
-
+custom.property.name=victor
+# Only run tests annotated with @QuarkusTest
+quarkus.test.type=quarkus-test

--- a/examples/greetings/src/test/java/io/quarkus/qe/DevModeGreetingResourceIT.java
+++ b/examples/greetings/src/test/java/io/quarkus/qe/DevModeGreetingResourceIT.java
@@ -1,0 +1,56 @@
+package io.quarkus.qe;
+
+import static org.hamcrest.Matchers.is;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.DevModeQuarkusService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.DevModeQuarkusApplication;
+import io.quarkus.test.utils.AwaitilityUtils;
+
+@QuarkusScenario
+public class DevModeGreetingResourceIT {
+
+    static final String VICTOR_NAME = "victor";
+
+    static final String HELLO_IN_ENGLISH = "Hello";
+    static final String HELLO_IN_SPANISH = "Hola";
+
+    @DevModeQuarkusApplication
+    static DevModeQuarkusService app = new DevModeQuarkusService();
+
+    @Test
+    public void shouldDetectNewTests() {
+        // At first, there are no tests annotated with @QuarkusTest
+        app.logs().assertContains("Tests paused, press [r] to resume");
+        // Now, we enable continuous testing via DEV UI
+        app.enableContinuousTesting();
+        // We wait for Quarkus to run the tests
+        app.logs().assertContains("Running Tests for the first time");
+        // But there are no tests yet
+        app.logs().assertContains("No tests to run");
+        // We add a new test
+        app.copyFile("src/test/resources/GreetingResourceTest.java.template", "src/test/java/GreetingResourceTest.java");
+        // And now, Quarkus find it and run it
+        app.logs().assertContains("Running 0/1");
+        // So good so far!
+        app.logs().assertContains("Tests all passed");
+    }
+
+    @Test
+    public void shouldUpdateResourcesAndSources() {
+        // Should say first Victor (the default name)
+        app.given().get("/greeting").then().statusCode(HttpStatus.SC_OK).body(is(HELLO_IN_ENGLISH + ", I'm " + VICTOR_NAME));
+
+        // Modify default name to manuel
+        app.modifyFile("src/main/java/io/quarkus/qe/GreetingResource.java",
+                content -> content.replace(HELLO_IN_ENGLISH, HELLO_IN_SPANISH));
+
+        // Now, the app should say Manuel
+        AwaitilityUtils.untilAsserted(
+                () -> app.given().get("/greeting").then().statusCode(HttpStatus.SC_OK)
+                        .body(is(HELLO_IN_SPANISH + ", I'm " + VICTOR_NAME)));
+    }
+}

--- a/examples/greetings/src/test/java/io/quarkus/qe/GreetingResourceUsingRuntimePropertiesIT.java
+++ b/examples/greetings/src/test/java/io/quarkus/qe/GreetingResourceUsingRuntimePropertiesIT.java
@@ -17,7 +17,6 @@ public class GreetingResourceUsingRuntimePropertiesIT {
 
     @QuarkusApplication
     static final RestService joseApp = new RestService().withProperty(GreetingResource.PROPERTY, JOSE_NAME);
-
     @QuarkusApplication
     static final RestService manuelApp = new RestService().withProperty(GreetingResource.PROPERTY, MANUEL_NAME);
 

--- a/examples/greetings/src/test/java/io/quarkus/qe/GreetingResourceUsingUsingPropertiesFileIT.java
+++ b/examples/greetings/src/test/java/io/quarkus/qe/GreetingResourceUsingUsingPropertiesFileIT.java
@@ -12,12 +12,13 @@ import io.quarkus.test.services.QuarkusApplication;
 @QuarkusScenario
 public class GreetingResourceUsingUsingPropertiesFileIT {
 
+    static final String JOSE_NAME = "jose";
+    static final String MANUEL_NAME = "manuel";
+
     @QuarkusApplication
     static final RestService joseApp = new RestService().withProperties("jose.properties");
     @QuarkusApplication
     static final RestService manuelApp = new RestService().withProperties("manuel.properties");
-    private static final String JOSE_NAME = "jose";
-    private static final String MANUEL_NAME = "manuel";
 
     @Test
     public void shouldSayJose() {

--- a/examples/greetings/src/test/resources/GreetingResourceTest.java.template
+++ b/examples/greetings/src/test/resources/GreetingResourceTest.java.template
@@ -1,0 +1,15 @@
+package io.quarkus.qe;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+
+@QuarkusTest
+public class GreetingResourceTest {
+    @Test
+    public void shouldSayVictor() {
+        RestAssured.given().get("/greeting").then().statusCode(HttpStatus.SC_OK);
+    }
+}

--- a/examples/greetings/src/test/resources/test.properties
+++ b/examples/greetings/src/test/resources/test.properties
@@ -1,0 +1,1 @@
+ts.app.log.enable=true

--- a/quarkus-test-core/pom.xml
+++ b/quarkus-test-core/pom.xml
@@ -35,5 +35,9 @@
             <artifactId>shrinkwrap-depchain</artifactId>
             <type>pom</type>
         </dependency>
+        <dependency>
+            <groupId>net.sourceforge.htmlunit</groupId>
+            <artifactId>htmlunit</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/BaseService.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/BaseService.java
@@ -3,6 +3,7 @@ package io.quarkus.test.bootstrap;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -15,6 +16,7 @@ import java.util.stream.Stream;
 import io.quarkus.test.configuration.Configuration;
 import io.quarkus.test.logging.Log;
 import io.quarkus.test.utils.FileUtils;
+import io.quarkus.test.utils.LogsVerifier;
 import io.quarkus.test.utils.PropertiesUtils;
 
 public class BaseService<T extends Service> implements Service {
@@ -102,6 +104,11 @@ public class BaseService<T extends Service> implements Service {
         return Collections.unmodifiableMap(properties);
     }
 
+    @Override
+    public List<String> getLogs() {
+        return new ArrayList<>(managedResource.logs());
+    }
+
     /**
      * Start the managed resource. If the managed resource is running, it does
      * nothing.
@@ -155,6 +162,11 @@ public class BaseService<T extends Service> implements Service {
 
     public void restart() {
         managedResource.restart();
+    }
+
+    @Override
+    public LogsVerifier logs() {
+        return new LogsVerifier(this);
     }
 
     protected <U> U getPropertyFromContext(String key) {

--- a/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/DevModeQuarkusService.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/DevModeQuarkusService.java
@@ -1,0 +1,117 @@
+package io.quarkus.test.bootstrap;
+
+import static java.util.stream.Collectors.toList;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.function.Function;
+
+import org.apache.commons.io.FileUtils;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+
+import com.gargoylesoftware.htmlunit.SilentCssErrorHandler;
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.HtmlElement;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+
+import io.quarkus.test.services.DevModeQuarkusApplication;
+import io.quarkus.test.utils.AwaitilityUtils;
+import io.restassured.RestAssured;
+import io.restassured.specification.RequestSpecification;
+
+public class DevModeQuarkusService extends BaseService<DevModeQuarkusService> {
+
+    private static final String DEV_UI_PATH = "/q/dev";
+    private static final String ENABLE_CONTINUOUS_TESTING_BTN = "//a[@class='btn btnPowerOnOffButton text-warning']";
+
+    public RequestSpecification given() {
+        return RestAssured.given().baseUri(getHost()).basePath("/").port(getPort());
+    }
+
+    public DevModeQuarkusService enableContinuousTesting() {
+        AwaitilityUtils.until(
+                () -> getElementsByXPath(webDevUiPage(), ENABLE_CONTINUOUS_TESTING_BTN),
+                Matchers.is(Matchers.not(Matchers.empty()))).forEach(this::clickOnElement);
+
+        return this;
+    }
+
+    public void modifyFile(String file, Function<String, String> modifier) {
+        try {
+            File targetFile = servicePath().resolve(file).toFile();
+            String original = FileUtils.readFileToString(targetFile, StandardCharsets.UTF_8);
+            String updated = modifier.apply(original);
+
+            FileUtils.writeStringToFile(targetFile, updated, StandardCharsets.UTF_8, false);
+        } catch (IOException e) {
+            Assertions.fail("Error modifying file. Caused by " + e.getMessage());
+        }
+    }
+
+    public void copyFile(String file, String target) {
+        try {
+            Path sourcePath = Path.of(file);
+            Path targetPath = servicePath().resolve(target);
+            FileUtils.deleteQuietly(targetPath.toFile());
+
+            FileUtils.copyFile(sourcePath.toFile(), targetPath.toFile());
+        } catch (IOException e) {
+            Assertions.fail("Error copying file. Caused by " + e.getMessage());
+        }
+    }
+
+    @Override
+    public void validate(Field field) {
+        if (!field.isAnnotationPresent(DevModeQuarkusApplication.class)) {
+            Assertions.fail("DevModeQuarkusService service is not annotated with DevModeQuarkusApplication");
+        }
+    }
+
+    private Path servicePath() {
+        return Paths.get("target/" + getName());
+    }
+
+    private void clickOnElement(HtmlElement elem) {
+        try {
+            elem.click();
+        } catch (IOException e) {
+            Assertions.fail("Can't click on element. Caused by: " + e.getMessage());
+        }
+    }
+
+    private List<HtmlElement> getElementsByXPath(HtmlPage htmlPage, String path) {
+        return htmlPage.getByXPath(path).stream()
+                .filter(elem -> elem instanceof HtmlElement)
+                .map(elem -> (HtmlElement) elem)
+                .collect(toList());
+    }
+
+    private HtmlPage webDevUiPage() {
+        return webPage(DEV_UI_PATH);
+    }
+
+    private HtmlPage webPage(String path) {
+        try {
+            return webClient().getPage(getHost() + ":" + getPort() + path);
+        } catch (IOException e) {
+            Assertions.fail("Page with path " + path + " does not exist");
+        }
+
+        return null;
+    }
+
+    private WebClient webClient() {
+        WebClient webClient = new WebClient();
+        webClient.setCssErrorHandler(new SilentCssErrorHandler());
+        webClient.getOptions().setThrowExceptionOnScriptError(false);
+        webClient.getOptions().setThrowExceptionOnFailingStatusCode(false);
+        webClient.getOptions().setRedirectEnabled(true);
+        return webClient;
+    }
+}

--- a/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/QuarkusScenarioBootstrap.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/QuarkusScenarioBootstrap.java
@@ -143,6 +143,7 @@ public class QuarkusScenarioBootstrap
 
         field.setAccessible(true);
         Service service = (Service) field.get(null);
+        service.validate(field);
         service.register(field.getName());
         ServiceContext serviceContext = new ServiceContext(service, context);
         extensions.forEach(ext -> ext.updateServiceContext(serviceContext));

--- a/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/Service.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/Service.java
@@ -1,8 +1,11 @@
 package io.quarkus.test.bootstrap;
 
+import java.lang.reflect.Field;
+import java.util.List;
 import java.util.Map;
 
 import io.quarkus.test.configuration.Configuration;
+import io.quarkus.test.utils.LogsVerifier;
 
 public interface Service {
 
@@ -12,6 +15,8 @@ public interface Service {
 
     Map<String, String> getProperties();
 
+    List<String> getLogs();
+
     void register(String name);
 
     void init(ManagedResourceBuilder resource, ServiceContext serviceContext);
@@ -20,5 +25,11 @@ public interface Service {
 
     void stop();
 
+    LogsVerifier logs();
+
     Service withProperty(String key, String value);
+
+    default void validate(Field field) {
+
+    }
 }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/logging/LoggingHandler.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/logging/LoggingHandler.java
@@ -28,6 +28,7 @@ public abstract class LoggingHandler {
         logs.clear();
         running = true;
         innerThread = new Thread(this::run);
+        innerThread.setDaemon(true);
         innerThread.start();
     }
 

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/DevModeQuarkusApplication.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/DevModeQuarkusApplication.java
@@ -1,0 +1,13 @@
+package io.quarkus.test.services;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DevModeQuarkusApplication {
+    // By default, it will load all the classes in the classpath.
+    Class<?>[] classes() default {};
+}

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/QuarkusApplication.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/QuarkusApplication.java
@@ -6,7 +6,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import io.quarkus.test.bootstrap.ManagedResourceBuilder;
-import io.quarkus.test.services.quarkus.QuarkusApplicationManagedResourceBuilder;
+import io.quarkus.test.services.quarkus.ProdQuarkusApplicationManagedResourceBuilder;
 
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)
@@ -14,7 +14,7 @@ public @interface QuarkusApplication {
     // By default, it will load all the classes in the classpath.
     Class<?>[] classes() default {};
 
-    Class<? extends ManagedResourceBuilder> builder() default QuarkusApplicationManagedResourceBuilder.class;
+    Class<? extends ManagedResourceBuilder> builder() default ProdQuarkusApplicationManagedResourceBuilder.class;
 
     /**
      * Enable SSL configuration. This property needs `quarkus.http.ssl.certificate.key-store-file` and

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/DevModeLocalhostQuarkusApplicationManagedResource.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/DevModeLocalhostQuarkusApplicationManagedResource.java
@@ -1,0 +1,30 @@
+package io.quarkus.test.services.quarkus;
+
+import static io.quarkus.test.utils.MavenUtils.SKIP_CHECKSTYLE;
+import static io.quarkus.test.utils.MavenUtils.SKIP_ITS;
+import static io.quarkus.test.utils.MavenUtils.mvnCommand;
+import static io.quarkus.test.utils.MavenUtils.withProperty;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class DevModeLocalhostQuarkusApplicationManagedResource extends LocalhostQuarkusApplicationManagedResource {
+
+    private final DevModeQuarkusApplicationManagedResourceBuilder model;
+
+    public DevModeLocalhostQuarkusApplicationManagedResource(DevModeQuarkusApplicationManagedResourceBuilder model) {
+        super(model);
+        this.model = model;
+    }
+
+    protected List<String> prepareCommand(List<String> systemProperties) {
+        List<String> command = mvnCommand(model.getContext());
+        command.addAll(Arrays.asList(SKIP_CHECKSTYLE, SKIP_ITS));
+        command.addAll(systemProperties);
+        command.add(withProperty("debug", "false"));
+        command.add("quarkus:dev");
+
+        return command;
+    }
+
+}

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/DevModeQuarkusApplicationAnnotationBinding.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/DevModeQuarkusApplicationAnnotationBinding.java
@@ -1,0 +1,25 @@
+package io.quarkus.test.services.quarkus;
+
+import java.lang.reflect.Field;
+
+import io.quarkus.test.bootstrap.AnnotationBinding;
+import io.quarkus.test.bootstrap.ManagedResourceBuilder;
+import io.quarkus.test.services.DevModeQuarkusApplication;
+
+public class DevModeQuarkusApplicationAnnotationBinding implements AnnotationBinding {
+
+    @Override
+    public boolean isFor(Field field) {
+        return field.isAnnotationPresent(DevModeQuarkusApplication.class);
+    }
+
+    @Override
+    public ManagedResourceBuilder createBuilder(Field field) throws Exception {
+        DevModeQuarkusApplication metadata = field.getAnnotation(DevModeQuarkusApplication.class);
+
+        ManagedResourceBuilder builder = new DevModeQuarkusApplicationManagedResourceBuilder();
+        builder.init(metadata);
+        return builder;
+    }
+
+}

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/DevModeQuarkusApplicationManagedResourceBuilder.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/DevModeQuarkusApplicationManagedResourceBuilder.java
@@ -1,0 +1,36 @@
+package io.quarkus.test.services.quarkus;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.lang.annotation.Annotation;
+
+import io.quarkus.test.bootstrap.ManagedResource;
+import io.quarkus.test.bootstrap.ServiceContext;
+import io.quarkus.test.services.DevModeQuarkusApplication;
+import io.quarkus.test.utils.FileUtils;
+
+public class DevModeQuarkusApplicationManagedResourceBuilder extends QuarkusApplicationManagedResourceBuilder {
+
+    @Override
+    public void init(Annotation annotation) {
+        DevModeQuarkusApplication metadata = (DevModeQuarkusApplication) annotation;
+        initAppClasses(metadata.classes());
+    }
+
+    @Override
+    public ManagedResource build(ServiceContext context) {
+        setContext(context);
+        configureLogging();
+        build();
+        return new DevModeLocalhostQuarkusApplicationManagedResource(this);
+    }
+
+    protected void build() {
+        try {
+            FileUtils.copyCurrentDirectoryTo(getContext().getServiceFolder());
+            copyResourcesToAppFolder();
+        } catch (Exception ex) {
+            fail("Failed to build Quarkus artifacts. Caused by " + ex);
+        }
+    }
+}

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/ProdLocalhostQuarkusApplicationManagedResource.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/ProdLocalhostQuarkusApplicationManagedResource.java
@@ -1,0 +1,32 @@
+package io.quarkus.test.services.quarkus;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import io.quarkus.utilities.JavaBinFinder;
+
+public class ProdLocalhostQuarkusApplicationManagedResource extends LocalhostQuarkusApplicationManagedResource {
+
+    private final ProdQuarkusApplicationManagedResourceBuilder model;
+
+    public ProdLocalhostQuarkusApplicationManagedResource(ProdQuarkusApplicationManagedResourceBuilder model) {
+        super(model);
+        this.model = model;
+    }
+
+    protected List<String> prepareCommand(List<String> systemProperties) {
+        List<String> command = new LinkedList<>();
+        if (model.getArtifact().getFileName().toString().endsWith(".jar")) {
+            command.add(JavaBinFinder.findBin());
+            command.addAll(systemProperties);
+            command.add("-jar");
+            command.add(model.getArtifact().toAbsolutePath().toString());
+        } else {
+            command.add(model.getArtifact().toAbsolutePath().toString());
+            command.addAll(systemProperties);
+        }
+
+        return command;
+    }
+
+}

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/ProdQuarkusApplicationManagedResourceBuilder.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/ProdQuarkusApplicationManagedResourceBuilder.java
@@ -1,0 +1,142 @@
+package io.quarkus.test.services.quarkus;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.lang.annotation.Annotation;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.ServiceLoader;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.exporter.ExplodedExporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+
+import io.quarkus.bootstrap.app.AugmentAction;
+import io.quarkus.bootstrap.app.AugmentResult;
+import io.quarkus.bootstrap.app.CuratedApplication;
+import io.quarkus.bootstrap.app.QuarkusBootstrap;
+import io.quarkus.test.bootstrap.ManagedResource;
+import io.quarkus.test.bootstrap.ServiceContext;
+import io.quarkus.test.common.PathTestHelper;
+import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.test.services.quarkus.model.LaunchMode;
+import io.quarkus.test.services.quarkus.model.QuarkusProperties;
+import io.quarkus.test.utils.FileUtils;
+
+public class ProdQuarkusApplicationManagedResourceBuilder extends QuarkusApplicationManagedResourceBuilder {
+
+    private static final String NATIVE_RUNNER = "-runner";
+    private static final String JVM_RUNNER = "-runner.jar";
+    private static final String QUARKUS_APP = "quarkus-app/";
+    private static final String QUARKUS_RUN = "quarkus-run.jar";
+
+    private final ServiceLoader<QuarkusApplicationManagedResourceBinding> managedResourceBindingsRegistry = ServiceLoader
+            .load(QuarkusApplicationManagedResourceBinding.class);
+
+    private LaunchMode launchMode = LaunchMode.JVM;
+    private Path artifact;
+    private QuarkusManagedResource managedResource;
+
+    protected LaunchMode getLaunchMode() {
+        return launchMode;
+    }
+
+    protected Path getArtifact() {
+        return artifact;
+    }
+
+    @Override
+    public void init(Annotation annotation) {
+        QuarkusApplication metadata = (QuarkusApplication) annotation;
+        setSslEnabled(metadata.ssl());
+        initAppClasses(metadata.classes());
+    }
+
+    @Override
+    public ManagedResource build(ServiceContext context) {
+        setContext(context);
+        configureLogging();
+        managedResource = findManagedResource();
+        build();
+
+        managedResource.validate();
+
+        return managedResource;
+    }
+
+    public void build() {
+        detectLaunchMode();
+        if (managedResource.needsBuildArtifact()) {
+            tryToReuseOrBuildArtifact();
+        }
+    }
+
+    private QuarkusManagedResource findManagedResource() {
+        for (QuarkusApplicationManagedResourceBinding binding : managedResourceBindingsRegistry) {
+            if (binding.appliesFor(getContext())) {
+                return binding.init(this);
+            }
+        }
+
+        return new ProdLocalhostQuarkusApplicationManagedResource(this);
+    }
+
+    private void tryToReuseOrBuildArtifact() {
+        Optional<String> artifactLocation = Optional.empty();
+        if (!containsBuildProperties() && !isSelectedAppClasses()) {
+            if (QuarkusProperties.isNativePackageType(getContext())) {
+                artifactLocation = FileUtils.findTargetFile(NATIVE_RUNNER);
+            } else {
+                artifactLocation = FileUtils.findTargetFile(JVM_RUNNER)
+                        .or(() -> FileUtils.findTargetFile(QUARKUS_APP, QUARKUS_RUN));
+            }
+        }
+
+        if (artifactLocation.isEmpty()) {
+            this.artifact = buildArtifact();
+        } else {
+            this.artifact = Path.of(artifactLocation.get());
+        }
+    }
+
+    private Path buildArtifact() {
+        try {
+            Path appFolder = getContext().getServiceFolder();
+            JavaArchive javaArchive = ShrinkWrap.create(JavaArchive.class).addClasses(getAppClasses());
+            javaArchive.as(ExplodedExporter.class).exportExplodedInto(appFolder.toFile());
+
+            copyResourcesToAppFolder();
+
+            Path testLocation = PathTestHelper.getTestClassesLocation(getContext().getTestContext().getRequiredTestClass());
+            QuarkusBootstrap.Builder builder = QuarkusBootstrap.builder().setApplicationRoot(appFolder)
+                    .setMode(QuarkusBootstrap.Mode.PROD).setLocalProjectDiscovery(true).addExcludedPath(testLocation)
+                    .setProjectRoot(testLocation).setBaseName(getContext().getName())
+                    .setTargetDirectory(appFolder);
+
+            AugmentResult result;
+            try (CuratedApplication curatedApplication = builder.build().bootstrap()) {
+                AugmentAction action = curatedApplication.createAugmentor();
+
+                result = action.createProductionApplication();
+            }
+
+            return Optional.ofNullable(result.getNativeResult())
+                    .orElseGet(() -> result.getJar().getPath());
+        } catch (Exception ex) {
+            fail("Failed to build Quarkus artifacts. Caused by " + ex);
+        }
+
+        return null;
+    }
+
+    private void detectLaunchMode() {
+        if (QuarkusProperties.isNativePackageType(getContext())) {
+            launchMode = LaunchMode.NATIVE;
+        } else if (QuarkusProperties.isLegacyJarPackageType(getContext())) {
+            launchMode = LaunchMode.LEGACY_JAR;
+        } else {
+            launchMode = LaunchMode.JVM;
+        }
+    }
+
+}

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusApplicationManagedResourceBinding.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusApplicationManagedResourceBinding.java
@@ -15,5 +15,5 @@ public interface QuarkusApplicationManagedResourceBinding {
      * @param builder
      * @return
      */
-    QuarkusManagedResource init(QuarkusApplicationManagedResourceBuilder builder);
+    QuarkusManagedResource init(ProdQuarkusApplicationManagedResourceBuilder builder);
 }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusApplicationManagedResourceBuilder.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusApplicationManagedResourceBuilder.java
@@ -1,10 +1,8 @@
 package io.quarkus.test.services.quarkus;
 
 import static java.util.stream.Collectors.toSet;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
-import java.lang.annotation.Annotation;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -12,66 +10,48 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.exporter.ExplodedExporter;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
-
-import io.quarkus.bootstrap.app.AugmentAction;
-import io.quarkus.bootstrap.app.AugmentResult;
-import io.quarkus.bootstrap.app.CuratedApplication;
-import io.quarkus.bootstrap.app.QuarkusBootstrap;
-import io.quarkus.test.bootstrap.ManagedResource;
 import io.quarkus.test.bootstrap.ManagedResourceBuilder;
 import io.quarkus.test.bootstrap.ServiceContext;
-import io.quarkus.test.common.PathTestHelper;
-import io.quarkus.test.services.QuarkusApplication;
-import io.quarkus.test.services.quarkus.model.LaunchMode;
-import io.quarkus.test.services.quarkus.model.QuarkusProperties;
 import io.quarkus.test.utils.ClassPathUtils;
 import io.quarkus.test.utils.FileUtils;
 import io.quarkus.test.utils.MapUtils;
 import io.quarkus.test.utils.PropertiesUtils;
 
-public class QuarkusApplicationManagedResourceBuilder implements ManagedResourceBuilder {
+public abstract class QuarkusApplicationManagedResourceBuilder implements ManagedResourceBuilder {
 
     private static final String BUILD_TIME_PROPERTIES = "/build-time-list";
-    private static final String NATIVE_RUNNER = "-runner";
-    private static final String JVM_RUNNER = "-runner.jar";
-    private static final String QUARKUS_APP = "quarkus-app/";
-    private static final String QUARKUS_RUN = "quarkus-run.jar";
     private static final String RESOURCES_FOLDER = "src/main/resources";
     private static final String TEST_RESOURCES_FOLDER = "src/test/resources";
     private static final String APPLICATION_PROPERTIES = "application.properties";
     private static final List<String> RESOURCES_TO_COPY = Arrays.asList(".sql", ".keystore", ".truststore");
     private static final Set<String> BUILD_PROPERTIES = FileUtils.loadFile(BUILD_TIME_PROPERTIES).lines().collect(toSet());
-    private final ServiceLoader<QuarkusApplicationManagedResourceBinding> managedResourceBindingsRegistry = ServiceLoader
-            .load(QuarkusApplicationManagedResourceBinding.class);
 
     private Class<?>[] appClasses;
-    private ServiceContext context;
-    private LaunchMode launchMode = LaunchMode.JVM;
-    private Path artifact;
-    private boolean sslEnabled = false;
     private boolean selectedAppClasses = true;
-    private QuarkusManagedResource managedResource;
+    private ServiceContext context;
+    private boolean sslEnabled = false;
     private Map<String, String> propertiesSnapshot;
 
-    protected LaunchMode getLaunchMode() {
-        return launchMode;
-    }
-
-    protected Path getArtifact() {
-        return artifact;
-    }
+    protected abstract void build();
 
     protected ServiceContext getContext() {
         return context;
+    }
+
+    protected void setContext(ServiceContext context) {
+        this.context = context;
+    }
+
+    protected boolean isSslEnabled() {
+        return sslEnabled;
+    }
+
+    protected void setSslEnabled(boolean sslEnabled) {
+        this.sslEnabled = sslEnabled;
     }
 
     protected Class<?>[] getAppClasses() {
@@ -80,40 +60,6 @@ public class QuarkusApplicationManagedResourceBuilder implements ManagedResource
 
     protected boolean isSelectedAppClasses() {
         return selectedAppClasses;
-    }
-
-    protected boolean isSslEnabled() {
-        return sslEnabled;
-    }
-
-    @Override
-    public void init(Annotation annotation) {
-        QuarkusApplication metadata = (QuarkusApplication) annotation;
-        sslEnabled = metadata.ssl();
-        appClasses = metadata.classes();
-        if (appClasses.length == 0) {
-            appClasses = ClassPathUtils.findAllClassesFromSource();
-            selectedAppClasses = false;
-        }
-    }
-
-    @Override
-    public ManagedResource build(ServiceContext context) {
-        this.context = context;
-        configureLogging();
-        managedResource = findManagedResource();
-        build();
-
-        managedResource.validate();
-
-        return managedResource;
-    }
-
-    public void build() {
-        detectLaunchMode();
-        if (managedResource.needsBuildArtifact()) {
-            tryToReuseOrBuildArtifact();
-        }
     }
 
     public boolean containsBuildProperties() {
@@ -127,6 +73,7 @@ public class QuarkusApplicationManagedResourceBuilder implements ManagedResource
     }
 
     public Map<String, String> createSnapshotOfBuildProperties() {
+        propertiesSnapshot = new HashMap<>(context.getOwner().getProperties());
         return new HashMap<>(context.getOwner().getProperties());
     }
 
@@ -136,87 +83,27 @@ public class QuarkusApplicationManagedResourceBuilder implements ManagedResource
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
-    private boolean isBuildProperty(String name) {
-        return BUILD_PROPERTIES.stream().anyMatch(build -> name.matches(build) || name.startsWith(build));
-    }
-
-    private QuarkusManagedResource findManagedResource() {
-        for (QuarkusApplicationManagedResourceBinding binding : managedResourceBindingsRegistry) {
-            if (binding.appliesFor(context)) {
-                return binding.init(this);
-            }
+    protected void initAppClasses(Class<?>[] classes) {
+        appClasses = classes;
+        if (appClasses.length == 0) {
+            appClasses = ClassPathUtils.findAllClassesFromSource();
+            selectedAppClasses = false;
         }
-
-        return new LocalhostQuarkusApplicationManagedResource(this);
     }
 
-    private void configureLogging() {
+    protected void configureLogging() {
         context.getOwner().withProperty("quarkus.log.console.format", "%d{HH:mm:ss,SSS} %s%e%n");
     }
 
-    private void tryToReuseOrBuildArtifact() {
-        Optional<String> artifactLocation = Optional.empty();
-        if (!containsBuildProperties() && !selectedAppClasses) {
-            if (QuarkusProperties.isNativePackageType(context)) {
-                artifactLocation = FileUtils.findTargetFile(NATIVE_RUNNER);
-            } else {
-                artifactLocation = FileUtils.findTargetFile(JVM_RUNNER)
-                        .or(() -> FileUtils.findTargetFile(QUARKUS_APP, QUARKUS_RUN));
-            }
-        }
-
-        if (artifactLocation.isEmpty()) {
-            this.artifact = buildArtifact();
-        } else {
-            this.artifact = Path.of(artifactLocation.get());
-        }
-    }
-
-    private Path buildArtifact() {
-        try {
-            Path appFolder = context.getServiceFolder();
-            JavaArchive javaArchive = ShrinkWrap.create(JavaArchive.class).addClasses(appClasses);
-            javaArchive.as(ExplodedExporter.class).exportExplodedInto(appFolder.toFile());
-
-            copyResourcesToAppFolder();
-
-            Path testLocation = PathTestHelper.getTestClassesLocation(context.getTestContext().getRequiredTestClass());
-            QuarkusBootstrap.Builder builder = QuarkusBootstrap.builder().setApplicationRoot(appFolder)
-                    .setMode(QuarkusBootstrap.Mode.PROD).setLocalProjectDiscovery(true).addExcludedPath(testLocation)
-                    .setProjectRoot(testLocation).setBaseName(context.getName())
-                    .setTargetDirectory(appFolder);
-
-            AugmentResult result;
-            try (CuratedApplication curatedApplication = builder.build().bootstrap()) {
-                AugmentAction action = curatedApplication.createAugmentor();
-
-                result = action.createProductionApplication();
-            }
-
-            return Optional.ofNullable(result.getNativeResult())
-                    .orElseGet(() -> result.getJar().getPath());
-        } catch (Exception ex) {
-            fail("Failed to build Quarkus artifacts. Caused by " + ex);
-        }
-
-        return null;
-    }
-
-    private void detectLaunchMode() {
-        if (QuarkusProperties.isNativePackageType(context)) {
-            launchMode = LaunchMode.NATIVE;
-        } else if (QuarkusProperties.isLegacyJarPackageType(context)) {
-            launchMode = LaunchMode.LEGACY_JAR;
-        } else {
-            launchMode = LaunchMode.JVM;
-        }
-    }
-
-    private void copyResourcesToAppFolder() throws IOException {
+    protected void copyResourcesToAppFolder() {
         copyResourcesInFolderToAppFolder(RESOURCES_FOLDER);
         copyResourcesInFolderToAppFolder(TEST_RESOURCES_FOLDER);
         PropertiesUtils.fromMap(createSnapshotOfBuildProperties(),
                 context.getServiceFolder().resolve(APPLICATION_PROPERTIES));
+    }
+
+    private boolean isBuildProperty(String name) {
+        return BUILD_PROPERTIES.stream().anyMatch(build -> name.matches(build) || name.startsWith(build));
     }
 
     private void copyResourcesInFolderToAppFolder(String folder) {

--- a/quarkus-test-core/src/main/java/io/quarkus/test/utils/AwaitilityUtils.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/utils/AwaitilityUtils.java
@@ -65,7 +65,7 @@ public final class AwaitilityUtils {
         awaits().untilAsserted(assertion);
     }
 
-    private static <T> T until(Supplier<T> supplier, Matcher<T> matcher) {
+    public static <T> T until(Supplier<T> supplier, Matcher<T> matcher) {
         return awaits().until(get(supplier), matcher);
     }
 

--- a/quarkus-test-core/src/main/java/io/quarkus/test/utils/LogsVerifier.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/utils/LogsVerifier.java
@@ -1,0 +1,24 @@
+package io.quarkus.test.utils;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+
+import io.quarkus.test.bootstrap.Service;
+
+public class LogsVerifier {
+
+    private final Service service;
+
+    public LogsVerifier(Service service) {
+        this.service = service;
+    }
+
+    public void assertContains(String expectedLog) {
+        AwaitilityUtils.untilAsserted(() -> {
+            List<String> actualLogs = service.getLogs();
+            Assertions.assertTrue(actualLogs.stream().anyMatch(line -> line.contains(expectedLog)),
+                    "Log does not contain " + expectedLog + ". Full logs: " + actualLogs);
+        });
+    }
+}

--- a/quarkus-test-core/src/main/java/io/quarkus/test/utils/MavenUtils.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/utils/MavenUtils.java
@@ -1,0 +1,46 @@
+package io.quarkus.test.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.quarkus.test.bootstrap.ServiceContext;
+
+public final class MavenUtils {
+
+    public static final String MVN_COMMAND = "mvn";
+    public static final String PACKAGE_GOAL = "package";
+    public static final String MVN_REPOSITORY_LOCAL = "maven.repo.local";
+    public static final String SKIP_TESTS = "-DskipTests=true";
+    public static final String SKIP_ITS = "-DskipITs=true";
+    public static final String BATCH_MODE = "-B";
+    public static final String DISPLAY_VERSION = "-V";
+    public static final String SKIP_CHECKSTYLE = "-Dcheckstyle.skip";
+    public static final String QUARKUS_PROFILE = "quarkus.profile";
+
+    private MavenUtils() {
+
+    }
+
+    public static List<String> mvnCommand(ServiceContext serviceContext) {
+        List<String> args = new ArrayList<>();
+        args.add(MVN_COMMAND);
+        args.add(withQuarkusProfile(serviceContext));
+        withMavenRepositoryLocalIfSet(args);
+        return args;
+    }
+
+    private static String withQuarkusProfile(ServiceContext serviceContext) {
+        return withProperty(QUARKUS_PROFILE, serviceContext.getTestContext().getRequiredTestClass().getSimpleName());
+    }
+
+    private static void withMavenRepositoryLocalIfSet(List<String> args) {
+        String mvnRepositoryPath = System.getProperty(MVN_REPOSITORY_LOCAL);
+        if (mvnRepositoryPath != null) {
+            args.add(withProperty(MVN_REPOSITORY_LOCAL, mvnRepositoryPath));
+        }
+    }
+
+    public static String withProperty(String property, String value) {
+        return String.format("-D%s=%s", property, value);
+    }
+}

--- a/quarkus-test-core/src/main/resources/META-INF/services/io.quarkus.test.bootstrap.AnnotationBinding
+++ b/quarkus-test-core/src/main/resources/META-INF/services/io.quarkus.test.bootstrap.AnnotationBinding
@@ -1,1 +1,2 @@
 io.quarkus.test.services.quarkus.QuarkusApplicationAnnotationBinding
+io.quarkus.test.services.quarkus.DevModeQuarkusApplicationAnnotationBinding

--- a/quarkus-test-core/src/main/resources/logging.properties
+++ b/quarkus-test-core/src/main/resources/logging.properties
@@ -10,4 +10,5 @@ java.util.logging.FileHandler.formatter=java.util.logging.SimpleFormatter
 java.util.logging.SimpleFormatter.format=%1$tH:%1$tM:%1$tS.%1$tL %4$-5s %5$s%6$s%n
 # Levels
 okhttp3.level = WARNING
-org.apache.http.level = WARNING
+org.apache.http.level=WARNING
+com.gargoylesoftware.htmlunit.level=OFF

--- a/quarkus-test-kubernetes/src/main/java/io/quarkus/test/services/quarkus/KubernetesQuarkusApplicationManagedResource.java
+++ b/quarkus-test-kubernetes/src/main/java/io/quarkus/test/services/quarkus/KubernetesQuarkusApplicationManagedResource.java
@@ -22,7 +22,7 @@ public class KubernetesQuarkusApplicationManagedResource extends QuarkusManagedR
     private static final String QUARKUS_HTTP_PORT_PROPERTY = "quarkus.http.port";
     private static final int INTERNAL_PORT_DEFAULT = 8080;
 
-    private final QuarkusApplicationManagedResourceBuilder model;
+    private final ProdQuarkusApplicationManagedResourceBuilder model;
     private final KubectlClient client;
 
     private LoggingHandler loggingHandler;
@@ -30,7 +30,7 @@ public class KubernetesQuarkusApplicationManagedResource extends QuarkusManagedR
     private boolean running;
     private String image;
 
-    public KubernetesQuarkusApplicationManagedResource(QuarkusApplicationManagedResourceBuilder model) {
+    public KubernetesQuarkusApplicationManagedResource(ProdQuarkusApplicationManagedResourceBuilder model) {
         this.model = model;
         this.client = model.getContext().get(KubernetesExtensionBootstrap.CLIENT);
     }

--- a/quarkus-test-kubernetes/src/main/java/io/quarkus/test/services/quarkus/KubernetesQuarkusApplicationManagedResourceBinding.java
+++ b/quarkus-test-kubernetes/src/main/java/io/quarkus/test/services/quarkus/KubernetesQuarkusApplicationManagedResourceBinding.java
@@ -11,7 +11,7 @@ public class KubernetesQuarkusApplicationManagedResourceBinding implements Quark
     }
 
     @Override
-    public QuarkusManagedResource init(QuarkusApplicationManagedResourceBuilder builder) {
+    public QuarkusManagedResource init(ProdQuarkusApplicationManagedResourceBuilder builder) {
         return new KubernetesQuarkusApplicationManagedResource(builder);
     }
 

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/BuildOpenShiftQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/BuildOpenShiftQuarkusApplicationManagedResource.java
@@ -26,7 +26,7 @@ public class BuildOpenShiftQuarkusApplicationManagedResource extends OpenShiftQu
     private static final PropertyLookup UBI_QUARKUS_NATIVE_S2I = new PropertyLookup("quarkus.s2i.base-native-image",
             "quay.io/quarkus/ubi-quarkus-native-binary-s2i:1.0");
 
-    public BuildOpenShiftQuarkusApplicationManagedResource(QuarkusApplicationManagedResourceBuilder model) {
+    public BuildOpenShiftQuarkusApplicationManagedResource(ProdQuarkusApplicationManagedResourceBuilder model) {
         super(model);
     }
 

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/ContainerRegistryOpenShiftQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/ContainerRegistryOpenShiftQuarkusApplicationManagedResource.java
@@ -16,7 +16,7 @@ public class ContainerRegistryOpenShiftQuarkusApplicationManagedResource extends
 
     private String image;
 
-    public ContainerRegistryOpenShiftQuarkusApplicationManagedResource(QuarkusApplicationManagedResourceBuilder model) {
+    public ContainerRegistryOpenShiftQuarkusApplicationManagedResource(ProdQuarkusApplicationManagedResourceBuilder model) {
         super(model);
     }
 

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/ExtensionOpenShiftUsingDockerBuildStrategyQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/ExtensionOpenShiftUsingDockerBuildStrategyQuarkusApplicationManagedResource.java
@@ -1,5 +1,6 @@
 package io.quarkus.test.services.quarkus;
 
+import static io.quarkus.test.utils.MavenUtils.withProperty;
 import static java.util.regex.Pattern.quote;
 
 import java.nio.file.Files;
@@ -18,7 +19,7 @@ public class ExtensionOpenShiftUsingDockerBuildStrategyQuarkusApplicationManaged
     private static final String DOCKERFILE_SOURCE_FOLDER = "src/main/docker";
 
     public ExtensionOpenShiftUsingDockerBuildStrategyQuarkusApplicationManagedResource(
-            QuarkusApplicationManagedResourceBuilder model) {
+            ProdQuarkusApplicationManagedResourceBuilder model) {
         super(model);
     }
 

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftQuarkusApplicationManagedResource.java
@@ -17,14 +17,14 @@ public abstract class OpenShiftQuarkusApplicationManagedResource extends Quarkus
 
     private static final int EXTERNAL_PORT = 80;
 
-    protected final QuarkusApplicationManagedResourceBuilder model;
+    protected final ProdQuarkusApplicationManagedResourceBuilder model;
     protected final OpenShiftClient client;
 
     private LoggingHandler loggingHandler;
     private boolean init;
     private boolean running;
 
-    public OpenShiftQuarkusApplicationManagedResource(QuarkusApplicationManagedResourceBuilder model) {
+    public OpenShiftQuarkusApplicationManagedResource(ProdQuarkusApplicationManagedResourceBuilder model) {
         this.model = model;
         this.client = model.getContext().get(OpenShiftExtensionBootstrap.CLIENT);
     }

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftQuarkusApplicationManagedResourceBinding.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftQuarkusApplicationManagedResourceBinding.java
@@ -13,13 +13,13 @@ public class OpenShiftQuarkusApplicationManagedResourceBinding implements Quarku
     }
 
     @Override
-    public QuarkusManagedResource init(QuarkusApplicationManagedResourceBuilder builder) {
+    public QuarkusManagedResource init(ProdQuarkusApplicationManagedResourceBuilder builder) {
         OpenShiftScenario annotation = builder.getContext().getTestContext().getRequiredTestClass()
                 .getAnnotation(OpenShiftScenario.class);
 
         try {
             return annotation.deployment().getStrategyClass()
-                    .getDeclaredConstructor(QuarkusApplicationManagedResourceBuilder.class)
+                    .getDeclaredConstructor(ProdQuarkusApplicationManagedResourceBuilder.class)
                     .newInstance(builder);
         } catch (Exception exception) {
             fail("Failed to load OpenShift strategy. Caused by " + exception.getMessage());


### PR DESCRIPTION
### Dev mode

The test framework supports bare metal testing of DEV mode Quarkus testing. Example:

```java
@QuarkusScenario
public class DevModeGreetingResourceIT {
    @DevModeQuarkusApplication
    static DevModeQuarkusService app = new DevModeQuarkusService();
}
```

The application will start on DEV mode and will have enabled all the live coding features.

This feature includes a new `DevModeQuarkusService` service with the next functionality:

- `modifyFile` - to modify a Java source or resources file:

```java
app.modifyFile("src/main/java/io/quarkus/qe/GreetingResource.java",content -> content.replace("victor", "manuel"));
```

- `copyFile` - to copy a Java source or resources file from one source to a destination. Note that the framework will overwrite the destination file if it exists:

```java
app.copyFile("src/test/resources/jose.properties", "src/main/resources/application.properties");
``` 

- Log verifications

All the services provide the logs of the running container or Quarkus application. Example of usage:

```java
@QuarkusScenario
public class DevModeMySqlDatabaseIT {

    @DevModeQuarkusApplication
    static RestService app = new RestService();

    @Test
    public void verifyLogsToAssertDevMode() {
        app.logs().assertContains("Profile dev activated. Live Coding activated");
        // or app.getLogs() to get the full list of logs.
    }
}
```

Fix https://github.com/quarkus-qe/quarkus-test-framework/issues/44