### PR TITLE
Enable run your test without ephemeral namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -1235,6 +1235,23 @@ mvn -T 1C clean verify
 
 This Maven command would use 1 thread by CPU.
 
+- Disable ephemeral namespaces
+
+Most of the time ephemeral namespace is a good idea, but some other times is not possible because maybe you are 
+not allowed to create namespaces on the fly with your own user. In those cases, you can disable ephemeral namespaces 
+and run all your tests in your current namespace.
+
+* OpenShift: 
+`-Dts.openshift.ephemeral.namespaces.enabled=false`
+
+* Kubernetes:
+`-Dts.kubernetes.ephemeral.namespaces.enabled=false`
+
+Full example command: `mvn clean verify -Popenshift -Dts.openshift.ephemeral.namespaces.enabled=false`
+
+Default value: `ts.openshift.ephemeral.namespaces.enabled=true`
+**Note:** this feature doesn't support operators
+
 - Partial SSL support
 
 This is only supported when running tests on bare metal:

--- a/quarkus-test-core/src/main/java/io/quarkus/test/utils/Command.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/utils/Command.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.BiConsumer;
@@ -49,6 +50,11 @@ public class Command {
             return program.substring(program.lastIndexOf(File.separator) + 1);
         }
         return program;
+    }
+
+    public void runAndWait(Duration waitAtLeast) throws IOException, InterruptedException {
+        runAndWait();
+        Thread.sleep(waitAtLeast.toMillis());
     }
 
     public void runAndWait() throws IOException, InterruptedException {

--- a/quarkus-test-kubernetes/src/main/java/io/quarkus/test/bootstrap/KubernetesExtensionBootstrap.java
+++ b/quarkus-test-kubernetes/src/main/java/io/quarkus/test/bootstrap/KubernetesExtensionBootstrap.java
@@ -11,8 +11,8 @@ import io.quarkus.test.scenarios.KubernetesScenario;
 import io.quarkus.test.utils.FileUtils;
 
 public class KubernetesExtensionBootstrap implements ExtensionBootstrap {
-
     public static final String CLIENT = "kubectl-client";
+
     private static final PropertyLookup DELETE_NAMESPACE_AFTER = new PropertyLookup("ts.kubernetes.delete.namespace.after.all",
             Boolean.TRUE.toString());
 
@@ -25,7 +25,7 @@ public class KubernetesExtensionBootstrap implements ExtensionBootstrap {
 
     @Override
     public void beforeAll(ScenarioContext context) {
-        client = KubectlClient.create();
+        client = KubectlClient.create(context.getId());
     }
 
     @Override

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/OpenShiftExtensionBootstrap.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/OpenShiftExtensionBootstrap.java
@@ -30,7 +30,7 @@ public class OpenShiftExtensionBootstrap implements ExtensionBootstrap {
 
     @Override
     public void beforeAll(ScenarioContext context) {
-        client = OpenShiftClient.create();
+        client = OpenShiftClient.create(context.getId());
         installOperators(context);
     }
 

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/ExtensionOpenShiftQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/ExtensionOpenShiftQuarkusApplicationManagedResource.java
@@ -103,6 +103,7 @@ public class ExtensionOpenShiftQuarkusApplicationManagedResource
         args.add(withKubernetesClientTrustCerts());
         args.add(withContainerImageGroup(namespace));
         args.add(withLabelsForWatching());
+        args.add(withLabelsForScenarioId());
         withEnvVars(args, model.getContext().getOwner().getProperties());
         withAdditionalArguments(args);
 
@@ -116,6 +117,10 @@ public class ExtensionOpenShiftQuarkusApplicationManagedResource
     private String withLabelsForWatching() {
         return withProperty(QUARKUS_OPENSHIFT_LABELS + OpenShiftClient.LABEL_TO_WATCH_FOR_LOGS,
                 model.getContext().getOwner().getName());
+    }
+
+    private String withLabelsForScenarioId() {
+        return withProperty(QUARKUS_OPENSHIFT_LABELS + OpenShiftClient.LABEL_SCENARIO_ID, client.getScenarioId());
     }
 
     private String withContainerName() {

--- a/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/OpenShiftStrimziKafkaContainerManagedResource.java
+++ b/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/OpenShiftStrimziKafkaContainerManagedResource.java
@@ -121,7 +121,8 @@ public class OpenShiftStrimziKafkaContainerManagedResource implements ManagedRes
     private void applyRegistryDeployment() {
         int registryPort = model.getVendor().getRegistry().getPort();
         client.applyServicePropertiesUsingTemplate(registry, REGISTRY_DEPLOYMENT_TEMPLATE_PROPERTY_DEFAULT,
-                content -> content.replaceAll(quote("${KAFKA_BOOTSTRAP_URL}"), getKafkaBootstrapUrl())
+                content -> content
+                        .replaceAll(quote("${KAFKA_BOOTSTRAP_URL}"), getKafkaBootstrapUrl())
                         .replaceAll(quote("${KAFKA_REGISTRY_IMAGE}"), getKafkaRegistryImage())
                         .replaceAll(quote("${KAFKA_REGISTRY_PORT}"), "" + registryPort),
                 model.getContext().getServiceFolder().resolve(REGISTRY_DEPLOYMENT));
@@ -148,7 +149,8 @@ public class OpenShiftStrimziKafkaContainerManagedResource implements ManagedRes
             content = content.replaceAll(quote(customServiceName), model.getContext().getOwner().getName());
         }
 
-        return content.replaceAll(quote("${IMAGE}"), getKafkaImage())
+        return content
+                .replaceAll(quote("${IMAGE}"), getKafkaImage())
                 .replaceAll(quote("${VERSION}"), getKafkaVersion())
                 .replaceAll(quote("${KAFKA_PORT}"), "" + model.getVendor().getPort())
                 .replaceAll(quote("${SERVICE_NAME}"), model.getContext().getName());


### PR DESCRIPTION
- Disable ephemeral namespaces

Most of the time ephemeral namespace is a good idea, but some other times is not possible because maybe you are not allowed to create namespaces on the fly with your own user. In those cases, you can disable ephemeral namespaces 
and run all your tests in your current namespace.

`-Dts.openshift.ephemeral.namespaces.enabled=false`

Full example command: `mvn clean verify -Popenshift -Dts.openshift.ephemeral.namespaces.enabled=false`

Pending items:
- Knative