### PR TITLE
Adapt Jaeger extension to work with 1.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <surefire-plugin.version>2.22.2</surefire-plugin.version>
         <testcontainers.version>1.16.0</testcontainers.version>
         <jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
-        <jaeger-client.version>1.6.0</jaeger-client.version>
+        <jaeger.version>1.6.0</jaeger.version>
         <prometheus.simpleclient_pushgateway.version>0.11.0</prometheus.simpleclient_pushgateway.version>
         <maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>
         <formatter-maven-plugin.version>2.16.0</formatter-maven-plugin.version>
@@ -148,7 +148,7 @@
             <dependency>
                 <groupId>io.jaegertracing</groupId>
                 <artifactId>jaeger-client</artifactId>
-                <version>${jaeger-client.version}</version>
+                <version>${jaeger.version}</version>
             </dependency>
             <dependency>
                 <groupId>net.sourceforge.htmlunit</groupId>

--- a/quarkus-test-core/src/main/java/io/quarkus/test/tracing/QuarkusScenarioTracer.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/tracing/QuarkusScenarioTracer.java
@@ -8,6 +8,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.thrift.transport.TTransportException;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 import io.jaegertracing.internal.JaegerTracer;
@@ -27,7 +28,7 @@ public class QuarkusScenarioTracer {
     private final QuarkusScenarioSpan quarkusScenarioSpan;
     private final QuarkusScenarioTags quarkusScenarioTags;
 
-    public QuarkusScenarioTracer(String jaegerHttpEndpoint) {
+    public QuarkusScenarioTracer(String jaegerHttpEndpoint) throws TTransportException {
         String serviceName = new PropertyLookup("ts.service-name", DEFAULT_SERVICE_NAME).get();
 
         tracer = new JaegerTracer.Builder(serviceName).withReporter(new RemoteReporter.Builder()

--- a/quarkus-test-core/src/main/java/io/quarkus/test/tracing/TracingExtensionBootstrap.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/tracing/TracingExtensionBootstrap.java
@@ -1,10 +1,12 @@
 package io.quarkus.test.tracing;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.thrift.transport.TTransportException;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 import io.quarkus.test.bootstrap.ExtensionBootstrap;
 import io.quarkus.test.bootstrap.Service;
+import io.quarkus.test.logging.Log;
 
 public class TracingExtensionBootstrap implements ExtensionBootstrap {
 
@@ -15,7 +17,11 @@ public class TracingExtensionBootstrap implements ExtensionBootstrap {
     public TracingExtensionBootstrap() {
         String jaegerHttpEndpoint = System.getProperty(JAEGER_HTTP_ENDPOINT_PROPERTY);
         if (StringUtils.isNotEmpty(jaegerHttpEndpoint)) {
-            quarkusScenarioTracer = new QuarkusScenarioTracer(jaegerHttpEndpoint);
+            try {
+                quarkusScenarioTracer = new QuarkusScenarioTracer(jaegerHttpEndpoint);
+            } catch (TTransportException e) {
+                Log.error("Error setting up tracing capabilities. Turning off the tracing. Caused by: " + e.getMessage());
+            }
         }
     }
 


### PR DESCRIPTION
The Quarkus BOM was ovewritting the Jaeger thrift dependency and hence making a compilation error when using 999-SNAPSHOT.