### PR TITLE
Improve build properties detect to start with

### DIFF
--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusApplicationManagedResourceBuilder.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusApplicationManagedResourceBuilder.java
@@ -128,7 +128,10 @@ public abstract class QuarkusApplicationManagedResourceBuilder implements Manage
     }
 
     private boolean isBuildProperty(String name) {
-        return BUILD_PROPERTIES.stream().anyMatch(build -> name.matches(build) || name.startsWith(build));
+        return BUILD_PROPERTIES.stream().anyMatch(
+                build -> name.matches(build) // It's a regular expression
+                        || (build.endsWith(".") && name.startsWith(build)) // contains with
+                        || name.equals(build)); // or it's equal to
     }
 
     private void copyResourcesInFolderToAppFolder(Path folder) {


### PR DESCRIPTION
At the moment, the framework was checking the properties with start with, but this is quite problematic.
With this change, it will check only with starts with if the build property ends with `.`.