### PR TITLE
Fix binding of ts.s2i.maven.remote.repository property and document it

### DIFF
--- a/README.md
+++ b/README.md
@@ -696,6 +696,33 @@ public class OpenShiftS2iQuickstartIT {
     //
 ```
 
+It's important to note that, by default, OpenShift will build the application's source code using the Red Hat maven repository `https://maven.repository.redhat.com/ga/`. However, some applications might require some dependencies from other remote Maven repositories. In order to allow us to add another remote Maven repository, you can use `-Dts.global.s2i.maven.remote.repository=http://host:port/repo/name`. If you only want to configure different maven repositories by service, you can do it by replacing `global` to the service name, for example: `-Dts.pingPong.s2i.maven.remote.repository=...`.
+
+The test framework will automatically load a custom maven settings with the provided maven remote repository. But if you're using a custom template, all you need to do is to configure the `settings-mvn` config map and the Maven args as follows:
+
+```
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  name: myApp
+spec:
+  source:
+    git:
+      uri: https://github.com/repo/name.git
+    type: Git
+    configMaps:
+    - configMap:
+        name: settings-mvn
+      destinationDir: "/configuration"
+  strategy:
+    type: Source
+    sourceStrategy:
+      env:
+      - name: MAVEN_ARGS
+        value: -s /configuration/settings.xml
+      // ...
+```
+
 - **Container Registry**
 
 This strategy will build the image locally and push it to an intermediary container registry (provided by a system property). Then, the image will be pulled from the container registry in OpenShift.

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftS2iGitRepositoryQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftS2iGitRepositoryQuarkusApplicationManagedResource.java
@@ -1,10 +1,12 @@
 package io.quarkus.test.services.quarkus;
 
 import static java.util.regex.Pattern.quote;
+import static org.apache.commons.lang3.StringUtils.EMPTY;
 
 import java.nio.file.Path;
 
 import io.quarkus.builder.Version;
+import io.quarkus.test.configuration.PropertyLookup;
 import io.quarkus.test.utils.FileUtils;
 
 public class OpenShiftS2iGitRepositoryQuarkusApplicationManagedResource extends OpenShiftQuarkusApplicationManagedResource {
@@ -14,6 +16,8 @@ public class OpenShiftS2iGitRepositoryQuarkusApplicationManagedResource extends 
     private static final String DEPLOYMENT = "openshift.yml";
     private static final String QUARKUS_SOURCE_S2I_SETTINGS_MVN_FILENAME = "settings-mvn.yml";
     private static final String QUARKUS_VERSION_PROPERTY = "${QUARKUS_VERSION}";
+    private static final String INTERNAL_MAVEN_REPOSITORY_PROPERTY = "${internal.s2i.maven.remote.repository}";
+    private static final PropertyLookup MAVEN_REMOTE_REPOSITORY = new PropertyLookup("s2i.maven.remote.repository", EMPTY);
 
     private final GitRepositoryQuarkusApplicationManagedResourceBuilder model;
 
@@ -65,7 +69,9 @@ public class OpenShiftS2iGitRepositoryQuarkusApplicationManagedResource extends 
     private void createMavenSettings() {
         Path targetQuarkusSourceS2iSettingsMvnFilename = model.getContext().getServiceFolder()
                 .resolve(QUARKUS_SOURCE_S2I_SETTINGS_MVN_FILENAME);
-        FileUtils.copyFileTo(QUARKUS_SOURCE_S2I_SETTINGS_MVN_FILENAME, targetQuarkusSourceS2iSettingsMvnFilename);
+        String content = FileUtils.loadFile("/" + QUARKUS_SOURCE_S2I_SETTINGS_MVN_FILENAME)
+                .replaceAll(quote(INTERNAL_MAVEN_REPOSITORY_PROPERTY), MAVEN_REMOTE_REPOSITORY.get(model.getContext()));
+        FileUtils.copyContentTo(content, targetQuarkusSourceS2iSettingsMvnFilename);
         client.apply(model.getContext().getOwner(), targetQuarkusSourceS2iSettingsMvnFilename);
     }
 

--- a/quarkus-test-openshift/src/main/resources/settings-mvn.yml
+++ b/quarkus-test-openshift/src/main/resources/settings-mvn.yml
@@ -30,8 +30,8 @@ data:
                 <id>customRemoteRepository</id>
                 <repositories>
                     <repository>
-                        <id>ts.s2i.maven.remote.repository</id>
-                        <url>${ts.s2i.maven.remote.repository}</url>
+                        <id>internal.s2i.maven.remote.repository</id>
+                        <url>${internal.s2i.maven.remote.repository}</url>
                         <snapshots>
                             <enabled>false</enabled>
                         </snapshots>
@@ -39,8 +39,8 @@ data:
                 </repositories>
                 <pluginRepositories>
                     <pluginRepository>
-                        <id>ts.s2i.maven.remote.repository</id>
-                        <url>${ts.s2i.maven.remote.repository}</url>
+                        <id>internal.s2i.maven.remote.repository</id>
+                        <url>${internal.s2i.maven.remote.repository}</url>
                         <snapshots>
                             <enabled>false</enabled>
                         </snapshots>


### PR DESCRIPTION
The property `ts.s2i.maven.remote.repository` has been renamed to `ts.global.s2i.maven.remote.repository`, so we can configure it by service scope (using `ts.myService.s2i.maven.remote.repository`).

Also, it has been fixed as before this property was not been replaced.
Fix https://github.com/quarkus-qe/quarkus-test-framework/issues/66