### PR TITLE
Support Remote GIT repositories on Baremetal

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,6 +571,30 @@ Modules within the testing framework must conform to the following package namin
 
 By default, the framework will run all the tests on bare metal (local machine). However, we can extend this functionality by adding other modules and annotating our tests.
 
+### Remote GIT repositories on Baremetal
+
+We can deploy a remote GIT repository using the annotation `@GitRepositoryQuarkusApplication`. Example:
+
+```java
+@QuarkusScenario
+public class QuickstartIT {
+
+    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", contextDir = "getting-started")
+    static final RestService app = new RestService();
+    //
+```
+
+This works on JVM and Native modes. For DEV mode, you need to set the devMode attribute as follows:
+
+```java
+@QuarkusScenario
+public class DevModeQuickstartIT {
+
+    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", contextDir = "getting-started", devMode = true)
+    static final RestService app = new RestService();
+    //
+```
+
 ### OpenShift
 
 Requirements:

--- a/examples/external-applications/src/test/java/io/quarkus/qe/DevModeQuickstartUsingDefaultsIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/DevModeQuickstartUsingDefaultsIT.java
@@ -1,0 +1,29 @@
+package io.quarkus.qe;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnNative;
+import io.quarkus.test.services.GitRepositoryQuarkusApplication;
+
+@QuarkusScenario
+@DisabledOnNative
+@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Windows does not support long file paths")
+public class DevModeQuickstartUsingDefaultsIT {
+
+    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", contextDir = "getting-started", devMode = true)
+    static final RestService app = new RestService();
+
+    @Test
+    public void test() {
+        app.given()
+                .get("/hello")
+                .then()
+                .statusCode(HttpStatus.SC_OK);
+    }
+
+}

--- a/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftS2iQuickstartUsingDefaultsIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftS2iQuickstartUsingDefaultsIT.java
@@ -1,26 +1,10 @@
 package io.quarkus.qe;
 
-import org.apache.http.HttpStatus;
-import org.junit.jupiter.api.Test;
-
-import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusSnapshot;
-import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 
 @DisabledOnQuarkusSnapshot(reason = "999-SNAPSHOT is not available in the Maven repositories in OpenShift")
 @OpenShiftScenario
-public class OpenShiftS2iQuickstartUsingDefaultsIT {
-
-    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", contextDir = "getting-started")
-    static final RestService app = new RestService();
-
-    @Test
-    public void test() {
-        app.given()
-                .get("/hello")
-                .then()
-                .statusCode(HttpStatus.SC_OK);
-    }
+public class OpenShiftS2iQuickstartUsingDefaultsIT extends QuickstartUsingDefaultsIT {
 
 }

--- a/examples/external-applications/src/test/java/io/quarkus/qe/QuickstartUsingDefaultsIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/QuickstartUsingDefaultsIT.java
@@ -1,0 +1,27 @@
+package io.quarkus.qe;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.GitRepositoryQuarkusApplication;
+
+@QuarkusScenario
+@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Windows does not support long file paths")
+public class QuickstartUsingDefaultsIT {
+
+    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", contextDir = "getting-started")
+    static final RestService app = new RestService();
+
+    @Test
+    public void test() {
+        app.given()
+                .get("/hello")
+                .then()
+                .statusCode(HttpStatus.SC_OK);
+    }
+
+}

--- a/examples/external-applications/src/test/java/io/quarkus/qe/QuickstartUsingUsingUberJarIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/QuickstartUsingUsingUberJarIT.java
@@ -1,0 +1,29 @@
+package io.quarkus.qe;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnNative;
+import io.quarkus.test.services.GitRepositoryQuarkusApplication;
+
+@QuarkusScenario
+@DisabledOnNative(reason = "This is to verify uber-jar, so it does not make sense on Native")
+@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Windows does not support long file paths")
+public class QuickstartUsingUsingUberJarIT {
+
+    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", contextDir = "getting-started", mavenArgs = "-Dquarkus.package.type=uber-jar")
+    static final RestService app = new RestService();
+
+    @Test
+    public void test() {
+        app.given()
+                .get("/hello")
+                .then()
+                .statusCode(HttpStatus.SC_OK);
+    }
+
+}

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/GitRepositoryQuarkusApplication.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/GitRepositoryQuarkusApplication.java
@@ -15,4 +15,6 @@ public @interface GitRepositoryQuarkusApplication {
     String contextDir() default "";
 
     String mavenArgs() default "-DskipTests=true -DskipITs=true";
+
+    boolean devMode() default false;
 }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/DevModeLocalhostQuarkusApplicationManagedResource.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/DevModeLocalhostQuarkusApplicationManagedResource.java
@@ -1,12 +1,8 @@
 package io.quarkus.test.services.quarkus;
 
-import static io.quarkus.test.utils.MavenUtils.SKIP_CHECKSTYLE;
-import static io.quarkus.test.utils.MavenUtils.SKIP_ITS;
+import static io.quarkus.test.utils.MavenUtils.devModeMavenCommand;
 import static io.quarkus.test.utils.MavenUtils.installParentPomsIfNeeded;
-import static io.quarkus.test.utils.MavenUtils.mvnCommand;
-import static io.quarkus.test.utils.MavenUtils.withProperty;
 
-import java.util.Arrays;
 import java.util.List;
 
 import io.quarkus.test.services.quarkus.model.LaunchMode;
@@ -28,13 +24,7 @@ public class DevModeLocalhostQuarkusApplicationManagedResource extends Localhost
     protected List<String> prepareCommand(List<String> systemProperties) {
         installParentPomsIfNeeded();
 
-        List<String> command = mvnCommand(model.getContext());
-        command.addAll(Arrays.asList(SKIP_CHECKSTYLE, SKIP_ITS));
-        command.addAll(systemProperties);
-        command.add(withProperty("debug", "false"));
-        command.add("quarkus:dev");
-
-        return command;
+        return devModeMavenCommand(model.getContext(), systemProperties);
     }
 
 }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/DevModeQuarkusApplicationManagedResourceBuilder.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/DevModeQuarkusApplicationManagedResourceBuilder.java
@@ -20,8 +20,8 @@ public class DevModeQuarkusApplicationManagedResourceBuilder extends QuarkusAppl
     }
 
     @Override
-    protected Path appResourcesFolder() {
-        return super.appResourcesFolder().resolve(RESOURCES_FOLDER);
+    protected Path getResourcesApplicationFolder() {
+        return super.getResourcesApplicationFolder().resolve(RESOURCES_FOLDER);
     }
 
     @Override

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/GitRepositoryLocalhostQuarkusApplicationManagedResource.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/GitRepositoryLocalhostQuarkusApplicationManagedResource.java
@@ -1,0 +1,86 @@
+package io.quarkus.test.services.quarkus;
+
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+
+import io.quarkus.test.services.quarkus.model.LaunchMode;
+import io.quarkus.test.utils.GitUtils;
+import io.quarkus.test.utils.MavenUtils;
+
+public class GitRepositoryLocalhostQuarkusApplicationManagedResource
+        extends ProdLocalhostQuarkusApplicationManagedResource {
+
+    private static final String QUARKUS_VERSION = "quarkus.version";
+    private static final String QUARKUS_PLUGIN_VERSION = "quarkus-plugin.version";
+    private static final String QUARKUS_VERSION_VALUE = "${quarkus.platform.version}";
+
+    private final GitRepositoryQuarkusApplicationManagedResourceBuilder model;
+
+    public GitRepositoryLocalhostQuarkusApplicationManagedResource(
+            GitRepositoryQuarkusApplicationManagedResourceBuilder model) {
+        super(model);
+
+        this.model = model;
+    }
+
+    @Override
+    public void onPreBuild() {
+        super.onPreBuild();
+
+        // Clone repository
+        GitUtils.cloneRepository(model.getContext(), model.getGitRepository());
+        if (StringUtils.isNotEmpty(model.getGitBranch())) {
+            GitUtils.checkoutBranch(model.getContext(), model.getGitBranch());
+        }
+
+        // Maven build
+        String[] mvnArgs = StringUtils.split(model.getMavenArgs(), " ");
+        List<String> effectiveProperties = getEffectivePropertiesForGitRepository(Arrays.asList(mvnArgs));
+        MavenUtils.build(model.getContext(), getApplicationFolder(), effectiveProperties);
+    }
+
+    @Override
+    protected Path getApplicationFolder() {
+        Path appFolder = model.getContext().getServiceFolder();
+        if (StringUtils.isNotEmpty(model.getContextDir())) {
+            appFolder = appFolder.resolve(model.getContextDir());
+        }
+
+        return appFolder;
+    }
+
+    @Override
+    protected List<String> prepareCommand(List<String> systemProperties) {
+        List<String> effectiveProperties = getEffectivePropertiesForGitRepository(systemProperties);
+
+        // Dev mode
+        if (model.isDevMode()) {
+            return MavenUtils.devModeMavenCommand(model.getContext(), effectiveProperties);
+        }
+
+        // JVM or Native
+        return super.prepareCommand(effectiveProperties);
+    }
+
+    @Override
+    protected LaunchMode getLaunchMode() {
+        if (model.isDevMode()) {
+            return LaunchMode.DEV;
+        }
+
+        return super.getLaunchMode();
+    }
+
+    private List<String> getEffectivePropertiesForGitRepository(List<String> properties) {
+        List<String> effectiveProperties = new LinkedList<>(properties);
+        // Override quarkus plugin version.
+        effectiveProperties.add(MavenUtils.withProperty(QUARKUS_VERSION, QUARKUS_VERSION_VALUE));
+        effectiveProperties.add(MavenUtils.withProperty(QUARKUS_PLUGIN_VERSION, QUARKUS_VERSION_VALUE));
+
+        return effectiveProperties;
+    }
+}

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/LocalhostQuarkusApplicationManagedResource.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/LocalhostQuarkusApplicationManagedResource.java
@@ -6,6 +6,7 @@ import static io.quarkus.test.services.quarkus.QuarkusApplicationManagedResource
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -57,7 +58,7 @@ public abstract class LocalhostQuarkusApplicationManagedResource extends Quarkus
             process = ProcessBuilderProvider.command(command)
                     .redirectErrorStream(true)
                     .redirectOutput(logOutputFile)
-                    .directory(model.getContext().getServiceFolder().toFile())
+                    .directory(getApplicationFolder().toFile())
                     .start();
 
             loggingHandler = new FileServiceLoggingHandler(model.getContext().getOwner(), logOutputFile);
@@ -118,6 +119,10 @@ public abstract class LocalhostQuarkusApplicationManagedResource extends Quarkus
     @Override
     protected LoggingHandler getLoggingHandler() {
         return loggingHandler;
+    }
+
+    protected Path getApplicationFolder() {
+        return model.getContext().getServiceFolder();
     }
 
     private void assignPorts() {

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusApplicationManagedResourceBuilder.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusApplicationManagedResourceBuilder.java
@@ -114,12 +114,16 @@ public abstract class QuarkusApplicationManagedResourceBuilder implements Manage
         createEffectiveApplicationProperties();
     }
 
-    protected Path appResourcesFolder() {
+    protected Path getApplicationFolder() {
         return context.getServiceFolder();
     }
 
+    protected Path getResourcesApplicationFolder() {
+        return getApplicationFolder();
+    }
+
     private void createEffectiveApplicationProperties() {
-        Path applicationProperties = appResourcesFolder().resolve(APPLICATION_PROPERTIES);
+        Path applicationProperties = getResourcesApplicationFolder().resolve(APPLICATION_PROPERTIES);
         Map<String, String> map = new HashMap<>();
         // Put the original application properties
         if (Files.exists(applicationProperties)) {
@@ -147,7 +151,7 @@ public abstract class QuarkusApplicationManagedResourceBuilder implements Manage
                 File fileToCopy = path.toFile();
 
                 Path source = folder.relativize(path).getParent();
-                Path target = appResourcesFolder();
+                Path target = getResourcesApplicationFolder();
                 if (source != null) {
                     // Resource is in a sub-folder:
                     target = target.resolve(source);

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusManagedResource.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusManagedResource.java
@@ -51,6 +51,14 @@ public abstract class QuarkusManagedResource implements ManagedResource {
         return getLaunchMode() == LaunchMode.NATIVE;
     }
 
+    public void onPreBuild() {
+
+    }
+
+    public void onPostBuild() {
+
+    }
+
     protected ServiceContext getContext() {
         return serviceContext;
     }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/utils/FileUtils.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/utils/FileUtils.java
@@ -115,13 +115,9 @@ public final class FileUtils {
         }
     }
 
-    public static Optional<String> findTargetFile(String endsWith) {
-        return findTargetFile(StringUtils.EMPTY, endsWith);
-    }
-
-    public static Optional<String> findTargetFile(String subFolder, String endsWith) {
+    public static Optional<String> findTargetFile(Path basePath, String endsWith) {
         try (Stream<Path> binariesFound = Files
-                .find(Paths.get(TARGET, subFolder), NO_RECURSIVE,
+                .find(basePath, NO_RECURSIVE,
                         (path, basicFileAttributes) -> path.toFile().getName().endsWith(endsWith))) {
             return binariesFound.map(path -> path.normalize().toString()).findFirst();
         } catch (IOException ex) {

--- a/quarkus-test-core/src/main/java/io/quarkus/test/utils/GitUtils.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/utils/GitUtils.java
@@ -1,0 +1,40 @@
+package io.quarkus.test.utils;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.Arrays;
+
+import io.quarkus.test.bootstrap.ServiceContext;
+
+public final class GitUtils {
+    private static final String GIT = "git";
+    private static final String CLONE = "clone";
+    private static final String CHECKOUT = "checkout";
+
+    private GitUtils() {
+
+    }
+
+    public static void cloneRepository(ServiceContext serviceContext, String repository) {
+        try {
+            new Command(Arrays.asList(GIT, CLONE, repository, "."))
+                    .outputToConsole()
+                    .onDirectory(serviceContext.getServiceFolder())
+                    .runAndWait();
+
+        } catch (Exception e) {
+            fail("Failed to clone GIT repository " + repository + ". Caused by: " + e.getMessage());
+        }
+    }
+
+    public static void checkoutBranch(ServiceContext serviceContext, String branch) {
+        try {
+            new Command(Arrays.asList(GIT, CHECKOUT, branch))
+                    .outputToConsole()
+                    .onDirectory(serviceContext.getServiceFolder())
+                    .runAndWait();
+        } catch (Exception e) {
+            fail("Failed to checkout GIT branch " + branch + ". Caused by: " + e.getMessage());
+        }
+    }
+}

--- a/quarkus-test-core/src/main/java/io/quarkus/test/utils/MavenUtils.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/utils/MavenUtils.java
@@ -1,12 +1,14 @@
 package io.quarkus.test.utils;
 
 import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.FileReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
@@ -35,6 +37,31 @@ public final class MavenUtils {
 
     private MavenUtils() {
 
+    }
+
+    public static void build(ServiceContext serviceContext, Path basePath, List<String> extraMavenArgs) {
+        List<String> command = mvnCommand(serviceContext);
+        command.addAll(extraMavenArgs);
+        command.add(PACKAGE_GOAL);
+        try {
+            new Command(command)
+                    .outputToConsole()
+                    .onDirectory(basePath)
+                    .runAndWait();
+
+        } catch (Exception e) {
+            fail("Failed to build Maven. Caused by: " + e.getMessage());
+        }
+    }
+
+    public static List<String> devModeMavenCommand(ServiceContext serviceContext, List<String> systemProperties) {
+        List<String> command = mvnCommand(serviceContext);
+        command.addAll(Arrays.asList(SKIP_CHECKSTYLE, SKIP_ITS));
+        command.addAll(systemProperties);
+        command.add(withProperty("debug", "false"));
+        command.add("quarkus:dev");
+
+        return command;
     }
 
     public static List<String> mvnCommand(ServiceContext serviceContext) {

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftS2iGitRepositoryQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftS2iGitRepositoryQuarkusApplicationManagedResource.java
@@ -64,6 +64,10 @@ public class OpenShiftS2iGitRepositoryQuarkusApplicationManagedResource
     @Override
     protected void validate() {
         super.validate();
+        if (model.isDevMode()) {
+            Assertions.fail("DEV mode is not supported when using GIT repositories on OpenShift deployments");
+        }
+
         if (DisabledOnQuarkusSnapshotCondition.isQuarkusSnapshotVersion()
                 && StringUtils.isEmpty(MAVEN_REMOTE_REPOSITORY.get(model.getContext()))) {
             Assertions.fail("s2i can't use the Quarkus 999-SNAPSHOT version if not Maven repository has been provided");


### PR DESCRIPTION
We can deploy a remote GIT repository using the annotation `@GitRepositoryQuarkusApplication`. Example:

```java
@QuarkusScenario
public class QuickstartIT {

    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", contextDir = "getting-started")
    static final RestService app = new RestService();
    //
```

This works on JVM and Native modes. For DEV mode, you need to set the devMode attribute as follows:

```java
@QuarkusScenario
public class DevModeQuickstartIT {

    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", contextDir = "getting-started", devMode = true)
    static final RestService app = new RestService();
    //
```