### PR TITLE
Support Custom Service Start Up order

### DIFF
--- a/examples/consul/src/test/java/io/quarkus/qe/BaseGreetingResourceIT.java
+++ b/examples/consul/src/test/java/io/quarkus/qe/BaseGreetingResourceIT.java
@@ -1,0 +1,49 @@
+package io.quarkus.qe;
+
+import static io.quarkus.test.utils.AwaitilityUtils.untilAsserted;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.ConsulService;
+import io.quarkus.test.bootstrap.LookupService;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.bootstrap.Service;
+import io.quarkus.test.services.QuarkusApplication;
+
+public abstract class BaseGreetingResourceIT {
+
+    private static final String CUSTOM_PROPERTY = "my.property";
+
+    @LookupService
+    static ConsulService consul;
+
+    @QuarkusApplication
+    static RestService app = new RestService().withProperty("quarkus.consul-config.agent.host-port",
+            () -> consul.getConsulEndpoint());
+
+    @Test
+    public void shouldUpdateCustomProperty() {
+        thenGreetingsApiReturns("Hello Default");
+
+        whenUpdateCustomPropertyTo("Test");
+        thenGreetingsApiReturns("Hello Test");
+    }
+
+    protected static final void onLoadConfigureConsul(Service service) {
+        consul.loadPropertiesFromFile("application.properties");
+    }
+
+    private void whenUpdateCustomPropertyTo(String newValue) {
+        consul.loadPropertiesFromString(CUSTOM_PROPERTY + "=" + newValue);
+
+        app.stop();
+        app.start();
+    }
+
+    private void thenGreetingsApiReturns(String expected) {
+        untilAsserted(() -> app.given().get("/api").then().statusCode(HttpStatus.SC_OK).extract().asString(),
+                actual -> assertEquals(expected, actual, "Unexpected response from service"));
+    }
+}

--- a/examples/consul/src/test/java/io/quarkus/qe/GreetingResourceIT.java
+++ b/examples/consul/src/test/java/io/quarkus/qe/GreetingResourceIT.java
@@ -1,51 +1,12 @@
 package io.quarkus.qe;
 
-import static io.quarkus.test.utils.AwaitilityUtils.untilAsserted;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import org.apache.http.HttpStatus;
-import org.junit.jupiter.api.Test;
-
 import io.quarkus.test.bootstrap.ConsulService;
-import io.quarkus.test.bootstrap.RestService;
-import io.quarkus.test.bootstrap.Service;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.Container;
-import io.quarkus.test.services.QuarkusApplication;
 
 @QuarkusScenario
-public class GreetingResourceIT {
-
-    private static final String CUSTOM_PROPERTY = "my.property";
+public class GreetingResourceIT extends BaseGreetingResourceIT {
 
     @Container(image = "quay.io/bitnami/consul:1.9.3", expectedLog = "Synced node info", port = 8500)
-    static final ConsulService consul = new ConsulService().onPostStart(GreetingResourceIT::onLoadConfigureConsul);
-
-    @QuarkusApplication
-    static final RestService app = new RestService().withProperty("quarkus.consul-config.agent.host-port",
-            consul::getConsulEndpoint);
-
-    @Test
-    public void shouldUpdateCustomProperty() {
-        thenGreetingsApiReturns("Hello Default");
-
-        whenUpdateCustomPropertyTo("Test");
-        thenGreetingsApiReturns("Hello Test");
-    }
-
-    private void whenUpdateCustomPropertyTo(String newValue) {
-        consul.loadPropertiesFromString(CUSTOM_PROPERTY + "=" + newValue);
-
-        app.stop();
-        app.start();
-    }
-
-    private void thenGreetingsApiReturns(String expected) {
-        untilAsserted(() -> app.given().get("/api").then().statusCode(HttpStatus.SC_OK).extract().asString(),
-                actual -> assertEquals(expected, actual, "Unexpected response from service"));
-    }
-
-    private static final void onLoadConfigureConsul(Service service) {
-        consul.loadPropertiesFromFile("application.properties");
-    }
+    static ConsulService consul = new ConsulService().onPostStart(BaseGreetingResourceIT::onLoadConfigureConsul);
 }

--- a/examples/greetings/src/test/java/io/quarkus/qe/GreetingResourceUsingRuntimePropertiesIT.java
+++ b/examples/greetings/src/test/java/io/quarkus/qe/GreetingResourceUsingRuntimePropertiesIT.java
@@ -16,9 +16,9 @@ public class GreetingResourceUsingRuntimePropertiesIT {
     static final String MANUEL_NAME = "manuel";
 
     @QuarkusApplication
-    static final RestService joseApp = new RestService().withProperty(GreetingResource.PROPERTY, JOSE_NAME);
+    static RestService joseApp = new RestService().withProperty(GreetingResource.PROPERTY, JOSE_NAME);
     @QuarkusApplication
-    static final RestService manuelApp = new RestService().withProperty(GreetingResource.PROPERTY, MANUEL_NAME);
+    static RestService manuelApp = new RestService().withProperty(GreetingResource.PROPERTY, MANUEL_NAME);
 
     @Test
     public void shouldSayJose() {

--- a/examples/keycloak/src/test/java/io/quarkus/qe/BaseSecurityResourceIT.java
+++ b/examples/keycloak/src/test/java/io/quarkus/qe/BaseSecurityResourceIT.java
@@ -1,0 +1,49 @@
+package io.quarkus.qe;
+
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.keycloak.authorization.client.AuthzClient;
+
+import io.quarkus.test.bootstrap.KeycloakService;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.services.Container;
+
+public abstract class BaseSecurityResourceIT {
+
+    static final String REALM_DEFAULT = "test-realm";
+    static final String CLIENT_ID_DEFAULT = "test-application-client";
+    static final String CLIENT_SECRET_DEFAULT = "test-application-client-secret";
+    static final String NORMAL_USER = "test-normal-user";
+
+    @Container(image = "quay.io/keycloak/keycloak:11.0.3", expectedLog = "Admin console listening", port = 8080)
+    static final KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT);
+
+    private AuthzClient authzClient;
+
+    protected abstract RestService getApp();
+
+    @BeforeEach
+    public void setup() {
+        initAuthzClient();
+    }
+
+    @Test
+    public void checkUserResourceByNormalUser() {
+        getApp().given()
+                .auth().oauth2(getTokenByTestNormalUser())
+                .get("/user")
+                .then()
+                .statusCode(200)
+                .body(equalTo("Hello, user test-normal-user"));
+    }
+
+    private void initAuthzClient() {
+        authzClient = keycloak.createAuthzClient(CLIENT_ID_DEFAULT, CLIENT_SECRET_DEFAULT);
+    }
+
+    private String getTokenByTestNormalUser() {
+        return authzClient.obtainAccessToken(NORMAL_USER, NORMAL_USER).getToken();
+    }
+}

--- a/examples/keycloak/src/test/java/io/quarkus/qe/DevModeSecurityResourceIT.java
+++ b/examples/keycloak/src/test/java/io/quarkus/qe/DevModeSecurityResourceIT.java
@@ -2,11 +2,11 @@ package io.quarkus.qe;
 
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.test.services.DevModeQuarkusApplication;
 
 @QuarkusScenario
-public class SecurityResourceIT extends BaseSecurityResourceIT {
-    @QuarkusApplication
+public class DevModeSecurityResourceIT extends BaseSecurityResourceIT {
+    @DevModeQuarkusApplication
     static final RestService app = new RestService()
             .withProperty("quarkus.oidc.auth-server-url", () -> keycloak.getRealmUrl())
             .withProperty("quarkus.oidc.client-id", CLIENT_ID_DEFAULT)

--- a/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/LookupService.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/LookupService.java
@@ -1,0 +1,14 @@
+package io.quarkus.test.bootstrap;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Target(FIELD)
+@Retention(RUNTIME)
+@Documented
+public @interface LookupService {
+}

--- a/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/Service.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/Service.java
@@ -31,6 +31,8 @@ public interface Service extends ExtensionContext.Store.CloseableResource {
 
     void stop();
 
+    boolean isRunning();
+
     LogsVerifier logs();
 
     Service withProperty(String key, String value);

--- a/quarkus-test-core/src/main/java/io/quarkus/test/logging/Log.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/logging/Log.java
@@ -97,7 +97,12 @@ public final class Log {
                 UNUSED_SERVICE_COLORS.addAll(ALL_SERVICE_COLORS);
             }
 
-            color = UNUSED_SERVICE_COLORS.remove(RND.nextInt(UNUSED_SERVICE_COLORS.size() - 1));
+            int colorIdx = 0;
+            if (UNUSED_SERVICE_COLORS.size() > 1) {
+                colorIdx = RND.nextInt(UNUSED_SERVICE_COLORS.size() - 1);
+            }
+
+            color = UNUSED_SERVICE_COLORS.remove(colorIdx);
             SERVICE_COLOR_MAPPING.put(service.getName(), color);
         }
 

--- a/quarkus-test-core/src/main/java/io/quarkus/test/utils/ReflectionUtils.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/utils/ReflectionUtils.java
@@ -1,0 +1,53 @@
+package io.quarkus.test.utils;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public final class ReflectionUtils {
+
+    private ReflectionUtils() {
+
+    }
+
+    public static <T> T getStaticFieldValue(Field field) {
+        try {
+            field.setAccessible(true);
+            return (T) field.get(null);
+        } catch (IllegalAccessException e) {
+            fail("Can't resolve field value. Fields need to be in static. Problematic field: " + field.getName());
+        }
+
+        return null;
+    }
+
+    public static void setStaticFieldValue(Field field, Object value) {
+        field.setAccessible(true);
+        if (Modifier.isStatic(field.getModifiers())) {
+            try {
+                field.set(null, value);
+            } catch (IllegalAccessException e) {
+                fail("Couldn't set value. Fields can only be injected into static instances. Problematic field: " + field
+                        .getName());
+            }
+        } else {
+            fail("Fields can only be injected into static instances. Problematic field: " + field.getName());
+        }
+    }
+
+    public static List<Field> findAllFields(Class<?> clazz) {
+        if (clazz == Object.class) {
+            return Collections.emptyList();
+        }
+
+        List<Field> fields = new ArrayList<>();
+        fields.addAll(findAllFields(clazz.getSuperclass()));
+        fields.addAll(Arrays.asList(clazz.getDeclaredFields()));
+        return fields;
+    }
+}

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/ExtensionOpenShiftQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/ExtensionOpenShiftQuarkusApplicationManagedResource.java
@@ -17,10 +17,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.function.Predicate;
 import java.util.regex.Pattern;
-
-import org.apache.commons.lang3.StringUtils;
 
 import io.quarkus.test.bootstrap.inject.OpenShiftClient;
 import io.quarkus.test.utils.Command;
@@ -39,8 +36,6 @@ public class ExtensionOpenShiftQuarkusApplicationManagedResource
     private static final String QUARKUS_CONTAINER_IMAGE_GROUP = "quarkus.container-image.group";
     private static final String QUARKUS_OPENSHIFT_ENV_VARS = "quarkus.openshift.env.vars.";
     private static final String QUARKUS_OPENSHIFT_LABELS = "quarkus.openshift.labels.";
-
-    private static final String QUARKUS_PROPERTY_PREFIX = "quarkus";
 
     private static final String APPLICATION_PROPERTIES_PATH = "src/main/resources/application.properties";
 
@@ -106,7 +101,6 @@ public class ExtensionOpenShiftQuarkusApplicationManagedResource
         args.add(withKubernetesClientTrustCerts());
         args.add(withContainerImageGroup(namespace));
         args.add(withLabelsForWatching());
-        withQuarkusProperties(args);
         withEnvVars(args, model.getContext().getOwner().getProperties());
         withAdditionalArguments(args);
 
@@ -126,16 +120,6 @@ public class ExtensionOpenShiftQuarkusApplicationManagedResource
         return withProperty(QUARKUS_CONTAINER_NAME, model.getContext().getName());
     }
 
-    private void withQuarkusProperties(List<String> args) {
-        System.getProperties().entrySet().stream()
-                .filter(isQuarkusProperty().and(propertyValueIsNotEmpty()))
-                .forEach(property -> {
-                    String key = (String) property.getKey();
-                    String value = (String) property.getValue();
-                    args.add(withProperty(key, value));
-                });
-    }
-
     private String withContainerImageGroup(String namespace) {
         return withProperty(QUARKUS_CONTAINER_IMAGE_GROUP, namespace);
     }
@@ -153,14 +137,6 @@ public class ExtensionOpenShiftQuarkusApplicationManagedResource
             String envVarKey = envVar.getKey().replaceAll(Pattern.quote("."), "-");
             args.add(withProperty(QUARKUS_OPENSHIFT_ENV_VARS + envVarKey, envVar.getValue()));
         }
-    }
-
-    private Predicate<Entry<Object, Object>> propertyValueIsNotEmpty() {
-        return property -> StringUtils.isNotEmpty((String) property.getValue());
-    }
-
-    private Predicate<Entry<Object, Object>> isQuarkusProperty() {
-        return property -> StringUtils.startsWith((String) property.getKey(), QUARKUS_PROPERTY_PREFIX);
     }
 
     private void cloneProjectToServiceAppFolder() {


### PR DESCRIPTION
By default, the services are initialized in Natural Order of presence. For example, having:

```java
class MyParent {
    @QuarkusApplication // ... or @Container
    static final RestService firstAppInParent = new RestService();
    
    @QuarkusApplication // ... or @Container
    static final RestService secondAppInParent = new RestService();

}

@QuarkusScenario
class MyScenarioIT extends MyParent {
    @QuarkusApplication // ... or @Container
    static final RestService firstAppInChild = new RestService();

    @QuarkusApplication // ... or @Container
    static final RestService secondAppInChild = new RestService();
}
```

Then, the framework will initialize the services at this order: `firstAppInParent`,  `secondAppInParent`, `firstAppInChild` and `secondAppInChild`.

We can change this order by using the `@LookupService` annotation:

```java
class MyParent {
    @LookupService
    static final RestService appInChild;

    @QuarkusApplication // ... or @Container
    static final RestService appInParent = new RestService().withProperty("x", () -> appInChild.getHost());
}

@QuarkusScenario
class MyScenarioIT extends MyParent {
    @QuarkusApplication // ... or @Container
    static final RestService appInChild = new RestService().dependsOn(appInParent);
}
```

Now, the framework will initialize the `appInChild` service first and then the `appInParent` service.