### PR TITLE
Allow to overwrite default template for OpenShift/Kubernetes deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -666,6 +666,8 @@ public class OpenShiftPingPongResourceIT {
 }
 ```
 
+The default template used by this strategy can be overwritten using the property `ts.global.openshift.template`. 
+
 - **OpenShift Extension**
 
 This strategy will delegate the deployment into the Quarkus OpenShift extension, so it will trigger a Maven command to run it. 
@@ -771,6 +773,8 @@ spec:
       // ...
 ```
 
+The default template used by this strategy can be overwritten using the property `ts.global.openshift.template`.
+
 - **Container Registry**
 
 This strategy will build the image locally and push it to an intermediary container registry (provided by a system property). Then, the image will be pulled from the container registry in OpenShift.
@@ -797,6 +801,8 @@ public class OpenShiftUsingExtensionPingPongResourceIT {
     // ...
 }
 ```
+
+The default template used by this strategy can be overwritten using the property `ts.global.openshift.template`.
 
 #### Interact with the OpenShift Client directly
 
@@ -886,6 +892,8 @@ public class KubernetesPingPongResourceIT {
     }
 }
 ```
+
+The default template used by this strategy can be overwritten using the property `ts.global.kubernetes.template`.
 
 #### Enable/Disable Namespace Deletion on Failures
 

--- a/examples/database-mysql/pom.xml
+++ b/examples/database-mysql/pom.xml
@@ -7,7 +7,7 @@
         <version>0.0.2-SNAPSHOT</version>
         <relativePath>../../</relativePath>
     </parent>
-    <artifactId>database-mysql</artifactId>
+    <artifactId>examples-database-mysql</artifactId>
     <packaging>jar</packaging>
     <name>Quarkus - Test Framework - Examples - Database - MySQL</name>
     <dependencies>

--- a/examples/database-mysql/src/test/java/io/quarkus/qe/database/mysql/MySqlDatabaseIT.java
+++ b/examples/database-mysql/src/test/java/io/quarkus/qe/database/mysql/MySqlDatabaseIT.java
@@ -14,7 +14,7 @@ public class MySqlDatabaseIT extends AbstractSqlDatabaseIT {
     static final String MYSQL_DATABASE = "mydb";
     static final int MYSQL_PORT = 3306;
 
-    @Container(image = "mysql/mysql-server:8.0.22", port = MYSQL_PORT, expectedLog = "port: 3306  MySQL Community Server")
+    @Container(image = "mysql/mysql-server:8.0", port = MYSQL_PORT, expectedLog = "port: 3306  MySQL Community Server")
     static DefaultService database = new DefaultService()
             .withProperty("MYSQL_USER", MYSQL_USER)
             .withProperty("MYSQL_PASSWORD", MYSQL_PASSWORD)

--- a/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftS2iQuickstartUsingDefaultsIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftS2iQuickstartUsingDefaultsIT.java
@@ -5,10 +5,12 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
 import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 
+@DisabledOnQuarkusVersion(version = "9\\..*", reason = "999-SNAPSHOT is not available in the Maven repositories in OpenShift")
 @OpenShiftScenario
-public class OpenShiftS2iQuickstartIT {
+public class OpenShiftS2iQuickstartUsingDefaultsIT {
 
     @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", contextDir = "getting-started")
     static final RestService app = new RestService();

--- a/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftS2iQuickstartUsingUberJarIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftS2iQuickstartUsingUberJarIT.java
@@ -1,0 +1,29 @@
+package io.quarkus.qe;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.OpenShiftScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
+import io.quarkus.test.services.GitRepositoryQuarkusApplication;
+
+@DisabledOnQuarkusVersion(version = "9\\..*", reason = "999-SNAPSHOT is not available in the Maven repositories in OpenShift")
+@OpenShiftScenario
+public class OpenShiftS2iQuickstartUsingUberJarIT {
+
+    /**
+     * Package type is set in the custom template.
+     */
+    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", contextDir = "getting-started", branch = "1.11")
+    static final RestService appuberjar = new RestService();
+
+    @Test
+    public void test() {
+        appuberjar.given()
+                .get("/hello")
+                .then()
+                .statusCode(HttpStatus.SC_OK);
+    }
+
+}

--- a/examples/external-applications/src/test/resources/test.properties
+++ b/examples/external-applications/src/test/resources/test.properties
@@ -1,0 +1,1 @@
+ts.appuberjar.openshift.template=/uber-jar-quarkus-s2i-source-build-template.yml

--- a/examples/external-applications/src/test/resources/uber-jar-quarkus-s2i-source-build-template.yml
+++ b/examples/external-applications/src/test/resources/uber-jar-quarkus-s2i-source-build-template.yml
@@ -32,8 +32,10 @@ items:
         type: Source
         sourceStrategy:
           env:
+            - name: ARTIFACT_COPY_ARGS
+              value: -p -r *-runner.jar
             - name: MAVEN_ARGS
-              value: -s /configuration/settings.xml ${GIT_MAVEN_ARGS} -Dquarkus.version=${QUARKUS_VERSION} -Dquarkus.platform.version=${QUARKUS_VERSION} -Dquarkus.plugin.version=${QUARKUS_VERSION} -Dquarkus-plugin.version=${QUARKUS_VERSION}
+              value: -s /configuration/settings.xml ${GIT_MAVEN_ARGS} -Dquarkus.platform.version=${QUARKUS_VERSION} -Dquarkus-plugin.version=${QUARKUS_VERSION} -Dquarkus.package.type=uber-jar
           from:
             kind: ImageStreamTag
             name: openjdk-11:latest

--- a/pom.xml
+++ b/pom.xml
@@ -460,9 +460,6 @@
         <!-- This profile generates jacoco coverage files. To generate html report use "-Pcoverage-generate-report" -->
         <profile>
             <id>coverage</id>
-            <properties>
-                <jacoco.agent.argLine>${jacoco.activated.agent.argLine}</jacoco.agent.argLine>
-            </properties>
             <build>
                 <plugins>
                     <plugin>
@@ -478,7 +475,7 @@
                                     <includes>
                                         <include>io.quarkus.test*</include>
                                     </includes>
-                                    <propertyName>jacoco.activated.agent.argLine</propertyName>
+                                    <propertyName>jacoco.agent.argLine</propertyName>
                                 </configuration>
                             </execution>
                         </executions>

--- a/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/Service.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/Service.java
@@ -19,10 +19,6 @@ public interface Service extends ExtensionContext.Store.CloseableResource {
 
     List<String> getLogs();
 
-    default ServiceContext register(String serviceName) {
-        return register(serviceName, null); // No test context attached
-    }
-
     ServiceContext register(String serviceName, ExtensionContext testContext);
 
     void init(ManagedResourceBuilder resource);

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/OpenShiftExtensionBootstrap.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/OpenShiftExtensionBootstrap.java
@@ -67,7 +67,7 @@ public class OpenShiftExtensionBootstrap implements ExtensionBootstrap {
         OpenShiftScenario openShiftScenario = context.getRequiredTestClass().getAnnotation(OpenShiftScenario.class);
         for (Operator operator : openShiftScenario.operators()) {
             Service defaultService = new DefaultService();
-            defaultService.register(operator.name());
+            defaultService.register(operator.name(), context);
             client.installOperator(defaultService, operator.channel(), operator.source(), operator.sourceNamespace());
         }
     }

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/ContainerRegistryOpenShiftQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/ContainerRegistryOpenShiftQuarkusApplicationManagedResource.java
@@ -2,18 +2,12 @@ package io.quarkus.test.services.quarkus;
 
 import static java.util.regex.Pattern.quote;
 
-import org.apache.commons.lang3.StringUtils;
-
 import io.quarkus.test.utils.DockerUtils;
 
 public class ContainerRegistryOpenShiftQuarkusApplicationManagedResource
-        extends OpenShiftQuarkusApplicationManagedResource<ProdQuarkusApplicationManagedResourceBuilder> {
+        extends TemplateOpenShiftQuarkusApplicationManagedResource<ProdQuarkusApplicationManagedResourceBuilder> {
 
     private static final String QUARKUS_OPENSHIFT_TEMPLATE = "/quarkus-registry-openshift-template.yml";
-    private static final String DEPLOYMENT = "openshift.yml";
-
-    private static final String QUARKUS_HTTP_PORT_PROPERTY = "quarkus.http.port";
-    private static final int INTERNAL_PORT_DEFAULT = 8080;
 
     private String image;
 
@@ -22,42 +16,25 @@ public class ContainerRegistryOpenShiftQuarkusApplicationManagedResource
     }
 
     @Override
+    protected String getDefaultTemplate() {
+        return QUARKUS_OPENSHIFT_TEMPLATE;
+    }
+
+    @Override
     protected void doInit() {
         image = createImageAndPush();
-        applyTemplate();
+        super.doInit();
         client.rollout(model.getContext().getOwner());
         client.expose(model.getContext().getOwner(), getInternalPort());
     }
 
-    @Override
-    protected void doUpdate() {
-        applyTemplate();
+    protected String replaceDeploymentContent(String content) {
+        return content.replaceAll(quote("${IMAGE}"), image)
+                .replaceAll(quote("${ARTIFACT}"), model.getArtifact().getFileName().toString());
     }
 
     private String createImageAndPush() {
         return DockerUtils.createImageAndPush(model.getContext(), model.getLaunchMode(), model.getArtifact());
-    }
-
-    private void applyTemplate() {
-        client.applyServicePropertiesUsingTemplate(model.getContext().getOwner(), QUARKUS_OPENSHIFT_TEMPLATE,
-                this::replaceDeploymentContent,
-                model.getContext().getServiceFolder().resolve(DEPLOYMENT));
-    }
-
-    private String replaceDeploymentContent(String content) {
-        return content.replaceAll(quote("${IMAGE}"), image)
-                .replaceAll(quote("${SERVICE_NAME}"), model.getContext().getName())
-                .replaceAll(quote("${ARTIFACT}"), model.getArtifact().getFileName().toString())
-                .replaceAll(quote("${INTERNAL_PORT}"), "" + getInternalPort());
-    }
-
-    private int getInternalPort() {
-        String internalPort = model.getContext().getOwner().getProperties().get(QUARKUS_HTTP_PORT_PROPERTY);
-        if (StringUtils.isNotBlank(internalPort)) {
-            return Integer.parseInt(internalPort);
-        }
-
-        return INTERNAL_PORT_DEFAULT;
     }
 
 }

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/TemplateOpenShiftQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/TemplateOpenShiftQuarkusApplicationManagedResource.java
@@ -1,0 +1,76 @@
+package io.quarkus.test.services.quarkus;
+
+import static java.util.regex.Pattern.quote;
+
+import org.apache.commons.lang3.StringUtils;
+
+import io.quarkus.test.logging.Log;
+
+public abstract class TemplateOpenShiftQuarkusApplicationManagedResource<T extends QuarkusApplicationManagedResourceBuilder>
+        extends OpenShiftQuarkusApplicationManagedResource<T> {
+
+    private static final String DEPLOYMENT_SERVICE_PROPERTY = "openshift.service";
+    private static final String DEPLOYMENT_TEMPLATE_PROPERTY = "openshift.template";
+    private static final String DEPLOYMENT = "openshift.yml";
+
+    private static final String QUARKUS_HTTP_PORT_PROPERTY = "quarkus.http.port";
+    private static final int INTERNAL_PORT_DEFAULT = 8080;
+
+    public TemplateOpenShiftQuarkusApplicationManagedResource(T model) {
+        super(model);
+    }
+
+    protected abstract String getDefaultTemplate();
+
+    protected String replaceDeploymentContent(String content) {
+        return content;
+    }
+
+    @Override
+    protected void doInit() {
+        applyTemplate();
+        awaitForImageStreams();
+    }
+
+    @Override
+    protected void doUpdate() {
+        applyTemplate();
+    }
+
+    protected int getInternalPort() {
+        String internalPort = model.getContext().getOwner().getProperties().get(QUARKUS_HTTP_PORT_PROPERTY);
+        if (StringUtils.isNotBlank(internalPort)) {
+            return Integer.parseInt(internalPort);
+        }
+
+        return INTERNAL_PORT_DEFAULT;
+    }
+
+    private void applyTemplate() {
+        String deploymentFile = model.getContext().getOwner().getConfiguration().getOrDefault(DEPLOYMENT_TEMPLATE_PROPERTY,
+                getDefaultTemplate());
+
+        client.applyServicePropertiesUsingTemplate(model.getContext().getOwner(), deploymentFile,
+                this::internalReplaceDeploymentContent,
+                model.getContext().getServiceFolder().resolve(DEPLOYMENT));
+    }
+
+    private String internalReplaceDeploymentContent(String content) {
+        String customServiceName = model.getContext().getOwner().getConfiguration().get(DEPLOYMENT_SERVICE_PROPERTY);
+        if (StringUtils.isNotEmpty(customServiceName)) {
+            // replace it by the service owner name
+            content = content.replaceAll(quote(customServiceName), model.getContext().getOwner().getName());
+        }
+
+        content = content.replaceAll(quote("${SERVICE_NAME}"), model.getContext().getName())
+                .replaceAll(quote("${INTERNAL_PORT}"), "" + getInternalPort());
+
+        return replaceDeploymentContent(content);
+    }
+
+    private void awaitForImageStreams() {
+        Log.info(model.getContext().getOwner(), "Waiting for image streams ... ");
+        client.awaitFor(model.getContext().getOwner(), model.getContext().getServiceFolder().resolve(DEPLOYMENT));
+    }
+
+}

--- a/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/OpenShiftStrimziKafkaContainerManagedResource.java
+++ b/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/OpenShiftStrimziKafkaContainerManagedResource.java
@@ -103,7 +103,7 @@ public class OpenShiftStrimziKafkaContainerManagedResource implements ManagedRes
 
     private void createRegistryService() {
         registry = new DefaultService();
-        registry.register("registry");
+        registry.register("registry", model.getContext().getTestContext());
     }
 
     private void applyDeployment() {


### PR DESCRIPTION
The default template used by strategies can now be overwritten using the property `ts.<GLOBAL or service name>.<kubernetes or openshift>.template`.

Fix https://github.com/quarkus-qe/quarkus-test-framework/issues/68
Fix https://github.com/quarkus-qe/quarkus-test-framework/issues/85