### PR TITLE
Upgrade Strimzi Kafka Version to 0.24.0-kafka-2.7.0

### DIFF
--- a/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/model/KafkaVendor.java
+++ b/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/model/KafkaVendor.java
@@ -2,7 +2,7 @@ package io.quarkus.test.services.containers.model;
 
 public enum KafkaVendor {
     CONFLUENT("confluentinc/cp-kafka", "6.1.1", 9093, KafkaRegistry.CONFLUENT),
-    STRIMZI("quay.io/strimzi/kafka", "0.22.1-kafka-2.7.0", 9092, KafkaRegistry.APICURIO);
+    STRIMZI("quay.io/strimzi/kafka", "0.24.0-kafka-2.7.0", 9092, KafkaRegistry.APICURIO);
 
     private final String image;
     private final String defaultVersion;


### PR DESCRIPTION
I prefer use the latest released version instead of the latest available image as in https://github.com/quarkus-qe/quarkus-openshift-test-suite/commit/5d9eadd0dbf72b5cbf531bb08f26d6bbbb7c9c74#diff-6a696a4af18185fc9e6fb77baf89383331c12b8f0edeba9697379923b258c864R50.