### PR TITLE
Deploy one QuarkusApplication if no services were defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,22 @@ In order to write Quarkus application in your tests, you first need to add the c
 </dependency>
 ```
 
-The framework aims to think on scenarios to verify. One scenario could include a few Quarkus instances and other container resources:
+The framework aims to think on scenarios to verify. The easiest scenario is to cope with the coverage of the current test module:
+
+```java
+@QuarkusScenario
+public class PingPongResourceIT {
+    @Test
+    public void shouldPingPongWorks() {
+        given().get("/ping").then().statusCode(HttpStatus.SC_OK).body(is("ping"));
+        given().get("/pong").then().statusCode(HttpStatus.SC_OK).body(is("pong"));
+    }
+}
+```
+
+This mimics the usage of the `@QuarkusTest` or `@QuarkusIntegrationTest` from the Quarkus framework. Plus, it has all the benefits of using this test framework like easy logging, tracing, etc. This behaviour can be disabled by setting `ts.global.create.service.by.default=false`.
+
+Another more complex scenario could include a few Quarkus instances:
 
 ```java
 @QuarkusScenario

--- a/examples/pingpong/src/test/java/io/quarkus/qe/KubernetesPingPongResourceIT.java
+++ b/examples/pingpong/src/test/java/io/quarkus/qe/KubernetesPingPongResourceIT.java
@@ -1,22 +1,7 @@
 package io.quarkus.qe;
 
-import static org.hamcrest.Matchers.is;
-
-import org.apache.http.HttpStatus;
-import org.junit.jupiter.api.Test;
-
-import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.KubernetesScenario;
-import io.quarkus.test.services.QuarkusApplication;
 
 @KubernetesScenario
-public class KubernetesPingPongResourceIT {
-    @QuarkusApplication
-    static final RestService pingpong = new RestService();
-
-    @Test
-    public void shouldPingPongWorks() {
-        pingpong.given().get("/ping").then().statusCode(HttpStatus.SC_OK).body(is("ping"));
-        pingpong.given().get("/pong").then().statusCode(HttpStatus.SC_OK).body(is("pong"));
-    }
+public class KubernetesPingPongResourceIT extends PingPongResourceIT {
 }

--- a/examples/pingpong/src/test/java/io/quarkus/qe/MultipleAppsPingPongResourceIT.java
+++ b/examples/pingpong/src/test/java/io/quarkus/qe/MultipleAppsPingPongResourceIT.java
@@ -1,0 +1,44 @@
+package io.quarkus.qe;
+
+import static org.hamcrest.Matchers.is;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnNative;
+import io.quarkus.test.services.QuarkusApplication;
+
+@DisabledOnNative(reason = "Due to high native build execution time for the three Quarkus services")
+@QuarkusScenario
+public class MultipleAppsPingPongResourceIT {
+
+    @QuarkusApplication(classes = PingResource.class)
+    static final RestService ping = new RestService();
+
+    @QuarkusApplication(classes = PongResource.class)
+    static final RestService pong = new RestService();
+
+    @QuarkusApplication
+    static final RestService pingpong = new RestService();
+
+    @Test
+    public void shouldPingWorks() {
+        ping.given().get("/ping").then().statusCode(HttpStatus.SC_OK).body(is("ping"));
+        ping.given().get("/pong").then().statusCode(HttpStatus.SC_NOT_FOUND);
+    }
+
+    @Test
+    public void shouldPongWorks() {
+        pong.given().get("/pong").then().statusCode(HttpStatus.SC_OK).body(is("pong"));
+        pong.given().get("/ping").then().statusCode(HttpStatus.SC_NOT_FOUND);
+    }
+
+    @Test
+    public void shouldPingPongWorks() {
+        pingpong.given().get("/ping").then().statusCode(HttpStatus.SC_OK).body(is("ping"));
+        pingpong.given().get("/pong").then().statusCode(HttpStatus.SC_OK).body(is("pong"));
+    }
+
+}

--- a/examples/pingpong/src/test/java/io/quarkus/qe/OpenShiftUsingContainerRegistryPingPongResourceIT.java
+++ b/examples/pingpong/src/test/java/io/quarkus/qe/OpenShiftUsingContainerRegistryPingPongResourceIT.java
@@ -1,26 +1,10 @@
 package io.quarkus.qe;
 
-import static org.hamcrest.Matchers.is;
-
-import org.apache.http.HttpStatus;
-import org.junit.jupiter.api.Test;
-
-import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.scenarios.annotations.EnabledIfOpenShiftScenarioPropertyIsTrue;
-import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingContainerRegistry)
 @EnabledIfOpenShiftScenarioPropertyIsTrue
-public class OpenShiftUsingContainerRegistryPingPongResourceIT {
-
-    @QuarkusApplication
-    static final RestService pingpong = new RestService();
-
-    @Test
-    public void shouldPingPongWorks() {
-        pingpong.given().get("/ping").then().statusCode(HttpStatus.SC_OK).body(is("ping"));
-        pingpong.given().get("/pong").then().statusCode(HttpStatus.SC_OK).body(is("pong"));
-    }
+public class OpenShiftUsingContainerRegistryPingPongResourceIT extends PingPongResourceIT {
 }

--- a/examples/pingpong/src/test/java/io/quarkus/qe/OpenShiftUsingExtensionAndDockerBuildAndServerlessPingPongResourceIT.java
+++ b/examples/pingpong/src/test/java/io/quarkus/qe/OpenShiftUsingExtensionAndDockerBuildAndServerlessPingPongResourceIT.java
@@ -1,24 +1,8 @@
 package io.quarkus.qe;
 
-import static org.hamcrest.Matchers.is;
-
-import org.apache.http.HttpStatus;
-import org.junit.jupiter.api.Test;
-
-import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtensionAndDockerBuildStrategy)
-public class OpenShiftUsingExtensionAndDockerBuildAndServerlessPingPongResourceIT {
-
-    @QuarkusApplication
-    static final RestService pingpong = new RestService();
-
-    @Test
-    public void shouldPingPongWorks() {
-        pingpong.given().get("/ping").then().statusCode(HttpStatus.SC_OK).body(is("ping"));
-        pingpong.given().get("/pong").then().statusCode(HttpStatus.SC_OK).body(is("pong"));
-    }
+public class OpenShiftUsingExtensionAndDockerBuildAndServerlessPingPongResourceIT extends PingPongResourceIT {
 }

--- a/examples/pingpong/src/test/java/io/quarkus/qe/OpenShiftUsingExtensionAndDockerBuildPingPongResourceIT.java
+++ b/examples/pingpong/src/test/java/io/quarkus/qe/OpenShiftUsingExtensionAndDockerBuildPingPongResourceIT.java
@@ -1,24 +1,8 @@
 package io.quarkus.qe;
 
-import static org.hamcrest.Matchers.is;
-
-import org.apache.http.HttpStatus;
-import org.junit.jupiter.api.Test;
-
-import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtensionAndDockerBuildStrategy)
-public class OpenShiftUsingExtensionAndDockerBuildPingPongResourceIT {
-
-    @QuarkusApplication
-    static final RestService pingpong = new RestService();
-
-    @Test
-    public void shouldPingPongWorks() {
-        pingpong.given().get("/ping").then().statusCode(HttpStatus.SC_OK).body(is("ping"));
-        pingpong.given().get("/pong").then().statusCode(HttpStatus.SC_OK).body(is("pong"));
-    }
+public class OpenShiftUsingExtensionAndDockerBuildPingPongResourceIT extends PingPongResourceIT {
 }

--- a/examples/pingpong/src/test/java/io/quarkus/qe/OpenShiftUsingExtensionAndServerlessPingPongResourceIT.java
+++ b/examples/pingpong/src/test/java/io/quarkus/qe/OpenShiftUsingExtensionAndServerlessPingPongResourceIT.java
@@ -1,24 +1,8 @@
 package io.quarkus.qe;
 
-import static org.hamcrest.Matchers.is;
-
-import org.apache.http.HttpStatus;
-import org.junit.jupiter.api.Test;
-
-import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
-public class OpenShiftUsingExtensionAndServerlessPingPongResourceIT {
-
-    @QuarkusApplication
-    static final RestService pingpong = new RestService();
-
-    @Test
-    public void shouldPingPongWorks() {
-        pingpong.given().get("/ping").then().statusCode(HttpStatus.SC_OK).body(is("ping"));
-        pingpong.given().get("/pong").then().statusCode(HttpStatus.SC_OK).body(is("pong"));
-    }
+public class OpenShiftUsingExtensionAndServerlessPingPongResourceIT extends PingPongResourceIT {
 }

--- a/examples/pingpong/src/test/java/io/quarkus/qe/OpenShiftUsingExtensionPingPongResourceIT.java
+++ b/examples/pingpong/src/test/java/io/quarkus/qe/OpenShiftUsingExtensionPingPongResourceIT.java
@@ -1,24 +1,8 @@
 package io.quarkus.qe;
 
-import static org.hamcrest.Matchers.is;
-
-import org.apache.http.HttpStatus;
-import org.junit.jupiter.api.Test;
-
-import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
-public class OpenShiftUsingExtensionPingPongResourceIT {
-
-    @QuarkusApplication
-    static final RestService pingpong = new RestService();
-
-    @Test
-    public void shouldPingPongWorks() {
-        pingpong.given().get("/ping").then().statusCode(HttpStatus.SC_OK).body(is("ping"));
-        pingpong.given().get("/pong").then().statusCode(HttpStatus.SC_OK).body(is("pong"));
-    }
+public class OpenShiftUsingExtensionPingPongResourceIT extends PingPongResourceIT {
 }

--- a/examples/pingpong/src/test/java/io/quarkus/qe/PingPongResourceIT.java
+++ b/examples/pingpong/src/test/java/io/quarkus/qe/PingPongResourceIT.java
@@ -1,44 +1,19 @@
 package io.quarkus.qe;
 
+import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.is;
 
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnNative;
-import io.quarkus.test.services.QuarkusApplication;
 
-@DisabledOnNative(reason = "Due to high native build execution time for the three Quarkus services")
 @QuarkusScenario
 public class PingPongResourceIT {
-
-    @QuarkusApplication(classes = PingResource.class)
-    static final RestService ping = new RestService();
-
-    @QuarkusApplication(classes = PongResource.class)
-    static final RestService pong = new RestService();
-
-    @QuarkusApplication
-    static final RestService pingpong = new RestService();
-
-    @Test
-    public void shouldPingWorks() {
-        ping.given().get("/ping").then().statusCode(HttpStatus.SC_OK).body(is("ping"));
-        ping.given().get("/pong").then().statusCode(HttpStatus.SC_NOT_FOUND);
-    }
-
-    @Test
-    public void shouldPongWorks() {
-        pong.given().get("/pong").then().statusCode(HttpStatus.SC_OK).body(is("pong"));
-        pong.given().get("/ping").then().statusCode(HttpStatus.SC_NOT_FOUND);
-    }
-
     @Test
     public void shouldPingPongWorks() {
-        pingpong.given().get("/ping").then().statusCode(HttpStatus.SC_OK).body(is("ping"));
-        pingpong.given().get("/pong").then().statusCode(HttpStatus.SC_OK).body(is("pong"));
+        given().get("/ping").then().statusCode(HttpStatus.SC_OK).body(is("ping"));
+        given().get("/pong").then().statusCode(HttpStatus.SC_OK).body(is("pong"));
     }
 
 }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/RestService.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/RestService.java
@@ -4,11 +4,23 @@ import io.restassured.RestAssured;
 import io.restassured.specification.RequestSpecification;
 
 public class RestService extends BaseService<RestService> {
+
+    private static final String BASE_PATH = "/";
+
     public RequestSpecification given() {
-        return RestAssured.given().baseUri(getHost()).basePath("/").port(getPort());
+        return RestAssured.given().baseUri(getHost()).basePath(BASE_PATH).port(getPort());
     }
 
     public RequestSpecification https() {
         return RestAssured.given().baseUri(getHost(Protocol.HTTPS)).basePath("/").port(getPort(Protocol.HTTPS));
+    }
+
+    @Override
+    public void start() {
+        super.start();
+
+        RestAssured.baseURI = getHost();
+        RestAssured.basePath = BASE_PATH;
+        RestAssured.port = getPort();
     }
 }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/configuration/PropertyLookup.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/configuration/PropertyLookup.java
@@ -6,6 +6,8 @@ import io.quarkus.test.bootstrap.ServiceContext;
 
 public class PropertyLookup {
 
+    private static final Configuration GLOBAL = Configuration.load();
+
     private final String propertyKey;
     private final String defaultValue;
 
@@ -46,7 +48,14 @@ public class PropertyLookup {
     }
 
     public String get() {
-        String value = System.getProperty(propertyKey);
+        // Try first using the Configuration API
+        String value = GLOBAL.get(propertyKey);
+        if (StringUtils.isNotBlank(value)) {
+            return value;
+        }
+
+        // Then via System Properties.
+        value = System.getProperty(propertyKey);
         if (StringUtils.isNotBlank(value)) {
             return value;
         }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusApplicationManagedResourceBuilder.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusApplicationManagedResourceBuilder.java
@@ -83,9 +83,9 @@ public abstract class QuarkusApplicationManagedResourceBuilder implements Manage
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
-    protected void initAppClasses(Class<?>[] classes) {
+    public void initAppClasses(Class<?>[] classes) {
         appClasses = classes;
-        if (appClasses.length == 0) {
+        if (appClasses == null || appClasses.length == 0) {
             appClasses = ClassPathUtils.findAllClassesFromSource();
             selectedAppClasses = false;
         }

--- a/quarkus-test-core/src/main/resources/global.properties
+++ b/quarkus-test-core/src/main/resources/global.properties
@@ -10,3 +10,5 @@ ts.global.operator.install.timeout=10m
 ts.global.imagestream.install.timeout=5m
 # Default timeout factor for all checks
 ts.global.factor.timeout=1
+# Create default Quarkus application if no other services are defined within the scenario
+ts.global.create.service.by.default=true

--- a/quarkus-test-openshift/src/test/resources/test.properties
+++ b/quarkus-test-openshift/src/test/resources/test.properties
@@ -1,0 +1,1 @@
+ts.global.create.service.by.default=false


### PR DESCRIPTION
The easiest scenario is to cope with the coverage of the current test module:

```java
@QuarkusScenario
public class PingPongResourceIT {
    @Test
    public void shouldPingPongWorks() {
        given().get("/ping").then().statusCode(HttpStatus.SC_OK).body(is("ping"));
        given().get("/pong").then().statusCode(HttpStatus.SC_OK).body(is("pong"));
    }
}
```

This mimics the usage of the `@QuarkusTest` or `@QuarkusIntegrationTest` from the Quarkus framework. Plus, it has all the benefits of using this test framework like easy logging, tracing, etc.