### PR TITLE
Automatically install Parent Poms when using DevMode and OpenShift

### DIFF
--- a/examples/greetings/tests.log
+++ b/examples/greetings/tests.log
@@ -1,3 +1,0 @@
-09:08:28.153 INFO  [43;1m[joseApp] Initialize service[0m
-09:08:28.166 INFO  [46m[manuelApp] Initialize service[0m
-09:08:30.175 INFO  [43;1m[joseApp] Service started[0m

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/DevModeLocalhostQuarkusApplicationManagedResource.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/DevModeLocalhostQuarkusApplicationManagedResource.java
@@ -2,6 +2,7 @@ package io.quarkus.test.services.quarkus;
 
 import static io.quarkus.test.utils.MavenUtils.SKIP_CHECKSTYLE;
 import static io.quarkus.test.utils.MavenUtils.SKIP_ITS;
+import static io.quarkus.test.utils.MavenUtils.installParentPomsIfNeeded;
 import static io.quarkus.test.utils.MavenUtils.mvnCommand;
 import static io.quarkus.test.utils.MavenUtils.withProperty;
 
@@ -18,6 +19,8 @@ public class DevModeLocalhostQuarkusApplicationManagedResource extends Localhost
     }
 
     protected List<String> prepareCommand(List<String> systemProperties) {
+        installParentPomsIfNeeded();
+
         List<String> command = mvnCommand(model.getContext());
         command.addAll(Arrays.asList(SKIP_CHECKSTYLE, SKIP_ITS));
         command.addAll(systemProperties);

--- a/quarkus-test-core/src/main/java/io/quarkus/test/utils/MavenUtils.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/utils/MavenUtils.java
@@ -1,7 +1,16 @@
 package io.quarkus.test.utils;
 
+import java.io.FileReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 
 import io.quarkus.test.bootstrap.ServiceContext;
 
@@ -9,6 +18,7 @@ public final class MavenUtils {
 
     public static final String MVN_COMMAND = "mvn";
     public static final String PACKAGE_GOAL = "package";
+    public static final String INSTALL_GOAL = "install";
     public static final String MVN_REPOSITORY_LOCAL = "maven.repo.local";
     public static final String SKIP_TESTS = "-DskipTests=true";
     public static final String SKIP_ITS = "-DskipITs=true";
@@ -16,6 +26,7 @@ public final class MavenUtils {
     public static final String DISPLAY_VERSION = "-V";
     public static final String SKIP_CHECKSTYLE = "-Dcheckstyle.skip";
     public static final String QUARKUS_PROFILE = "quarkus.profile";
+    public static final String POM_XML = "pom.xml";
 
     private MavenUtils() {
 
@@ -29,6 +40,40 @@ public final class MavenUtils {
         return args;
     }
 
+    public static String withProperty(String property, String value) {
+        return String.format("-D%s=%s", property, value);
+    }
+
+    public static void installParentPomsIfNeeded() {
+        installParentPomsIfNeeded(Paths.get("."));
+    }
+
+    public static void installParentPomsIfNeeded(Path basePath) {
+        if (Files.exists(basePath.resolve(POM_XML))) {
+            Model mavenModel = getMavenModel(basePath);
+            if (mavenModel != null && mavenModel.getParent() != null) {
+                Path relativePath = basePath
+                        .resolve(StringUtils.defaultIfBlank(mavenModel.getParent().getRelativePath(), ".."));
+                installParentPom(relativePath);
+                installParentPomsIfNeeded(relativePath);
+            }
+        }
+    }
+
+    private static void installParentPom(Path relativePath) {
+        List<String> args = new ArrayList<>();
+        args.addAll(Arrays.asList(MVN_COMMAND, INSTALL_GOAL, SKIP_CHECKSTYLE, SKIP_TESTS, SKIP_ITS, "-pl", "."));
+        withMavenRepositoryLocalIfSet(args);
+
+        Command cmd = new Command(args);
+        cmd.onDirectory(relativePath);
+        try {
+            cmd.runAndWait();
+        } catch (Exception ignored) {
+            // Could not find POM.xml, ignoring
+        }
+    }
+
     private static String withQuarkusProfile(ServiceContext serviceContext) {
         return withProperty(QUARKUS_PROFILE, serviceContext.getTestContext().getRequiredTestClass().getSimpleName());
     }
@@ -40,7 +85,14 @@ public final class MavenUtils {
         }
     }
 
-    public static String withProperty(String property, String value) {
-        return String.format("-D%s=%s", property, value);
+    private static Model getMavenModel(Path basePath) {
+        MavenXpp3Reader reader = new MavenXpp3Reader();
+        try (FileReader is = new FileReader(basePath.resolve(POM_XML).toFile())) {
+            return reader.read(is);
+        } catch (Exception ignored) {
+            // Could not find POM.xml, ignoring
+        }
+
+        return null;
     }
 }

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/ExtensionOpenShiftQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/ExtensionOpenShiftQuarkusApplicationManagedResource.java
@@ -6,6 +6,7 @@ import static io.quarkus.test.utils.MavenUtils.PACKAGE_GOAL;
 import static io.quarkus.test.utils.MavenUtils.SKIP_CHECKSTYLE;
 import static io.quarkus.test.utils.MavenUtils.SKIP_ITS;
 import static io.quarkus.test.utils.MavenUtils.SKIP_TESTS;
+import static io.quarkus.test.utils.MavenUtils.installParentPomsIfNeeded;
 import static io.quarkus.test.utils.MavenUtils.mvnCommand;
 import static io.quarkus.test.utils.MavenUtils.withProperty;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -31,7 +32,6 @@ public class ExtensionOpenShiftQuarkusApplicationManagedResource extends OpenShi
     private static final String USING_EXTENSION_PROFILE = "-Pdeploy-to-openshift-using-extension";
     private static final String QUARKUS_PLUGIN_DEPLOY = "-Dquarkus.kubernetes.deploy=true";
     private static final String QUARKUS_PLUGIN_EXPOSE = "-Dquarkus.openshift.expose=true";
-    private static final String QUARKUS_PROFILE = "quarkus.profile";
     private static final String QUARKUS_CONTAINER_NAME = "quarkus.application.name";
     private static final String QUARKUS_KUBERNETES_CLIENT_NAMESPACE = "quarkus.kubernetes-client.namespace";
     private static final String QUARKUS_KUBERNETES_CLIENT_TRUST_CERTS = "quarkus.kubernetes-client.trust-certs";
@@ -93,6 +93,8 @@ public class ExtensionOpenShiftQuarkusApplicationManagedResource extends OpenShi
     }
 
     private void deployProjectUsingMavenCommand() {
+        installParentPomsIfNeeded();
+
         String namespace = client.project();
 
         List<String> args = mvnCommand(model.getContext());


### PR DESCRIPTION
With these changes, the framework will ensure that the inner Maven command will work even when the test module uses a parent dependency.

Fix https://github.com/quarkus-qe/quarkus-test-framework/issues/78