### PR TITLE
Do not deploy examples when releasing

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -108,7 +108,7 @@ jobs:
         if: steps.coverage.outputs.needs-commit-badge == 'true'
         uses: ad-m/github-push-action@master
         with:
-          github_token: ${{ secrets.COVERAGE_BADGE_CI_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           force: true
       - name: Zip Artifacts
         if: failure()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
           mvn -B release:prepare -Prelease,framework,examples -DautoVersionSubmodules -DreleaseVersion=${{steps.metadata.outputs.current-version}} -DdevelopmentVersion=${{steps.metadata.outputs.next-version}} -s maven-settings.xml
           git checkout ${{github.base_ref}}
           git rebase release
-          mvn -B release:perform -DskipITs -Darguments=-DskipITs -Prelease,framework,examples -s maven-settings.xml
+          mvn -B release:perform -DskipITs -Darguments=-DskipITs -Prelease,framework -s maven-settings.xml
       - name: Push changes to ${{github.base_ref}}
         uses: ad-m/github-push-action@v0.6.0
         with:


### PR DESCRIPTION
Fix https://github.com/quarkus-qe/quarkus-test-framework/issues/46

This PR also includes another change to use the same secret to push coverage badgets.