### PR TITLE
Allow to configure timeouts via system properties / configuration files

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ As seen in the above example, everything is bounded to a Service object that wil
 
 Test framework allows to customise the configuration for running the test case via a `test.properties` file placed under `src/test/resources` folder.
 
+All the properties can be configured globally by replacing `<YOUR SERVICE NAME>` with `global`.
+
 The current configuration options are: 
 
 - Enable/Disable logging (enabled by default):
@@ -70,6 +72,37 @@ ts.global.log.enable=false
 ```
 
 The above configuration will disable logging for all your services. The same can be set via system properties by running `-Dts.global.log.enable=false`.
+
+- Timeouts
+
+Timeouts are quite important property to, as an example, control how long to wait for a service to start. The existing options to configure timeouts are:
+ 
+```
+# Startup timeout for services is 5 minutes
+ts.<global or YOUR SERVICE NAME>.startup.timeout=5m
+# Default startup check poll interval is every 2 seconds
+ts.<global or YOUR SERVICE NAME>.startup.check-poll-interval=2s
+# Install operator timeout is 10 minutes
+ts.<global or YOUR SERVICE NAME>.operator.install.timeout=10m
+# Install image stream timeout is 5 minutes
+ts.<global or YOUR SERVICE NAME>.imagestream.install.timeout=5m
+```
+
+In order to increase the default timeout for all the services, we can use the `global` scope. For example, to increase the default startup timeout: `ts.global.startup.timeout=10m`. Also, we can configure how often the test framework will check for the startup condition using the property `ts.global.startup.check-poll-interval=3s`. Using these two properties, we are making all the services to wait up to 10 minutes to start and checking the condition every 3 seconds.
+
+On the other hand, if we want to update the timeout for a single service because we know that this service is quite slow, the scope of the property is the service name. For example, let's imagine that the `pingApp` service from the [Getting Started](#getting-started) section is very slow, we can use `ts.pingApp.startup.timeout=20m` to wait up to 20 min for only the ping application to start. 
+
+How can we manipulate the overall timeout in slower environments? Let's say that our environment is twice and a half slower than a good environment, then we can instruct the test framework with:
+
+```
+ts.global.factor.timeout=2.5
+```
+
+And all the timeouts will take into account this factor value. For example, if previously, the startup timeout was 10 minutes, now it will be 10 * 2.5 = 25 minutes.
+
+In a Multi-Module Maven test suite, if we want to configure the timeouts, we can do this via system properties:
+- Increase the startup timeout only: `mvn clean verify -Dts.global.startup.timeout=20m`
+- Increase all the timeouts at once using the factor: `mvn clean verify -Dts.global.factor.timeout=2.5`
 
 ### Native
 

--- a/quarkus-test-core/src/main/java/io/quarkus/test/configuration/Configuration.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/configuration/Configuration.java
@@ -1,6 +1,7 @@
 package io.quarkus.test.configuration;
 
 import java.io.InputStream;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -20,6 +21,28 @@ public final class Configuration {
 
     private Configuration(Map<String, String> properties) {
         this.properties = properties;
+    }
+
+    public Duration getAsDuration(String property, Duration defaultValue) {
+        String value = get(property);
+        if (StringUtils.isEmpty(value)) {
+            return defaultValue;
+        }
+
+        if (Character.isDigit(value.charAt(0))) {
+            value = "PT" + value;
+        }
+
+        return Duration.parse(value);
+    }
+
+    public Double getAsDouble(String property, double defaultValue) {
+        String value = get(property);
+        if (StringUtils.isEmpty(value)) {
+            return defaultValue;
+        }
+
+        return Double.parseDouble(value);
     }
 
     public String get(String property) {

--- a/quarkus-test-core/src/main/resources/global.properties
+++ b/quarkus-test-core/src/main/resources/global.properties
@@ -1,1 +1,12 @@
+# Enable logging for all services by default
 ts.global.log.enable=true
+# Default startup timeout for services is 5 minutes
+ts.global.startup.timeout=5m
+# Default startup check poll interval is every 2 seconds
+ts.global.startup.check-poll-interval=2s
+# Default install operator timeout is 10 minutes
+ts.global.operator.install.timeout=10m
+# Default install image stream timeout is 5 minutes
+ts.global.imagestream.install.timeout=5m
+# Default timeout factor for all checks
+ts.global.factor.timeout=1

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/OpenShiftExtensionBootstrap.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/OpenShiftExtensionBootstrap.java
@@ -66,7 +66,9 @@ public class OpenShiftExtensionBootstrap implements ExtensionBootstrap {
     private void installOperators(ExtensionContext context) {
         OpenShiftScenario openShiftScenario = context.getRequiredTestClass().getAnnotation(OpenShiftScenario.class);
         for (Operator operator : openShiftScenario.operators()) {
-            client.installOperator(operator.name(), operator.channel(), operator.source(), operator.sourceNamespace());
+            Service defaultService = new DefaultService();
+            defaultService.register(operator.name());
+            client.installOperator(defaultService, operator.channel(), operator.source(), operator.sourceNamespace());
         }
     }
 }

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/operator/OperatorManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/operator/OperatorManagedResource.java
@@ -90,6 +90,9 @@ public class OperatorManagedResource implements ManagedResource {
     }
 
     private void installOperator() {
-        client.installOperator(model.getName(), model.getChannel(), model.getSource(), model.getSourceNamespace());
+        client.installOperator(model.getContext().getOwner(),
+                model.getChannel(),
+                model.getSource(),
+                model.getSourceNamespace());
     }
 }


### PR DESCRIPTION
### Configuration

Test framework allows to customise the configuration for running the test case via a `test.properties` file placed under `src/test/resources` folder.

All the properties can be configured globally by replacing `<YOUR SERVICE NAME>` with `global`.

- Timeouts

Timeouts are quite important property to, as an example, control how long to wait for a service to start. The existing options to configure timeouts are::
 
```
# Startup timeout for services is 5 minutes
ts.<YOUR SERVICE NAME>.startup.timeout=5m
# Install operator timeout is 10 minutes
ts.<YOUR SERVICE NAME>.operator.install.timeout=10m
# Install image stream timeout is 5 minutes
ts.<YOUR SERVICE NAME>.imagestream.install.timeout=5m
```

For example, we can use `ts.pingApp.startup.timeout` to wait up to 10 min for the ping application to start. 

How often does the test framework check for startup conditions? This is also configurable via:

```
ts.<YOUR SERVICE NAME>.startup.check-poll-interval=2s
```

Now, we're saying that we need to wait up to 10 minutes for our service to start and will be checking the condition every 2 seconds.

How can we manipulate the overall timeout in slower environments? Let's say that our environment is twice and a half slower than a good environment, then we can instruct the test framework with:

```
ts.global.factor.timeout=2.5
```

And all the timeouts will take into account this factor value. For example, if previously, the startup timeout was 10 minutes, now it will be 10 * 2.5 = 25 minutes.

Fix https://github.com/quarkus-qe/quarkus-test-framework/issues/75