### PR TITLE
Support assertion for startup failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,37 @@ class MyScenarioIT extends MyParent {
 
 Now, the framework will initialize the `appInChild` service first and then the `appInParent` service.
 
+### Test expected failures
+
+With the test framework, we can assert startup failures using `service.setAutoStart(false)`. When disabling this flag, the
+test framework will not start the service and users will need to manually start them by doing `service.start()` at each test case. 
+Hence users should be able now to assert failure messages from the logs for each test case. For example:
+
+```java
+@QuarkusApplication
+static final RestService app = new RestService()
+        .setAutoStart(false);
+
+@Test
+public void shouldFailOnStart() {
+    assertThrows(AssertionError.class, () -> app.start(),
+            "Should fail because runtime exception in ValidateCustomProperty");
+    // or checks service logs
+    app.logs().assertContains("Missing property a.b.z");
+}
+```
+
+Moreover, we can try to fix the application during the test execution:
+
+```java
+@Test
+public void shouldWorkWhenPropertyIsCorrect() {
+    app.withProperty("a.b.z", "here you have!");
+    app.start();
+    app.given().get("/hello").then().statusCode(HttpStatus.SC_OK);
+}
+```
+
 ### Configuration
 
 Test framework allows to customise the configuration for running the test case via a `test.properties` file placed under `src/test/resources` folder.

--- a/examples/greetings/src/main/java/io/quarkus/qe/GreetingResource.java
+++ b/examples/greetings/src/main/java/io/quarkus/qe/GreetingResource.java
@@ -12,9 +12,7 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 @Path("/greeting")
 public class GreetingResource {
 
-    public static final String PROPERTY = "custom.property.name";
-
-    @ConfigProperty(name = PROPERTY)
+    @ConfigProperty(name = ValidateCustomProperty.CUSTOM_PROPERTY)
     String name;
 
     @GET

--- a/examples/greetings/src/main/java/io/quarkus/qe/ReactiveGreetingResource.java
+++ b/examples/greetings/src/main/java/io/quarkus/qe/ReactiveGreetingResource.java
@@ -12,9 +12,7 @@ import io.smallrye.mutiny.Uni;
 @Path("/reactive-greeting")
 public class ReactiveGreetingResource {
 
-    public static final String PROPERTY = "custom.property.name";
-
-    @ConfigProperty(name = PROPERTY)
+    @ConfigProperty(name = ValidateCustomProperty.CUSTOM_PROPERTY)
     String name;
 
     @GET

--- a/examples/greetings/src/main/java/io/quarkus/qe/ValidateCustomProperty.java
+++ b/examples/greetings/src/main/java/io/quarkus/qe/ValidateCustomProperty.java
@@ -1,0 +1,27 @@
+package io.quarkus.qe;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+
+import io.quarkus.runtime.StartupEvent;
+
+@ApplicationScoped
+public class ValidateCustomProperty {
+
+    public static final String DISALLOW_PROPERTY_VALUE = "WRONG!";
+    public static final String CUSTOM_PROPERTY = "custom.property.name";
+
+    private static final Logger LOG = Logger.getLogger(ValidateCustomProperty.class.getName());
+
+    @ConfigProperty(name = CUSTOM_PROPERTY)
+    String value;
+
+    void onStart(@Observes StartupEvent ev) {
+        if (DISALLOW_PROPERTY_VALUE.equals(value)) {
+            throw new RuntimeException("Wrong value! " + value);
+        }
+    }
+}

--- a/examples/greetings/src/test/java/io/quarkus/qe/FailGreetingResourceIT.java
+++ b/examples/greetings/src/test/java/io/quarkus/qe/FailGreetingResourceIT.java
@@ -1,0 +1,48 @@
+package io.quarkus.qe;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.QuarkusApplication;
+
+@QuarkusScenario
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class FailGreetingResourceIT {
+
+    static final String MANUEL_NAME = "manuel";
+
+    @QuarkusApplication
+    static final RestService app = new RestService()
+            .withProperty(ValidateCustomProperty.CUSTOM_PROPERTY, ValidateCustomProperty.DISALLOW_PROPERTY_VALUE)
+            .setAutoStart(false);
+
+    @Order(1)
+    @Test
+    public void shouldBeStopped() {
+        assertFalse(app.isRunning(), "Autostart is not working!");
+    }
+
+    @Order(2)
+    @Test
+    public void shouldFailOnStart() {
+        assertThrows(AssertionError.class, () -> app.start(),
+                "Should fail because runtime exception in ValidateCustomProperty");
+    }
+
+    @Order(3)
+    @Test
+    public void shouldWorkWhenPropertyIsCorrect() {
+        app.withProperty(ValidateCustomProperty.CUSTOM_PROPERTY, MANUEL_NAME);
+        app.start();
+        app.given().get("/greeting").then().statusCode(HttpStatus.SC_OK).body(is("Hello, I'm " + MANUEL_NAME));
+    }
+}

--- a/examples/greetings/src/test/java/io/quarkus/qe/GreetingResourceUsingRuntimePropertiesIT.java
+++ b/examples/greetings/src/test/java/io/quarkus/qe/GreetingResourceUsingRuntimePropertiesIT.java
@@ -17,9 +17,9 @@ public class GreetingResourceUsingRuntimePropertiesIT {
     static final String MANUEL_NAME = "manuel";
 
     @QuarkusApplication
-    static RestService joseApp = new RestService().withProperty(GreetingResource.PROPERTY, JOSE_NAME);
+    static RestService joseApp = new RestService().withProperty(ValidateCustomProperty.CUSTOM_PROPERTY, JOSE_NAME);
     @QuarkusApplication
-    static RestService manuelApp = new RestService().withProperty(GreetingResource.PROPERTY, MANUEL_NAME);
+    static RestService manuelApp = new RestService().withProperty(ValidateCustomProperty.CUSTOM_PROPERTY, MANUEL_NAME);
 
     @Test
     public void shouldSayJose() {

--- a/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/QuarkusScenarioBootstrap.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/QuarkusScenarioBootstrap.java
@@ -55,6 +55,7 @@ public class QuarkusScenarioBootstrap
     public void beforeAll(ExtensionContext context) {
         // Init scenario context
         scenario = new ScenarioContext(context);
+        Log.info("Scenario ID: '%s'", scenario.getId());
 
         // Init extensions
         extensions = initExtensions();
@@ -90,7 +91,11 @@ public class QuarkusScenarioBootstrap
                 .getDisplayName());
         scenario.setMethodTestContext(context);
         extensions.forEach(ext -> ext.beforeEach(scenario));
-        services.forEach(Service::start);
+        services.forEach(service -> {
+            if (service.isAutoStart()) {
+                service.start();
+            }
+        });
     }
 
     @Override
@@ -144,6 +149,11 @@ public class QuarkusScenarioBootstrap
     }
 
     private void launchService(Service service) {
+        if (!service.isAutoStart()) {
+            Log.debug(service, "Service (%s) auto start is off", service.getDisplayName());
+            return;
+        }
+
         Log.info(service, "Initialize service (%s)", service.getDisplayName());
         extensions.forEach(ext -> ext.onServiceLaunch(scenario, service));
         try {

--- a/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/ScenarioContext.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/ScenarioContext.java
@@ -5,8 +5,6 @@ import java.util.Optional;
 
 import org.junit.jupiter.api.extension.ExtensionContext;
 
-import io.quarkus.test.logging.Log;
-
 public final class ScenarioContext {
 
     private static final int SCENARIO_ID_MAX_SIZE = 60;
@@ -20,8 +18,6 @@ public final class ScenarioContext {
         this.testContext = testContext;
         this.id = generateScenarioId(testContext);
         this.testNamespace = ExtensionContext.Namespace.create(ScenarioContext.class);
-
-        Log.info("Scenario ID: '%s'", this.id);
     }
 
     public String getId() {

--- a/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/Service.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/Service.java
@@ -38,6 +38,10 @@ public interface Service extends ExtensionContext.Store.CloseableResource {
 
     Service withProperty(String key, String value);
 
+    default boolean isAutoStart() {
+        return true;
+    }
+
     default void validate(Field field) {
 
     }


### PR DESCRIPTION
With the test framework, we can assert startup failures using `service.setAutoStart(false)`. When disabling this flag, the
test framework will not start the service and users will need to manually start them by doing `service.start()` at each test case. 
Hence users should be able now to assert failure messages from the logs for each test case. For example:

```java
@QuarkusApplication
static final RestService app = new RestService()
        .setAutoStart(false);

@Test
public void shouldFailOnStart() {
    assertThrows(AssertionError.class, () -> app.start(),
            "Should fail because runtime exception in ValidateCustomProperty");
    // or checks service logs
    app.logs().assertContains("Missing property a.b.z");
}
```

Moreover, we can try to fix the application during the test execution:

```java
@Test
public void shouldWorkWhenPropertyIsCorrect() {
    app.withProperty("a.b.z", "here you have!");
    app.start();
    app.given().get("/hello").then().statusCode(HttpStatus.SC_OK);
}
```