### PR TITLE
Quarkus source S2I strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,6 +519,27 @@ public class OpenShiftUsingExtensionPingPongResourceIT {
 
 The same limitations as in `OpenShift Extension` strategy apply here too.
 
+- **Quarkus Source S2I**
+
+This strategy utilises source S2I process described by the Quarkus product documentation:
+```shell
+oc import-image --confirm ubi8/openjdk-11 --from=registry.access.redhat.com/ubi8/openjdk-11
+oc new-app ubi8/openjdk-11 <git_path> --context-dir=<context_dir> --name=<project_name>
+```
+
+The application's git repository, ref, context dir and Quarkus version are all specified in `@QuarkusApplication` annotation.
+
+Example:
+
+```java
+@OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.QuarkusS2IBuild)
+public class OpenShiftS2iQuickstartIT {
+
+    @QuarkusApplication(gitRepositoryUri = "https://github.com/quarkusio/quarkus-quickstarts.git", contextDir = "getting-started")
+    static final RestService app = new RestService();
+    //
+```
+
 - **Container Registry**
 
 This strategy will build the image locally and push it to an intermediary container registry (provided by a system property). Then, the image will be pulled from the container registry in OpenShift.

--- a/examples/external-applications/pom.xml
+++ b/examples/external-applications/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus.qe</groupId>
+        <artifactId>quarkus-test-parent</artifactId>
+        <version>0.0.2-SNAPSHOT</version>
+        <relativePath>../../</relativePath>
+    </parent>
+    <artifactId>examples-external-applications</artifactId>
+    <name>Quarkus - Test Framework - Examples - External Applications</name>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus.qe</groupId>
+            <artifactId>quarkus-test-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus.qe</groupId>
+            <artifactId>quarkus-test-containers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus.qe</groupId>
+            <artifactId>quarkus-test-openshift</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftS2iQuickstartIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftS2iQuickstartIT.java
@@ -1,0 +1,25 @@
+package io.quarkus.qe;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
+import io.quarkus.test.scenarios.OpenShiftScenario;
+import io.quarkus.test.services.QuarkusApplication;
+
+@OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.QuarkusS2IBuild)
+public class OpenShiftS2iQuickstartIT {
+
+    @QuarkusApplication(gitRepositoryUri = "https://github.com/quarkusio/quarkus-quickstarts.git", contextDir = "getting-started")
+    static final RestService app = new RestService();
+
+    @Test
+    public void test() {
+        app.given()
+                .get("/hello")
+                .then()
+                .statusCode(HttpStatus.SC_OK);
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -341,6 +341,7 @@
                 <module>examples/amq-amqp</module>
                 <module>examples/jaeger</module>
                 <module>examples/database-mysql</module>
+                <module>examples/external-applications</module>
             </modules>
         </profile>
         <profile>

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/QuarkusApplication.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/QuarkusApplication.java
@@ -21,4 +21,13 @@ public @interface QuarkusApplication {
      * `quarkus.http.ssl.certificate.key-store-password` to be set.
      */
     boolean ssl() default false;
+
+    String gitRepositoryUri() default "";
+
+    String gitRef() default "";
+
+    String contextDir() default "";
+
+    String quarkusBuildVersion() default "";
+
 }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/ProdQuarkusApplicationManagedResourceBuilder.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/ProdQuarkusApplicationManagedResourceBuilder.java
@@ -50,6 +50,10 @@ public class ProdQuarkusApplicationManagedResourceBuilder extends QuarkusApplica
         QuarkusApplication metadata = (QuarkusApplication) annotation;
         setSslEnabled(metadata.ssl());
         initAppClasses(metadata.classes());
+        setGitRepositoryUri(metadata.gitRepositoryUri());
+        setGitRef(metadata.gitRef());
+        setContextDir(metadata.contextDir());
+        setQuarkusBuildVersion(metadata.quarkusBuildVersion());
     }
 
     @Override

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusApplicationManagedResourceBuilder.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusApplicationManagedResourceBuilder.java
@@ -35,6 +35,11 @@ public abstract class QuarkusApplicationManagedResourceBuilder implements Manage
     private ServiceContext context;
     private boolean sslEnabled = false;
     private Map<String, String> propertiesSnapshot;
+    private String gitRepositoryUri;
+    private String gitRef;
+    private String contextDir;
+    private String quarkusBuildVersion;
+    private Map<String, String> envVars;
 
     protected abstract void build();
 
@@ -60,6 +65,38 @@ public abstract class QuarkusApplicationManagedResourceBuilder implements Manage
 
     protected boolean isSelectedAppClasses() {
         return selectedAppClasses;
+    }
+
+    protected String getGitRepositoryUri() {
+        return gitRepositoryUri;
+    }
+
+    public void setGitRepositoryUri(String gitRepositoryUri) {
+        this.gitRepositoryUri = gitRepositoryUri;
+    }
+
+    protected String getGitRef() {
+        return gitRef;
+    }
+
+    public void setGitRef(String gitRef) {
+        this.gitRef = gitRef;
+    }
+
+    protected String getContextDir() {
+        return contextDir;
+    }
+
+    public void setContextDir(String contextDir) {
+        this.contextDir = contextDir;
+    }
+
+    public String getQuarkusBuildVersion() {
+        return quarkusBuildVersion;
+    }
+
+    public void setQuarkusBuildVersion(String quarkusBuildVersion) {
+        this.quarkusBuildVersion = quarkusBuildVersion;
     }
 
     public boolean containsBuildProperties() {

--- a/quarkus-test-core/src/main/java/io/quarkus/test/utils/ClassPathUtils.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/utils/ClassPathUtils.java
@@ -22,6 +22,9 @@ public final class ClassPathUtils {
         List<Class<?>> classes = new LinkedList<>();
         try {
             Path classesPathInSources = Path.of(SOURCE_CLASSES_LOCATION);
+            if (!Files.exists(classesPathInSources)) {
+                return new Class<?>[0];
+            }
             try (Stream<Path> stream = Files.walk(classesPathInSources)) {
                 stream.map(Path::toString).filter(s -> s.endsWith(CLASS_SUFFIX)).map(ClassPathUtils::normalizeClassName)
                         .forEach(className -> {

--- a/quarkus-test-core/src/main/java/io/quarkus/test/utils/FileUtils.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/utils/FileUtils.java
@@ -4,10 +4,12 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -65,6 +67,14 @@ public final class FileUtils {
         }
     }
 
+    public static void copyFileTo(String resourceFileName, Path targetPath) {
+        try (InputStream resources = FileUtils.class.getClassLoader().getResourceAsStream(resourceFileName)) {
+            Files.copy(resources, targetPath, StandardCopyOption.REPLACE_EXISTING);
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
     public static void copyCurrentDirectoryTo(Path target) {
         try {
             org.apache.commons.io.FileUtils.copyDirectory(Paths.get(".").toFile(), target.toFile(),
@@ -100,4 +110,5 @@ public final class FileUtils {
 
         return Optional.empty();
     }
+
 }

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/scenarios/OpenShiftDeploymentStrategy.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/scenarios/OpenShiftDeploymentStrategy.java
@@ -5,6 +5,7 @@ import io.quarkus.test.services.quarkus.ContainerRegistryOpenShiftQuarkusApplica
 import io.quarkus.test.services.quarkus.ExtensionOpenShiftQuarkusApplicationManagedResource;
 import io.quarkus.test.services.quarkus.ExtensionOpenShiftUsingDockerBuildStrategyQuarkusApplicationManagedResource;
 import io.quarkus.test.services.quarkus.OpenShiftQuarkusApplicationManagedResource;
+import io.quarkus.test.services.quarkus.QuarkusSourceS2iBuildApplicationManagedResource;
 
 /**
  * OpenShift Deployment strategies.
@@ -14,6 +15,11 @@ public enum OpenShiftDeploymentStrategy {
      * Will push the artifacts into OpenShift and build the image that will be used to run the pods.
      */
     Build(BuildOpenShiftQuarkusApplicationManagedResource.class),
+    /**
+     * This build strategy will use the source S2I build strategy to build the container with the running Quarkus
+     * application.
+     */
+    QuarkusS2IBuild(QuarkusSourceS2iBuildApplicationManagedResource.class),
     /**
      * Will build the Quarkus app image and push it into a Container Registry to be accessed by OpenShift to deploy the app.
      */

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/QuarkusSourceS2iBuildApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/QuarkusSourceS2iBuildApplicationManagedResource.java
@@ -1,0 +1,104 @@
+package io.quarkus.test.services.quarkus;
+
+import static java.util.regex.Pattern.quote;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.nio.file.Path;
+
+import org.codehaus.plexus.util.StringUtils;
+
+import io.quarkus.test.services.quarkus.model.LaunchMode;
+import io.quarkus.test.utils.FileUtils;
+
+public class QuarkusSourceS2iBuildApplicationManagedResource extends OpenShiftQuarkusApplicationManagedResource {
+
+    private static final String QUARKUS_SOURCE_S2I_BASE_IMAGE_FILENAME = "openjdk-11.yml";
+    private static final String QUARKUS_SOURCE_S2I_BUILD_TEMPLATE_FILENAME = "quarkus-s2i-source-build-template.yml";
+    private static final String QUARKUS_SOURCE_S2I_SETTINGS_MVN_FILENAME = "settings-mvn.yml";
+
+    public QuarkusSourceS2iBuildApplicationManagedResource(ProdQuarkusApplicationManagedResourceBuilder model) {
+        super(model);
+    }
+
+    /**
+     * - Apply base image stream (resources/openjdk-11.yml).
+     * - Wait for base image stream (resources/openjdk-11.yml).
+     * - Express parameters in S2I build application (resources/quarkus-s2i-source-build-template.yml).
+     * - Add environment variables to deployment config in S2I build application
+     * (resources/quarkus-s2i-source-build-template.yml).
+     * - Enrich deployment config for purposes of the test suite in S2I build application
+     * (resources/quarkus-s2i-source-build-template.yml).
+     * - Apply the resulting OpenShift yml file.
+     * - Wait for build config to have a complete build.
+     * - Wait for deployment to be ready.
+     */
+    @Override
+    protected void doInit() {
+        waitForBaseImage();
+        createMavenSettings();
+        applyTemplate();
+        client.followBuildConfigLogs(model.getContext().getName());
+    }
+
+    @Override
+    protected void doUpdate() {
+        applyTemplate();
+    }
+
+    @Override
+    protected boolean needsBuildArtifact() {
+        return false;
+    }
+
+    @Override
+    public void validate() {
+        super.validate();
+
+        if (model.isSelectedAppClasses()) {
+            fail("Custom source classes as @QuarkusApplication(classes = ...) is not supported by Quarkus source S2I build.");
+        }
+
+        if (StringUtils.isEmpty(model.getGitRepositoryUri())) {
+            fail("Source S2I build requires a remote Git repository with a Quarkus application.");
+        }
+
+        if (model.getLaunchMode().equals(LaunchMode.NATIVE)) {
+            fail("Quarkus source S2I build is not supported with native launch mode.");
+        }
+    }
+
+    private void waitForBaseImage() {
+        Path targetQuarkusSourceS2iBaseImageFileName = model.getContext().getServiceFolder()
+                .resolve(QUARKUS_SOURCE_S2I_BASE_IMAGE_FILENAME);
+        FileUtils.copyFileTo(QUARKUS_SOURCE_S2I_BASE_IMAGE_FILENAME, targetQuarkusSourceS2iBaseImageFileName);
+        client.apply(model.getContext().getOwner(), targetQuarkusSourceS2iBaseImageFileName);
+        client.awaitFor(model.getContext().getOwner(), targetQuarkusSourceS2iBaseImageFileName);
+    }
+
+    private void createMavenSettings() {
+        Path targetQuarkusSourceS2iSettingsMvnFilename = model.getContext().getServiceFolder()
+                .resolve(QUARKUS_SOURCE_S2I_SETTINGS_MVN_FILENAME);
+        FileUtils.copyFileTo(QUARKUS_SOURCE_S2I_SETTINGS_MVN_FILENAME, targetQuarkusSourceS2iSettingsMvnFilename);
+        client.apply(model.getContext().getOwner(), targetQuarkusSourceS2iSettingsMvnFilename);
+    }
+
+    private void applyTemplate() {
+        Path targetQuarkusSourceS2iBuildTemplateFileName = model.getContext().getServiceFolder()
+                .resolve(QUARKUS_SOURCE_S2I_BUILD_TEMPLATE_FILENAME);
+        FileUtils.copyFileTo(QUARKUS_SOURCE_S2I_BUILD_TEMPLATE_FILENAME,
+                targetQuarkusSourceS2iBuildTemplateFileName);
+        client.applyServicePropertiesUsingTemplate(model.getContext().getOwner(),
+                "/" + QUARKUS_SOURCE_S2I_BUILD_TEMPLATE_FILENAME,
+                this::replaceDeploymentContent,
+                targetQuarkusSourceS2iBuildTemplateFileName);
+    }
+
+    private String replaceDeploymentContent(String content) {
+        return content.replaceAll(quote("${APP_NAME}"), model.getContext().getOwner().getName())
+                .replaceAll(quote("${GIT_URI}"), model.getGitRepositoryUri())
+                .replaceAll(quote("${GIT_REF}"), model.getGitRef())
+                .replaceAll(quote("${CONTEXT_DIR}"), model.getContextDir())
+                .replaceAll(quote("${QUARKUS_VERSION}"), model.getQuarkusBuildVersion());
+    }
+
+}

--- a/quarkus-test-openshift/src/main/resources/openjdk-11.yml
+++ b/quarkus-test-openshift/src/main/resources/openjdk-11.yml
@@ -1,0 +1,12 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: openjdk-11
+spec:
+  lookupPolicy:
+    local: false
+  tags:
+    - name: latest
+      from:
+        kind: DockerImage
+        name: registry.access.redhat.com/ubi8/openjdk-11:latest

--- a/quarkus-test-openshift/src/main/resources/quarkus-s2i-source-build-template.yml
+++ b/quarkus-test-openshift/src/main/resources/quarkus-s2i-source-build-template.yml
@@ -1,0 +1,97 @@
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: image.openshift.io/v1
+    kind: ImageStream
+    metadata:
+      name: ${APP_NAME}
+    spec:
+      lookupPolicy:
+        local: false
+
+  - apiVersion: build.openshift.io/v1
+    kind: BuildConfig
+    metadata:
+      name: ${APP_NAME}
+    spec:
+      output:
+        to:
+          kind: ImageStreamTag
+          name: ${APP_NAME}:latest
+      source:
+        git:
+          uri: ${GIT_URI}
+          ref: ${GIT_REF}
+        type: Git
+        contextDir: ${CONTEXT_DIR}
+        configMaps:
+          - configMap:
+              name: settings-mvn
+            destinationDir: "/configuration"
+      strategy:
+        type: Source
+        sourceStrategy:
+          env:
+            - name: ARTIFACT_COPY_ARGS
+              value: -p -r quarkus-app/quarkus-run.jar
+            - name: MAVEN_ARGS
+              value: -s /configuration/settings.xml -Dquarkus.version=${QUARKUS_VERSION} -DskipTests=true
+          from:
+            kind: ImageStreamTag
+            name: openjdk-11:latest
+      triggers:
+        - type: ConfigChange
+        - type: ImageChange
+          imageChange: {}
+
+  - apiVersion: apps.openshift.io/v1
+    kind: DeploymentConfig
+    metadata:
+      name: ${APP_NAME}
+    spec:
+      replicas: 1
+      selector:
+        name: ${APP_NAME}
+      template:
+        metadata:
+          labels:
+            name: ${APP_NAME}
+        spec:
+          containers:
+            - name: ${APP_NAME}
+              image: ${APP_NAME}:latest
+              ports:
+                - containerPort: 8080
+                  protocol: TCP
+      test: false
+      triggers:
+        - type: ConfigChange
+        - type: ImageChange
+          imageChangeParams:
+            automatic: true
+            containerNames:
+              - ${APP_NAME}
+            from:
+              kind: ImageStreamTag
+              name: ${APP_NAME}:latest
+
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: ${APP_NAME}
+    spec:
+      ports:
+        - name: 8080-tcp
+          port: 8080
+          protocol: TCP
+          targetPort: 8080
+      selector:
+        name: ${APP_NAME}
+
+  - apiVersion: route.openshift.io/v1
+    kind: Route
+    metadata:
+      name: ${APP_NAME}
+    spec:
+      to:
+        name: ${APP_NAME}

--- a/quarkus-test-openshift/src/main/resources/settings-mvn.yml
+++ b/quarkus-test-openshift/src/main/resources/settings-mvn.yml
@@ -1,0 +1,55 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: settings-mvn
+data:
+  settings.xml: |
+    <?xml version="1.0" encoding="UTF-8"?>
+    <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+        <profiles>
+            <profile>
+                <id>redhat</id>
+                <repositories>
+                    <repository>
+                        <id>redhat</id>
+                        <name>Repository for Redhat dependencies</name>
+                        <url>https://maven.repository.redhat.com/ga/</url>
+                    </repository>
+                </repositories>
+                <pluginRepositories>
+                    <pluginRepository>
+                        <id>redhat</id>
+                        <name>Repository for Redhat dependencies</name>
+                        <url>https://maven.repository.redhat.com/ga/</url>
+                    </pluginRepository>
+                </pluginRepositories>
+            </profile>
+            <profile>
+                <id>customRemoteRepository</id>
+                <repositories>
+                    <repository>
+                        <id>ts.s2i.maven.remote.repository</id>
+                        <url>${ts.s2i.maven.remote.repository}</url>
+                        <snapshots>
+                            <enabled>false</enabled>
+                        </snapshots>
+                    </repository>
+                </repositories>
+                <pluginRepositories>
+                    <pluginRepository>
+                        <id>ts.s2i.maven.remote.repository</id>
+                        <url>${ts.s2i.maven.remote.repository}</url>
+                        <snapshots>
+                            <enabled>false</enabled>
+                        </snapshots>
+                    </pluginRepository>
+                </pluginRepositories>
+            </profile>
+        </profiles>
+        <activeProfiles>
+            <activeProfile>customRemoteRepository</activeProfile>
+            <activeProfile>redhat</activeProfile>
+        </activeProfiles>
+    </settings>


### PR DESCRIPTION
* Adding Quarkus source S2I strategy. This strategy utilises OpenShift
  objects generated by the following oc commands:

   ```
   oc import-image --confirm ubi8/openjdk-11 --from=registry.access.redhat.com/ubi8/openjdk-11
   oc new-app ubi8/openjdk-11 <git_path> --context-dir=<context_dir> --name=<project_name>
   ```

  There are additional enhancements, like adding environment variables,
  which are not available from `oc new-app` command.
