### PR TITLE
Remove Jaeger persistence due to an open issue

### DIFF
--- a/misc/jaeger-for-tracing.yaml
+++ b/misc/jaeger-for-tracing.yaml
@@ -1,64 +1,65 @@
 apiVersion: v1
 kind: List
 items:
-  - apiVersion: apps/v1
-    kind: StatefulSet
-    metadata:
-      name: elasticsearch
-    spec:
-      serviceName: elasticsearch
-      replicas: 1
-      selector:
-        matchLabels:
-          app: elasticsearch
-      template:
-        metadata:
-          labels:
-            app: elasticsearch
-        spec:
-          containers:
-            - name: elasticsearch
-              image: quay.io/pires/docker-elasticsearch-kubernetes:5.6.2
-              imagePullPolicy: Always
-              command:
-                - bin/elasticsearch
-              args:
-                - "-Ehttp.host=0.0.0.0"
-                - "-Etransport.host=127.0.0.1"
-              env:
-                - name: NODE_NAME
-                  value: master
-              volumeMounts:
-                - name: data
-                  mountPath: /data
-              readinessProbe:
-                exec:
-                  command:
-                    - wget
-                    - -O
-                    - /dev/null
-                    - localhost:9200
-                initialDelaySeconds: 5
-                periodSeconds: 5
-                timeoutSeconds: 4
-          volumes:
-            - name: data
-              emptyDir: { }
-  - apiVersion: v1
-    kind: Service
-    metadata:
-      name: elasticsearch
-      labels:
-        app: jaeger
-    spec:
-      clusterIP: None
-      selector:
-        app: elasticsearch
-      ports:
-        - port: 9200
-          name: elasticsearch
-        - port: 9300
-          name: transport
+# BUG: https://github.com/jaegertracing/jaeger/issues/2976
+#  - apiVersion: apps/v1
+#    kind: StatefulSet
+#    metadata:
+#      name: elasticsearch
+#    spec:
+#      serviceName: elasticsearch
+#      replicas: 1
+#      selector:
+#        matchLabels:
+#          app: elasticsearch
+#      template:
+#        metadata:
+#          labels:
+#            app: elasticsearch
+#        spec:
+#          containers:
+#            - name: elasticsearch
+#              image: quay.io/pires/docker-elasticsearch-kubernetes:5.6.2
+#              imagePullPolicy: Always
+#              command:
+#                - bin/elasticsearch
+#              args:
+#                - "-Ehttp.host=0.0.0.0"
+#                - "-Etransport.host=127.0.0.1"
+#              env:
+#                - name: NODE_NAME
+#                  value: master
+#              volumeMounts:
+#                - name: data
+#                  mountPath: /data
+#              readinessProbe:
+#                exec:
+#                  command:
+#                    - wget
+#                    - -O
+#                    - /dev/null
+#                    - localhost:9200
+#                initialDelaySeconds: 5
+#                periodSeconds: 5
+#                timeoutSeconds: 4
+#          volumes:
+#            - name: data
+#              emptyDir: { }
+#  - apiVersion: v1
+#    kind: Service
+#    metadata:
+#      name: elasticsearch
+#      labels:
+#        app: jaeger
+#    spec:
+#      clusterIP: None
+#      selector:
+#        app: elasticsearch
+#      ports:
+#        - port: 9200
+#          name: elasticsearch
+#        - port: 9300
+#          name: transport
   - apiVersion: apps.openshift.io/v1
     kind: DeploymentConfig
     metadata:
@@ -76,11 +77,11 @@ items:
           containers:
             - image: 'quay.io/jaegertracing/all-in-one:1.21.0'
               name: 'jaeger'
-              env:
-                - name: SPAN_STORAGE_TYPE
-                  value: "elasticsearch"
-                - name: ES_SERVER_URLS
-                  value: "http://elasticsearch:9200"
+#              env:
+#                - name: SPAN_STORAGE_TYPE
+#                  value: "elasticsearch"
+#                - name: ES_SERVER_URLS
+#                  value: "http://elasticsearch:9200"
               ports:
                 - containerPort: 5775
                   protocol: UDP


### PR DESCRIPTION
Jaeger used by Jenkins is throwing an exception due to an open issue:

Exception:
```
Error 400 (Bad Request): all shards failed
```
