### PR TITLE
Refactor of s2i solution for Quarkus Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,10 +553,10 @@ The application's git repository, ref, context dir and Quarkus version are all s
 Example:
 
 ```java
-@OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.QuarkusS2IBuild)
+@OpenShiftScenario
 public class OpenShiftS2iQuickstartIT {
 
-    @QuarkusApplication(gitRepositoryUri = "https://github.com/quarkusio/quarkus-quickstarts.git", contextDir = "getting-started")
+    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", contextDir = "getting-started")
     static final RestService app = new RestService();
     //
 ```

--- a/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftS2iQuickstartIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftS2iQuickstartIT.java
@@ -4,14 +4,13 @@ import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
-import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 
-@OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.QuarkusS2IBuild)
+@OpenShiftScenario
 public class OpenShiftS2iQuickstartIT {
 
-    @QuarkusApplication(gitRepositoryUri = "https://github.com/quarkusio/quarkus-quickstarts.git", contextDir = "getting-started")
+    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", contextDir = "getting-started")
     static final RestService app = new RestService();
 
     @Test

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/GitRepositoryQuarkusApplication.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/GitRepositoryQuarkusApplication.java
@@ -1,0 +1,18 @@
+package io.quarkus.test.services;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface GitRepositoryQuarkusApplication {
+    String repo();
+
+    String branch() default "";
+
+    String contextDir() default "";
+
+    String mavenArgs() default "-DskipTests=true -DskipITs=true";
+}

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/QuarkusApplication.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/QuarkusApplication.java
@@ -21,13 +21,4 @@ public @interface QuarkusApplication {
      * `quarkus.http.ssl.certificate.key-store-password` to be set.
      */
     boolean ssl() default false;
-
-    String gitRepositoryUri() default "";
-
-    String gitRef() default "";
-
-    String contextDir() default "";
-
-    String quarkusBuildVersion() default "";
-
 }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/DevModeQuarkusApplicationAnnotationBinding.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/DevModeQuarkusApplicationAnnotationBinding.java
@@ -14,7 +14,7 @@ public class DevModeQuarkusApplicationAnnotationBinding implements AnnotationBin
     }
 
     @Override
-    public ManagedResourceBuilder createBuilder(Field field) throws Exception {
+    public ManagedResourceBuilder createBuilder(Field field) {
         DevModeQuarkusApplication metadata = field.getAnnotation(DevModeQuarkusApplication.class);
 
         ManagedResourceBuilder builder = new DevModeQuarkusApplicationManagedResourceBuilder();

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/GitRepositoryQuarkusApplicationAnnotationBinding.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/GitRepositoryQuarkusApplicationAnnotationBinding.java
@@ -1,0 +1,25 @@
+package io.quarkus.test.services.quarkus;
+
+import java.lang.reflect.Field;
+
+import io.quarkus.test.bootstrap.AnnotationBinding;
+import io.quarkus.test.bootstrap.ManagedResourceBuilder;
+import io.quarkus.test.services.GitRepositoryQuarkusApplication;
+
+public class GitRepositoryQuarkusApplicationAnnotationBinding implements AnnotationBinding {
+
+    @Override
+    public boolean isFor(Field field) {
+        return field.isAnnotationPresent(GitRepositoryQuarkusApplication.class);
+    }
+
+    @Override
+    public ManagedResourceBuilder createBuilder(Field field) {
+        GitRepositoryQuarkusApplication metadata = field.getAnnotation(GitRepositoryQuarkusApplication.class);
+
+        ManagedResourceBuilder builder = new GitRepositoryQuarkusApplicationManagedResourceBuilder();
+        builder.init(metadata);
+        return builder;
+    }
+
+}

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/GitRepositoryQuarkusApplicationManagedResourceBinding.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/GitRepositoryQuarkusApplicationManagedResourceBinding.java
@@ -1,0 +1,19 @@
+package io.quarkus.test.services.quarkus;
+
+import io.quarkus.test.bootstrap.ServiceContext;
+
+public interface GitRepositoryQuarkusApplicationManagedResourceBinding {
+    /**
+     * @param context
+     * @return if the current managed resource applies for the current context.
+     */
+    boolean appliesFor(ServiceContext context);
+
+    /**
+     * Init and return the managed resource for the current context.
+     *
+     * @param builder
+     * @return
+     */
+    QuarkusManagedResource init(GitRepositoryQuarkusApplicationManagedResourceBuilder builder);
+}

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/GitRepositoryQuarkusApplicationManagedResourceBuilder.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/GitRepositoryQuarkusApplicationManagedResourceBuilder.java
@@ -1,0 +1,75 @@
+package io.quarkus.test.services.quarkus;
+
+import java.lang.annotation.Annotation;
+import java.util.ServiceLoader;
+
+import org.junit.jupiter.api.Assertions;
+
+import io.quarkus.test.bootstrap.ManagedResource;
+import io.quarkus.test.bootstrap.ServiceContext;
+import io.quarkus.test.services.GitRepositoryQuarkusApplication;
+
+public class GitRepositoryQuarkusApplicationManagedResourceBuilder extends QuarkusApplicationManagedResourceBuilder {
+
+    private final ServiceLoader<GitRepositoryQuarkusApplicationManagedResourceBinding> bindings = ServiceLoader
+            .load(GitRepositoryQuarkusApplicationManagedResourceBinding.class);
+
+    private String gitRepository;
+    private String gitBranch;
+    private String contextDir;
+    private String mavenArgs;
+    private QuarkusManagedResource managedResource;
+
+    protected String getGitRepository() {
+        return gitRepository;
+    }
+
+    protected String getGitBranch() {
+        return gitBranch;
+    }
+
+    protected String getContextDir() {
+        return contextDir;
+    }
+
+    protected String getMavenArgs() {
+        return mavenArgs;
+    }
+
+    @Override
+    public void init(Annotation annotation) {
+        GitRepositoryQuarkusApplication metadata = (GitRepositoryQuarkusApplication) annotation;
+        gitRepository = metadata.repo();
+        gitBranch = metadata.branch();
+        contextDir = metadata.contextDir();
+        mavenArgs = metadata.mavenArgs();
+    }
+
+    @Override
+    public ManagedResource build(ServiceContext context) {
+        setContext(context);
+        configureLogging();
+        managedResource = findManagedResource();
+        build();
+
+        managedResource.validate();
+
+        return managedResource;
+    }
+
+    @Override
+    protected void build() {
+
+    }
+
+    private QuarkusManagedResource findManagedResource() {
+        for (GitRepositoryQuarkusApplicationManagedResourceBinding binding : bindings) {
+            if (binding.appliesFor(getContext())) {
+                return binding.init(this);
+            }
+        }
+
+        Assertions.fail("No managed resource builder found for @GitRepositoryQuarkusApplication annotation");
+        return null;
+    }
+}

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/ProdQuarkusApplicationManagedResourceBuilder.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/ProdQuarkusApplicationManagedResourceBuilder.java
@@ -50,10 +50,6 @@ public class ProdQuarkusApplicationManagedResourceBuilder extends QuarkusApplica
         QuarkusApplication metadata = (QuarkusApplication) annotation;
         setSslEnabled(metadata.ssl());
         initAppClasses(metadata.classes());
-        setGitRepositoryUri(metadata.gitRepositoryUri());
-        setGitRef(metadata.gitRef());
-        setContextDir(metadata.contextDir());
-        setQuarkusBuildVersion(metadata.quarkusBuildVersion());
     }
 
     @Override

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusApplicationManagedResourceBuilder.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusApplicationManagedResourceBuilder.java
@@ -35,11 +35,6 @@ public abstract class QuarkusApplicationManagedResourceBuilder implements Manage
     private ServiceContext context;
     private boolean sslEnabled = false;
     private Map<String, String> propertiesSnapshot;
-    private String gitRepositoryUri;
-    private String gitRef;
-    private String contextDir;
-    private String quarkusBuildVersion;
-    private Map<String, String> envVars;
 
     protected abstract void build();
 
@@ -65,38 +60,6 @@ public abstract class QuarkusApplicationManagedResourceBuilder implements Manage
 
     protected boolean isSelectedAppClasses() {
         return selectedAppClasses;
-    }
-
-    protected String getGitRepositoryUri() {
-        return gitRepositoryUri;
-    }
-
-    public void setGitRepositoryUri(String gitRepositoryUri) {
-        this.gitRepositoryUri = gitRepositoryUri;
-    }
-
-    protected String getGitRef() {
-        return gitRef;
-    }
-
-    public void setGitRef(String gitRef) {
-        this.gitRef = gitRef;
-    }
-
-    protected String getContextDir() {
-        return contextDir;
-    }
-
-    public void setContextDir(String contextDir) {
-        this.contextDir = contextDir;
-    }
-
-    public String getQuarkusBuildVersion() {
-        return quarkusBuildVersion;
-    }
-
-    public void setQuarkusBuildVersion(String quarkusBuildVersion) {
-        this.quarkusBuildVersion = quarkusBuildVersion;
     }
 
     public boolean containsBuildProperties() {

--- a/quarkus-test-core/src/main/resources/META-INF/services/io.quarkus.test.bootstrap.AnnotationBinding
+++ b/quarkus-test-core/src/main/resources/META-INF/services/io.quarkus.test.bootstrap.AnnotationBinding
@@ -1,2 +1,3 @@
 io.quarkus.test.services.quarkus.QuarkusApplicationAnnotationBinding
 io.quarkus.test.services.quarkus.DevModeQuarkusApplicationAnnotationBinding
+io.quarkus.test.services.quarkus.GitRepositoryQuarkusApplicationAnnotationBinding

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
@@ -1,6 +1,7 @@
 package io.quarkus.test.bootstrap.inject;
 
 import static io.quarkus.test.utils.AwaitilityUtils.AwaitilitySettings;
+import static io.quarkus.test.utils.AwaitilityUtils.untilIsNotNull;
 import static io.quarkus.test.utils.AwaitilityUtils.untilIsTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -205,6 +206,7 @@ public final class OpenShiftClient {
     }
 
     public void followBuildConfigLogs(String buildConfigName) {
+        untilIsNotNull(client.buildConfigs().withName(buildConfigName)::get);
         try {
             new Command(OC, "logs", "bc/" + buildConfigName, "--follow").runAndWait();
         } catch (Exception e) {

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/scenarios/OpenShiftDeploymentStrategy.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/scenarios/OpenShiftDeploymentStrategy.java
@@ -5,7 +5,6 @@ import io.quarkus.test.services.quarkus.ContainerRegistryOpenShiftQuarkusApplica
 import io.quarkus.test.services.quarkus.ExtensionOpenShiftQuarkusApplicationManagedResource;
 import io.quarkus.test.services.quarkus.ExtensionOpenShiftUsingDockerBuildStrategyQuarkusApplicationManagedResource;
 import io.quarkus.test.services.quarkus.OpenShiftQuarkusApplicationManagedResource;
-import io.quarkus.test.services.quarkus.QuarkusSourceS2iBuildApplicationManagedResource;
 
 /**
  * OpenShift Deployment strategies.
@@ -15,11 +14,6 @@ public enum OpenShiftDeploymentStrategy {
      * Will push the artifacts into OpenShift and build the image that will be used to run the pods.
      */
     Build(BuildOpenShiftQuarkusApplicationManagedResource.class),
-    /**
-     * This build strategy will use the source S2I build strategy to build the container with the running Quarkus
-     * application.
-     */
-    QuarkusS2IBuild(QuarkusSourceS2iBuildApplicationManagedResource.class),
     /**
      * Will build the Quarkus app image and push it into a Container Registry to be accessed by OpenShift to deploy the app.
      */

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/BuildOpenShiftQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/BuildOpenShiftQuarkusApplicationManagedResource.java
@@ -10,7 +10,8 @@ import io.quarkus.test.logging.Log;
 import io.quarkus.test.services.quarkus.model.LaunchMode;
 import io.quarkus.test.utils.Command;
 
-public class BuildOpenShiftQuarkusApplicationManagedResource extends OpenShiftQuarkusApplicationManagedResource {
+public class BuildOpenShiftQuarkusApplicationManagedResource
+        extends OpenShiftQuarkusApplicationManagedResource<ProdQuarkusApplicationManagedResourceBuilder> {
 
     private static final String S2I_DEFAULT_VERSION = "latest";
 

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/ContainerRegistryOpenShiftQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/ContainerRegistryOpenShiftQuarkusApplicationManagedResource.java
@@ -6,7 +6,8 @@ import org.apache.commons.lang3.StringUtils;
 
 import io.quarkus.test.utils.DockerUtils;
 
-public class ContainerRegistryOpenShiftQuarkusApplicationManagedResource extends OpenShiftQuarkusApplicationManagedResource {
+public class ContainerRegistryOpenShiftQuarkusApplicationManagedResource
+        extends OpenShiftQuarkusApplicationManagedResource<ProdQuarkusApplicationManagedResourceBuilder> {
 
     private static final String QUARKUS_OPENSHIFT_TEMPLATE = "/quarkus-registry-openshift-template.yml";
     private static final String DEPLOYMENT = "openshift.yml";

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/ExtensionOpenShiftQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/ExtensionOpenShiftQuarkusApplicationManagedResource.java
@@ -26,7 +26,8 @@ import io.quarkus.test.utils.Command;
 import io.quarkus.test.utils.FileUtils;
 import io.quarkus.test.utils.PropertiesUtils;
 
-public class ExtensionOpenShiftQuarkusApplicationManagedResource extends OpenShiftQuarkusApplicationManagedResource {
+public class ExtensionOpenShiftQuarkusApplicationManagedResource
+        extends OpenShiftQuarkusApplicationManagedResource<ProdQuarkusApplicationManagedResourceBuilder> {
 
     private static final String USING_EXTENSION_PROFILE = "-Pdeploy-to-openshift-using-extension";
     private static final String QUARKUS_PLUGIN_DEPLOY = "-Dquarkus.kubernetes.deploy=true";

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftQuarkusApplicationManagedResource.java
@@ -13,18 +13,19 @@ import io.quarkus.test.bootstrap.inject.OpenShiftClient;
 import io.quarkus.test.logging.LoggingHandler;
 import io.quarkus.test.logging.OpenShiftLoggingHandler;
 
-public abstract class OpenShiftQuarkusApplicationManagedResource extends QuarkusManagedResource {
+public abstract class OpenShiftQuarkusApplicationManagedResource<T extends QuarkusApplicationManagedResourceBuilder>
+        extends QuarkusManagedResource {
 
     private static final int EXTERNAL_PORT = 80;
 
-    protected final ProdQuarkusApplicationManagedResourceBuilder model;
+    protected final T model;
     protected final OpenShiftClient client;
 
     private LoggingHandler loggingHandler;
     private boolean init;
     private boolean running;
 
-    public OpenShiftQuarkusApplicationManagedResource(ProdQuarkusApplicationManagedResourceBuilder model) {
+    public OpenShiftQuarkusApplicationManagedResource(T model) {
         this.model = model;
         this.client = model.getContext().get(OpenShiftExtensionBootstrap.CLIENT);
     }

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftS2iGitRepositoryQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftS2iGitRepositoryQuarkusApplicationManagedResource.java
@@ -1,23 +1,27 @@
 package io.quarkus.test.services.quarkus;
 
 import static java.util.regex.Pattern.quote;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.nio.file.Path;
 
-import org.codehaus.plexus.util.StringUtils;
-
-import io.quarkus.test.services.quarkus.model.LaunchMode;
+import io.quarkus.builder.Version;
 import io.quarkus.test.utils.FileUtils;
 
-public class QuarkusSourceS2iBuildApplicationManagedResource extends OpenShiftQuarkusApplicationManagedResource {
+public class OpenShiftS2iGitRepositoryQuarkusApplicationManagedResource extends OpenShiftQuarkusApplicationManagedResource {
 
     private static final String QUARKUS_SOURCE_S2I_BASE_IMAGE_FILENAME = "openjdk-11.yml";
     private static final String QUARKUS_SOURCE_S2I_BUILD_TEMPLATE_FILENAME = "quarkus-s2i-source-build-template.yml";
+    private static final String DEPLOYMENT = "openshift.yml";
     private static final String QUARKUS_SOURCE_S2I_SETTINGS_MVN_FILENAME = "settings-mvn.yml";
+    private static final String QUARKUS_VERSION_PROPERTY = "${QUARKUS_VERSION}";
 
-    public QuarkusSourceS2iBuildApplicationManagedResource(ProdQuarkusApplicationManagedResourceBuilder model) {
+    private final GitRepositoryQuarkusApplicationManagedResourceBuilder model;
+
+    public OpenShiftS2iGitRepositoryQuarkusApplicationManagedResource(
+            GitRepositoryQuarkusApplicationManagedResourceBuilder model) {
         super(model);
+
+        this.model = model;
     }
 
     /**
@@ -50,23 +54,6 @@ public class QuarkusSourceS2iBuildApplicationManagedResource extends OpenShiftQu
         return false;
     }
 
-    @Override
-    public void validate() {
-        super.validate();
-
-        if (model.isSelectedAppClasses()) {
-            fail("Custom source classes as @QuarkusApplication(classes = ...) is not supported by Quarkus source S2I build.");
-        }
-
-        if (StringUtils.isEmpty(model.getGitRepositoryUri())) {
-            fail("Source S2I build requires a remote Git repository with a Quarkus application.");
-        }
-
-        if (model.getLaunchMode().equals(LaunchMode.NATIVE)) {
-            fail("Quarkus source S2I build is not supported with native launch mode.");
-        }
-    }
-
     private void waitForBaseImage() {
         Path targetQuarkusSourceS2iBaseImageFileName = model.getContext().getServiceFolder()
                 .resolve(QUARKUS_SOURCE_S2I_BASE_IMAGE_FILENAME);
@@ -83,8 +70,7 @@ public class QuarkusSourceS2iBuildApplicationManagedResource extends OpenShiftQu
     }
 
     private void applyTemplate() {
-        Path targetQuarkusSourceS2iBuildTemplateFileName = model.getContext().getServiceFolder()
-                .resolve(QUARKUS_SOURCE_S2I_BUILD_TEMPLATE_FILENAME);
+        Path targetQuarkusSourceS2iBuildTemplateFileName = model.getContext().getServiceFolder().resolve(DEPLOYMENT);
         FileUtils.copyFileTo(QUARKUS_SOURCE_S2I_BUILD_TEMPLATE_FILENAME,
                 targetQuarkusSourceS2iBuildTemplateFileName);
         client.applyServicePropertiesUsingTemplate(model.getContext().getOwner(),
@@ -94,11 +80,14 @@ public class QuarkusSourceS2iBuildApplicationManagedResource extends OpenShiftQu
     }
 
     private String replaceDeploymentContent(String content) {
+        String quarkusVersion = Version.getVersion();
+        String mavenArgs = model.getMavenArgs().replaceAll(quote(QUARKUS_VERSION_PROPERTY), quarkusVersion);
         return content.replaceAll(quote("${APP_NAME}"), model.getContext().getOwner().getName())
-                .replaceAll(quote("${GIT_URI}"), model.getGitRepositoryUri())
-                .replaceAll(quote("${GIT_REF}"), model.getGitRef())
+                .replaceAll(quote("${GIT_URI}"), model.getGitRepository())
+                .replaceAll(quote("${GIT_REF}"), model.getGitBranch())
                 .replaceAll(quote("${CONTEXT_DIR}"), model.getContextDir())
-                .replaceAll(quote("${QUARKUS_VERSION}"), model.getQuarkusBuildVersion());
+                .replaceAll(quote("${GIT_MAVEN_ARGS}"), mavenArgs)
+                .replaceAll(quote(QUARKUS_VERSION_PROPERTY), quarkusVersion);
     }
 
 }

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftS2iGitRepositoryQuarkusApplicationManagedResourceBinding.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftS2iGitRepositoryQuarkusApplicationManagedResourceBinding.java
@@ -1,0 +1,17 @@
+package io.quarkus.test.services.quarkus;
+
+import io.quarkus.test.bootstrap.ServiceContext;
+import io.quarkus.test.scenarios.OpenShiftScenario;
+
+public class OpenShiftS2iGitRepositoryQuarkusApplicationManagedResourceBinding
+        implements GitRepositoryQuarkusApplicationManagedResourceBinding {
+    @Override
+    public boolean appliesFor(ServiceContext context) {
+        return context.getTestContext().getRequiredTestClass().isAnnotationPresent(OpenShiftScenario.class);
+    }
+
+    @Override
+    public QuarkusManagedResource init(GitRepositoryQuarkusApplicationManagedResourceBuilder builder) {
+        return new OpenShiftS2iGitRepositoryQuarkusApplicationManagedResource(builder);
+    }
+}

--- a/quarkus-test-openshift/src/main/resources/META-INF/services/io.quarkus.test.services.quarkus.GitRepositoryQuarkusApplicationManagedResourceBinding
+++ b/quarkus-test-openshift/src/main/resources/META-INF/services/io.quarkus.test.services.quarkus.GitRepositoryQuarkusApplicationManagedResourceBinding
@@ -1,0 +1,1 @@
+io.quarkus.test.services.quarkus.OpenShiftS2iGitRepositoryQuarkusApplicationManagedResourceBinding

--- a/quarkus-test-openshift/src/main/resources/quarkus-s2i-source-build-template.yml
+++ b/quarkus-test-openshift/src/main/resources/quarkus-s2i-source-build-template.yml
@@ -35,7 +35,7 @@ items:
             - name: ARTIFACT_COPY_ARGS
               value: -p -r quarkus-app/quarkus-run.jar
             - name: MAVEN_ARGS
-              value: -s /configuration/settings.xml -Dquarkus.version=${QUARKUS_VERSION} -DskipTests=true
+              value: -s /configuration/settings.xml ${GIT_MAVEN_ARGS} -Dquarkus.verison=${QUARKUS_VERSION} -Dquarkus.platform.version=${QUARKUS_VERSION} -Dquarkus.plugin.version=${QUARKUS_VERSION} -Dquarkus-plugin.version=${QUARKUS_VERSION}
           from:
             kind: ImageStreamTag
             name: openjdk-11:latest


### PR DESCRIPTION
- Separate git configuration from QuarkusApplication onto GitRepositoryQuarkus
++ Adding Maven Arguments
++ Add more Quarkus version properties
++ Use Version.getVersion() to resolve the Quarkus version
- Remove unnecessary throws Exception in DevModeQuarkusApplication...
- Ensure BuildConfig is present before following logs

Fix https://github.com/quarkus-qe/quarkus-test-framework/issues/65
Fix https://github.com/quarkus-qe/quarkus-test-framework/issues/59