### PR TITLE
Refactor Contexts: Create ScenarioContext that wraps ExtensionContext

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -451,6 +451,7 @@
         <profile>
             <id>coverage</id>
             <properties>
+                <!--suppress UnresolvedMavenProperty to ignore warnings in idea-->
                 <jacoco.agent.argLine>${jacoco.generated.agent.argLine}</jacoco.agent.argLine>
             </properties>
             <build>

--- a/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/QuarkusCliClient.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/QuarkusCliClient.java
@@ -13,7 +13,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.commons.lang3.StringUtils;
-import org.junit.jupiter.api.extension.ExtensionContext;
 
 import io.quarkus.test.configuration.PropertyLookup;
 import io.quarkus.test.logging.FileLoggingHandler;
@@ -30,9 +29,9 @@ public class QuarkusCliClient {
     private static final PropertyLookup COMMAND = new PropertyLookup("ts.quarkus.cli.cmd", "quarkus");
     private static final Path TARGET = Paths.get("target");
 
-    private final ExtensionContext context;
+    private final ScenarioContext context;
 
-    public QuarkusCliClient(ExtensionContext context) {
+    public QuarkusCliClient(ScenarioContext context) {
         this.context = context;
     }
 

--- a/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/QuarkusCliExtensionBootstrap.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/QuarkusCliExtensionBootstrap.java
@@ -2,23 +2,21 @@ package io.quarkus.test.bootstrap;
 
 import java.util.Optional;
 
-import org.junit.jupiter.api.extension.ExtensionContext;
-
 import io.quarkus.test.scenarios.QuarkusScenario;
 
 public class QuarkusCliExtensionBootstrap implements ExtensionBootstrap {
 
-    private ExtensionContext context;
+    private ScenarioContext context;
     private QuarkusCliClient client;
 
     @Override
-    public boolean appliesFor(ExtensionContext context) {
+    public boolean appliesFor(ScenarioContext context) {
         this.context = context;
-        return context.getRequiredTestClass().isAnnotationPresent(QuarkusScenario.class);
+        return context.isAnnotationPresent(QuarkusScenario.class);
     }
 
     @Override
-    public void beforeAll(ExtensionContext context) {
+    public void beforeAll(ScenarioContext context) {
         this.client = new QuarkusCliClient(context);
     }
 

--- a/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/BaseService.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/BaseService.java
@@ -12,10 +12,9 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.ServiceLoader;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
-
-import org.junit.jupiter.api.extension.ExtensionContext;
 
 import io.quarkus.test.configuration.Configuration;
 import io.quarkus.test.logging.Log;
@@ -31,6 +30,8 @@ public class BaseService<T extends Service> implements Service {
     private static final String SERVICE_STARTUP_CHECK_POLL_INTERVAL = "startup.check-poll-interval";
     private static final Duration SERVICE_STARTUP_CHECK_POLL_INTERVAL_DEFAULT = Duration.ofSeconds(2);
 
+    private final ServiceLoader<ServiceListener> listeners = ServiceLoader.load(ServiceListener.class);
+
     private final List<Action> onPreStartActions = new LinkedList<>();
     private final List<Action> onPostStartActions = new LinkedList<>();
     private final Map<String, String> properties = new HashMap<>();
@@ -40,6 +41,11 @@ public class BaseService<T extends Service> implements Service {
     private String serviceName;
     private Configuration configuration;
     private ServiceContext context;
+
+    @Override
+    public String getScenarioId() {
+        return context.getScenarioId();
+    }
 
     @Override
     public String getName() {
@@ -151,10 +157,20 @@ public class BaseService<T extends Service> implements Service {
         Log.debug(this, "Starting service (%s)", getDisplayName());
 
         onPreStartActions.forEach(a -> a.handle(this));
-        managedResource.start();
+        doStart();
         waitUntilServiceIsStarted();
         onPostStartActions.forEach(a -> a.handle(this));
         Log.info(this, "Service started (%s)", getDisplayName());
+    }
+
+    private void doStart() {
+        try {
+            managedResource.start();
+            listeners.forEach(ext -> ext.onServiceStarted(context));
+        } catch (Exception ex) {
+            listeners.forEach(ext -> ext.onServiceError(context, ex));
+            throw ex;
+        }
     }
 
     /**
@@ -167,18 +183,19 @@ public class BaseService<T extends Service> implements Service {
         }
 
         Log.debug(this, "Stopping service (%s)", getDisplayName());
+        listeners.forEach(ext -> ext.onServiceStopped(context));
         managedResource.stop();
 
         Log.info(this, "Service stopped (%s)", getDisplayName());
     }
 
     @Override
-    public ServiceContext register(String serviceName, ExtensionContext testContext) {
+    public ServiceContext register(String serviceName, ScenarioContext context) {
         this.serviceName = serviceName;
         this.configuration = Configuration.load(serviceName);
-        this.context = new ServiceContext(this, testContext);
+        this.context = new ServiceContext(this, context);
         onPreStart(s -> futureProperties.forEach(Runnable::run));
-        testContext.getStore(ExtensionContext.Namespace.create(QuarkusScenarioBootstrap.class)).put(serviceName, this);
+        context.getTestStore().put(serviceName, this);
         return this.context;
     }
 

--- a/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/ExtensionBootstrap.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/ExtensionBootstrap.java
@@ -2,21 +2,19 @@ package io.quarkus.test.bootstrap;
 
 import java.util.Optional;
 
-import org.junit.jupiter.api.extension.ExtensionContext;
-
 public interface ExtensionBootstrap {
 
-    boolean appliesFor(ExtensionContext context);
+    boolean appliesFor(ScenarioContext context);
 
-    default void beforeAll(ExtensionContext context) {
-
-    }
-
-    default void afterAll(ExtensionContext context) {
+    default void beforeAll(ScenarioContext context) {
 
     }
 
-    default void onError(ExtensionContext context, Throwable throwable) {
+    default void afterAll(ScenarioContext context) {
+
+    }
+
+    default void onError(ScenarioContext context, Throwable throwable) {
 
     }
 
@@ -24,35 +22,23 @@ public interface ExtensionBootstrap {
 
     }
 
-    default void onServiceInitiate(ExtensionContext context, Service service) {
+    default void onServiceLaunch(ScenarioContext context, Service service) {
 
     }
 
-    default void onServiceError(ExtensionContext context, Service service, Throwable throwable) {
+    default void onSuccess(ScenarioContext context) {
 
     }
 
-    default void onServiceStarted(ExtensionContext context, Service service) {
+    default void onDisabled(ScenarioContext context, Optional<String> reason) {
 
     }
 
-    default void onServiceStopped(ExtensionContext context, Service service) {
+    default void beforeEach(ScenarioContext context) {
 
     }
 
-    default void onSuccess(ExtensionContext context) {
-
-    }
-
-    default void onDisabled(ExtensionContext context, Optional<String> reason) {
-
-    }
-
-    default void beforeEach(ExtensionContext context) {
-
-    }
-
-    default void afterEach(ExtensionContext context) {
+    default void afterEach(ScenarioContext context) {
 
     }
 

--- a/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/ScenarioContext.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/ScenarioContext.java
@@ -1,0 +1,67 @@
+package io.quarkus.test.bootstrap;
+
+import java.lang.annotation.Annotation;
+import java.util.Optional;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import io.quarkus.test.logging.Log;
+
+public final class ScenarioContext {
+
+    private static final int SCENARIO_ID_MAX_SIZE = 60;
+
+    private final ExtensionContext testContext;
+    private final String id;
+    private final ExtensionContext.Namespace testNamespace;
+    private ExtensionContext methodTestContext;
+
+    protected ScenarioContext(ExtensionContext testContext) {
+        this.testContext = testContext;
+        this.id = generateScenarioId(testContext);
+        this.testNamespace = ExtensionContext.Namespace.create(ScenarioContext.class);
+
+        Log.info("Scenario ID: '%s'", this.id);
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getRunningTestClassName() {
+        return getTestContext().getRequiredTestClass().getSimpleName();
+    }
+
+    public Optional<String> getRunningTestMethodName() {
+        if (methodTestContext == null) {
+            return Optional.empty();
+        }
+
+        return Optional.of(methodTestContext.getRequiredTestMethod().getName());
+    }
+
+    public ExtensionContext.Store getTestStore() {
+        return getTestContext().getStore(this.testNamespace);
+    }
+
+    public ExtensionContext getTestContext() {
+        return Optional.ofNullable(methodTestContext).orElse(testContext);
+    }
+
+    public boolean isAnnotationPresent(Class<? extends Annotation> annotationClass) {
+        return getTestContext().getRequiredTestClass().isAnnotationPresent(annotationClass);
+    }
+
+    public <T extends Annotation> T getAnnotation(Class<T> annotationClass) {
+        return getTestContext().getRequiredTestClass().getAnnotation(annotationClass);
+    }
+
+    public void setMethodTestContext(ExtensionContext methodTestContext) {
+        this.methodTestContext = methodTestContext;
+    }
+
+    private static String generateScenarioId(ExtensionContext context) {
+        String fullId = context.getRequiredTestClass().getSimpleName() + "-" + System.currentTimeMillis();
+        return fullId.substring(0, Math.min(SCENARIO_ID_MAX_SIZE, fullId.length()));
+    }
+}

--- a/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/Service.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/Service.java
@@ -12,6 +12,8 @@ import io.quarkus.test.utils.LogsVerifier;
 
 public interface Service extends ExtensionContext.Store.CloseableResource {
 
+    String getScenarioId();
+
     String getName();
 
     String getDisplayName();
@@ -22,7 +24,7 @@ public interface Service extends ExtensionContext.Store.CloseableResource {
 
     List<String> getLogs();
 
-    ServiceContext register(String serviceName, ExtensionContext testContext);
+    ServiceContext register(String serviceName, ScenarioContext context);
 
     void init(ManagedResourceBuilder resource);
 

--- a/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/ServiceContext.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/ServiceContext.java
@@ -3,37 +3,40 @@ package io.quarkus.test.bootstrap;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 public final class ServiceContext {
 
     private final Service owner;
-    private final Optional<ExtensionContext> testContext;
+    private final ScenarioContext scenarioContext;
     private final Path serviceFolder;
     private final Map<String, Object> store = new HashMap<>();
 
-    protected ServiceContext(Service owner, ExtensionContext testContext) {
+    protected ServiceContext(Service owner, ScenarioContext scenarioContext) {
         this.owner = owner;
-        this.testContext = Optional.ofNullable(testContext);
-        this.serviceFolder = Path.of("target", testContext.getRequiredTestClass().getSimpleName(), getName());
+        this.scenarioContext = scenarioContext;
+        this.serviceFolder = Path.of("target", scenarioContext.getRunningTestClassName(), getName());
     }
 
     public Service getOwner() {
         return owner;
     }
 
+    public String getScenarioId() {
+        return scenarioContext.getId();
+    }
+
     public String getName() {
         return owner.getName();
     }
 
-    public ExtensionContext getTestContext() {
-        if (testContext.isEmpty()) {
-            throw new RuntimeException("Service has not been initialized with test context");
-        }
+    public ScenarioContext getScenarioContext() {
+        return scenarioContext;
+    }
 
-        return testContext.get();
+    public ExtensionContext getTestContext() {
+        return scenarioContext.getTestContext();
     }
 
     public Path getServiceFolder() {
@@ -48,5 +51,4 @@ public final class ServiceContext {
     public <T> T get(String key) {
         return (T) store.get(key);
     }
-
 }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/ServiceListener.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/ServiceListener.java
@@ -1,0 +1,16 @@
+package io.quarkus.test.bootstrap;
+
+public interface ServiceListener {
+
+    default void onServiceError(ServiceContext service, Throwable throwable) {
+
+    }
+
+    default void onServiceStarted(ServiceContext service) {
+
+    }
+
+    default void onServiceStopped(ServiceContext service) {
+
+    }
+}

--- a/quarkus-test-core/src/main/java/io/quarkus/test/metrics/MetricsExtensionBootstrap.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/metrics/MetricsExtensionBootstrap.java
@@ -3,10 +3,9 @@ package io.quarkus.test.metrics;
 import java.util.Optional;
 
 import org.gradle.internal.impldep.com.google.common.base.Strings;
-import org.junit.jupiter.api.extension.ExtensionContext;
 
 import io.quarkus.test.bootstrap.ExtensionBootstrap;
-import io.quarkus.test.bootstrap.Service;
+import io.quarkus.test.bootstrap.ScenarioContext;
 import io.quarkus.test.scenarios.QuarkusScenario;
 
 public class MetricsExtensionBootstrap implements ExtensionBootstrap {
@@ -28,12 +27,12 @@ public class MetricsExtensionBootstrap implements ExtensionBootstrap {
     }
 
     @Override
-    public boolean appliesFor(ExtensionContext context) {
-        return extensionEnabled && context.getRequiredTestClass().isAnnotationPresent(QuarkusScenario.class);
+    public boolean appliesFor(ScenarioContext context) {
+        return extensionEnabled && context.isAnnotationPresent(QuarkusScenario.class);
     }
 
     @Override
-    public void onSuccess(ExtensionContext context) {
+    public void onSuccess(ScenarioContext context) {
         quarkusGauges.upsert(GaugesTypes.TOTAL_SUCCESS);
         quarkusGauges.upsert(GaugesTypes.TOTAL);
         quarkusGauges.upsert(GaugesTypes.MODULE_SUCCESS);
@@ -41,7 +40,7 @@ public class MetricsExtensionBootstrap implements ExtensionBootstrap {
     }
 
     @Override
-    public void onError(ExtensionContext context, Throwable throwable) {
+    public void onError(ScenarioContext context, Throwable throwable) {
         quarkusGauges.upsert(GaugesTypes.TOTAL_FAIL);
         quarkusGauges.upsert(GaugesTypes.TOTAL);
         quarkusGauges.upsert(GaugesTypes.MODULE_FAIL);
@@ -49,7 +48,7 @@ public class MetricsExtensionBootstrap implements ExtensionBootstrap {
     }
 
     @Override
-    public void onDisabled(ExtensionContext context, Optional<String> reason) {
+    public void onDisabled(ScenarioContext context, Optional<String> reason) {
         quarkusGauges.upsert(GaugesTypes.TOTAL_IGNORE);
         quarkusGauges.upsert(GaugesTypes.TOTAL);
         quarkusGauges.upsert(GaugesTypes.MODULE_IGNORE);
@@ -57,24 +56,12 @@ public class MetricsExtensionBootstrap implements ExtensionBootstrap {
     }
 
     @Override
-    public void onServiceStarted(ExtensionContext context, Service service) {
-    }
-
-    @Override
-    public void onServiceInitiate(ExtensionContext context, Service service) {
-    }
-
-    @Override
-    public void beforeEach(ExtensionContext context) {
-    }
-
-    @Override
-    public void beforeAll(ExtensionContext context) {
+    public void beforeAll(ScenarioContext context) {
         quarkusHistograms.startDurationBeforeAll(HistogramTypes.MODULE_TEST_TIME_SEC);
     }
 
     @Override
-    public void afterAll(ExtensionContext context) {
+    public void afterAll(ScenarioContext context) {
         quarkusHistograms.stopDurationAfterAll(HistogramTypes.MODULE_TEST_TIME_SEC);
         quarkusHistograms.push();
         quarkusGauges.push();
@@ -84,8 +71,8 @@ public class MetricsExtensionBootstrap implements ExtensionBootstrap {
         return tag.equalsIgnoreCase(METRIC_FORCE_PUSH_TAG);
     }
 
-    private void onlyIfRequiredForcePush(ExtensionContext context) {
-        context.getTags().stream()
+    private void onlyIfRequiredForcePush(ScenarioContext context) {
+        context.getTestContext().getTags().stream()
                 .filter(MetricsExtensionBootstrap::checkForcePush)
                 .findFirst().ifPresent(requiredForcePush -> quarkusGauges.push());
     }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/tracing/QuarkusScenarioSpan.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/tracing/QuarkusScenarioSpan.java
@@ -1,19 +1,18 @@
 package io.quarkus.test.tracing;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.platform.commons.PreconditionViolationException;
-
 import io.opentracing.Span;
 import io.opentracing.Tracer;
+import io.quarkus.test.bootstrap.ScenarioContext;
 
 public class QuarkusScenarioSpan {
 
     private final Tracer tracer;
-    private QuarkusScenarioTags quarkusScenarioTags;
+    private final QuarkusScenarioTags quarkusScenarioTags;
     private final Map<String, Span> spanBucket = new ConcurrentHashMap<>();
 
     public QuarkusScenarioSpan(Tracer tracer, QuarkusScenarioTags quarkusScenarioTags) {
@@ -21,38 +20,37 @@ public class QuarkusScenarioSpan {
         this.tracer = tracer;
     }
 
-    public Span getOrCreate(ExtensionContext extensionContext) {
-        String spanId = getSpanId(extensionContext);
-        if (!spanBucket.containsKey(spanId)) {
-            return buildNewSpan(spanId, extensionContext.getTags());
+    public Span getOrCreate(ScenarioContext context) {
+        String operationName = getOperationName(context);
+        if (!spanBucket.containsKey(operationName)) {
+            return buildNewSpan(operationName, context.getTestContext().getTags());
         }
 
-        return spanBucket.get(spanId);
+        return spanBucket.get(operationName);
     }
 
-    public Span save(Map<String, ?> logs, Set<String> tags, ExtensionContext extensionContext) {
-        String spanId = getSpanId(extensionContext);
-        Span span = spanBucket.get(spanId);
+    public Span save(Map<String, ?> logs, Set<String> tags, ScenarioContext scenarioContext) {
+        String operationName = getOperationName(scenarioContext);
+        Span span = spanBucket.get(operationName);
         span.log(logs);
         tags.forEach(tag -> span.setTag(tag, true));
-        return spanBucket.put(spanId, span);
+        return span;
     }
 
-    public String getSpanId(ExtensionContext extensionContext) {
-        String spanId = extensionContext.getRequiredTestClass().getSimpleName();
-        try {
-            spanId += "_" + extensionContext.getRequiredTestMethod().getName();
-        } catch (PreconditionViolationException e) {
-            // there is no method name to append
+    public String getOperationName(ScenarioContext scenarioContext) {
+        String operationName = scenarioContext.getRunningTestClassName();
+        Optional<String> methodName = scenarioContext.getRunningTestMethodName();
+        if (methodName.isPresent()) {
+            operationName += "_" + methodName.get();
         }
 
-        return spanId;
+        return operationName;
     }
 
-    private Span buildNewSpan(String spanId, Set<String> tags) {
-        Span span = tracer.buildSpan(spanId).start();
+    private Span buildNewSpan(String operationName, Set<String> tags) {
+        Span span = tracer.buildSpan(operationName).start();
         quarkusScenarioTags.initializedTags(span, tags);
-        spanBucket.put(spanId, span);
+        spanBucket.put(operationName, span);
         return span;
     }
 }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/tracing/QuarkusScenarioTracer.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/tracing/QuarkusScenarioTracer.java
@@ -7,9 +7,9 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import org.apache.thrift.transport.TTransportException;
-import org.junit.jupiter.api.extension.ExtensionContext;
 
 import io.jaegertracing.internal.JaegerTracer;
 import io.jaegertracing.internal.reporters.RemoteReporter;
@@ -18,6 +18,7 @@ import io.jaegertracing.thrift.internal.senders.HttpSender;
 import io.opentracing.Span;
 import io.opentracing.Tracer;
 import io.opentracing.log.Fields;
+import io.quarkus.test.bootstrap.ScenarioContext;
 import io.quarkus.test.configuration.PropertyLookup;
 
 public class QuarkusScenarioTracer {
@@ -40,25 +41,29 @@ public class QuarkusScenarioTracer {
         this.quarkusScenarioSpan = new QuarkusScenarioSpan(tracer, quarkusScenarioTags);
     }
 
-    public void finishWithSuccess(ExtensionContext extensionContext) {
-        finishWithSuccess(extensionContext, SUCCESS);
+    public void updateWithTag(ScenarioContext context, String tag) {
+        quarkusScenarioSpan.save(Collections.emptyMap(), newHashSet(tag), context);
     }
 
-    public void finishWithSuccess(ExtensionContext extensionContext, String tag) {
-        quarkusScenarioSpan.save(Collections.emptyMap(), newHashSet(tag), extensionContext).finish();
+    public void finishWithSuccess(ScenarioContext context) {
+        finishWithSuccess(context, SUCCESS);
     }
 
-    public void finishWithError(ExtensionContext extensionContext, Throwable cause) {
-        finishWithError(extensionContext, cause, ERROR);
+    public void finishWithSuccess(ScenarioContext context, String tag) {
+        quarkusScenarioSpan.save(Collections.emptyMap(), newHashSet(tag), context).finish();
     }
 
-    public void finishWithError(ExtensionContext extensionContext, Throwable cause, String tag) {
+    public void finishWithError(ScenarioContext context, Throwable cause) {
+        finishWithError(context, cause, ERROR);
+    }
+
+    public void finishWithError(ScenarioContext context, Throwable cause, String tag) {
         Map<String, ?> err = Map.of(Fields.EVENT, "error", Fields.ERROR_OBJECT, cause, Fields.MESSAGE, cause.getMessage());
-        quarkusScenarioSpan.save(err, newHashSet(tag), extensionContext).finish();
+        quarkusScenarioSpan.save(err, newHashSet(tag), context).finish();
     }
 
-    public Span createSpanContext(ExtensionContext extensionContext) {
-        return quarkusScenarioSpan.getOrCreate(extensionContext);
+    public Span createSpanContext(ScenarioContext context) {
+        return quarkusScenarioSpan.getOrCreate(context);
     }
 
     public Tracer getTracer() {
@@ -69,9 +74,9 @@ public class QuarkusScenarioTracer {
         return quarkusScenarioTags;
     }
 
-    private static Set<String> newHashSet(String value) {
+    private static Set<String> newHashSet(String... values) {
         Set<String> set = new HashSet<>();
-        set.add(value);
+        Stream.of(values).forEach(set::add);
         return set;
     }
 }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/tracing/TracingServiceListener.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/tracing/TracingServiceListener.java
@@ -1,0 +1,32 @@
+package io.quarkus.test.tracing;
+
+import java.util.Optional;
+
+import io.quarkus.test.bootstrap.ScenarioContext;
+import io.quarkus.test.bootstrap.ServiceContext;
+import io.quarkus.test.bootstrap.ServiceListener;
+
+public class TracingServiceListener implements ServiceListener {
+
+    @Override
+    public void onServiceStarted(ServiceContext service) {
+        getTracer(service.getScenarioContext())
+                .ifPresent(tracer -> tracer.updateWithTag(service.getScenarioContext(), service.getName()));
+    }
+
+    @Override
+    public void onServiceError(ServiceContext service, Throwable throwable) {
+        getTracer(service.getScenarioContext())
+                .ifPresent(tracer -> tracer.finishWithError(service.getScenarioContext(), throwable, service.getName()));
+    }
+
+    private Optional<QuarkusScenarioTracer> getTracer(ScenarioContext scenario) {
+        Object tracer = scenario.getTestStore().get(TracingExtensionBootstrap.TRACING_ID);
+        if (tracer == null) {
+            // Tracing is off
+            return Optional.empty();
+        }
+
+        return Optional.of((QuarkusScenarioTracer) tracer);
+    }
+}

--- a/quarkus-test-core/src/main/resources/META-INF/services/io.quarkus.test.bootstrap.ServiceListener
+++ b/quarkus-test-core/src/main/resources/META-INF/services/io.quarkus.test.bootstrap.ServiceListener
@@ -1,0 +1,1 @@
+io.quarkus.test.tracing.TracingServiceListener

--- a/quarkus-test-kubernetes/src/main/java/io/quarkus/test/bootstrap/KubernetesExtensionBootstrap.java
+++ b/quarkus-test-kubernetes/src/main/java/io/quarkus/test/bootstrap/KubernetesExtensionBootstrap.java
@@ -4,8 +4,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 
-import org.junit.jupiter.api.extension.ExtensionContext;
-
 import io.quarkus.test.bootstrap.inject.KubectlClient;
 import io.quarkus.test.configuration.PropertyLookup;
 import io.quarkus.test.logging.Log;
@@ -21,17 +19,17 @@ public class KubernetesExtensionBootstrap implements ExtensionBootstrap {
     private KubectlClient client;
 
     @Override
-    public boolean appliesFor(ExtensionContext context) {
-        return context.getRequiredTestClass().isAnnotationPresent(KubernetesScenario.class);
+    public boolean appliesFor(ScenarioContext context) {
+        return context.isAnnotationPresent(KubernetesScenario.class);
     }
 
     @Override
-    public void beforeAll(ExtensionContext context) {
+    public void beforeAll(ScenarioContext context) {
         client = KubectlClient.create();
     }
 
     @Override
-    public void afterAll(ExtensionContext context) {
+    public void afterAll(ScenarioContext context) {
         if (DELETE_NAMESPACE_AFTER.getAsBoolean()) {
             client.deleteNamespace();
         }
@@ -52,7 +50,7 @@ public class KubernetesExtensionBootstrap implements ExtensionBootstrap {
     }
 
     @Override
-    public void onError(ExtensionContext context, Throwable throwable) {
+    public void onError(ScenarioContext context, Throwable throwable) {
         Map<String, String> logs = client.logs();
         for (Entry<String, String> podLog : logs.entrySet()) {
             FileUtils.copyContentTo(podLog.getValue(), Log.LOG_OUTPUT_DIRECTORY.resolve(podLog.getKey() + Log.LOG_SUFFIX));

--- a/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/OpenShiftStrimziKafkaContainerManagedResource.java
+++ b/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/OpenShiftStrimziKafkaContainerManagedResource.java
@@ -108,7 +108,7 @@ public class OpenShiftStrimziKafkaContainerManagedResource implements ManagedRes
 
     private void createRegistryService() {
         registry = new DefaultService();
-        registry.register("registry", model.getContext().getTestContext());
+        registry.register("registry", model.getContext().getScenarioContext());
     }
 
     private void applyDeployment() {


### PR DESCRIPTION
ExtensionContext comes from JUnit and we were coupling it in too many interfaces.
With this refactor, we have a scenario context that wraps the ExtensionContext and some common functionality like:
- get / check annotations present
- common test store (junit)
- generate an unique id per test scenario

Moreover, we have created a ServiceListener to bind actions to the service lifespan (start, stop, error).