### PR TITLE
Allow to use default values that contains `:` characters

### DIFF
--- a/examples/consul/src/test/java/io/quarkus/qe/GreetingResourceIT.java
+++ b/examples/consul/src/test/java/io/quarkus/qe/GreetingResourceIT.java
@@ -7,6 +7,10 @@ import io.quarkus.test.services.Container;
 @QuarkusScenario
 public class GreetingResourceIT extends BaseGreetingResourceIT {
 
-    @Container(image = "quay.io/bitnami/consul:1.9.3", expectedLog = "Synced node info", port = 8500)
+    /**
+     * The framework will try to resolve the property `property.do.not.exist`
+     * and as it does not exist, it will use the default image.
+     */
+    @Container(image = "${property.do.not.exist:quay.io/bitnami/consul:1.9.3}", expectedLog = "Synced node info", port = 8500)
     static ConsulService consul = new ConsulService().onPostStart(BaseGreetingResourceIT::onLoadConfigureConsul);
 }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/utils/LogsVerifier.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/utils/LogsVerifier.java
@@ -21,4 +21,10 @@ public class LogsVerifier {
                     "Log does not contain " + expectedLog + ". Full logs: " + actualLogs);
         });
     }
+
+    public void assertDoesNotContain(String unexpectedLog) {
+        List<String> actualLogs = service.getLogs();
+        Assertions.assertTrue(actualLogs.stream().noneMatch(line -> line.contains(unexpectedLog)),
+                "Log does contain " + unexpectedLog + ". Full logs: " + actualLogs);
+    }
 }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/utils/PropertiesUtils.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/utils/PropertiesUtils.java
@@ -34,10 +34,10 @@ public final class PropertiesUtils {
         if (StringUtils.startsWith(value, PROPERTY_START_TAG)) {
             String propertyKey = StringUtils.substringBetween(value, PROPERTY_START_TAG, PROPERTY_END_TAG);
             String defaultValue = StringUtils.EMPTY;
-            if (StringUtils.contains(propertyKey, PROPERTY_WITH_OPTIONAL)) {
-                String[] propertyKeySplit = propertyKey.split(PROPERTY_WITH_OPTIONAL);
-                propertyKey = propertyKeySplit[0];
-                defaultValue = propertyKeySplit[1];
+            int optionalIndex = propertyKey.indexOf(PROPERTY_WITH_OPTIONAL);
+            if (optionalIndex > 0) {
+                defaultValue = propertyKey.substring(optionalIndex + 1);
+                propertyKey = propertyKey.substring(0, optionalIndex);
             }
 
             return System.getProperty(propertyKey, defaultValue);


### PR DESCRIPTION
Using:
```
@Container(image = "${property.do.not.exist:quay.io/bitnami/consul:1.9.3}"
```

Will ignore the version (it will use only `quay.io/bitnami/consul`).
These changes fix the above.