### PR TITLE
Use ZeroDep client for DockerJava ++ Stop containers before image delete

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,12 @@
             </dependency>
             <dependency>
                 <groupId>com.github.docker-java</groupId>
-                <artifactId>docker-java</artifactId>
+                <artifactId>docker-java-core</artifactId>
+                <version>${com.github.docker-java.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.docker-java</groupId>
+                <artifactId>docker-java-transport-zerodep</artifactId>
                 <version>${com.github.docker-java.version}</version>
             </dependency>
         </dependencies>

--- a/quarkus-test-images/pom.xml
+++ b/quarkus-test-images/pom.xml
@@ -15,7 +15,11 @@
         </dependency>
         <dependency>
             <groupId>com.github.docker-java</groupId>
-            <artifactId>docker-java</artifactId>
+            <artifactId>docker-java-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.docker-java</groupId>
+            <artifactId>docker-java-transport-zerodep</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/quarkus-test-images/src/main/java/io/quarkus/test/annotations/DisabledIfNotContainerRegistryCondition.java
+++ b/quarkus-test-images/src/main/java/io/quarkus/test/annotations/DisabledIfNotContainerRegistryCondition.java
@@ -1,6 +1,6 @@
 package io.quarkus.test.annotations;
 
-import static io.quarkus.test.utils.DockerUtils.CONTAINER_REGISTY_URL_PROPERTY;
+import static io.quarkus.test.utils.DockerUtils.CONTAINER_REGISTRY_URL_PROPERTY;
 
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -11,7 +11,7 @@ public class DisabledIfNotContainerRegistryCondition extends CheckIfSystemProper
 
     @Override
     protected String getSystemPropertyName(ExtensionContext context) {
-        return CONTAINER_REGISTY_URL_PROPERTY;
+        return CONTAINER_REGISTRY_URL_PROPERTY;
     }
 
     @Override

--- a/quarkus-test-images/src/main/java/io/quarkus/test/utils/DockerUtils.java
+++ b/quarkus-test-images/src/main/java/io/quarkus/test/utils/DockerUtils.java
@@ -4,30 +4,32 @@ import static java.util.regex.Pattern.quote;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
 
 import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.model.Container;
 import com.github.dockerjava.api.model.Image;
 import com.github.dockerjava.core.DefaultDockerClientConfig;
-import com.github.dockerjava.core.DockerClientBuilder;
+import com.github.dockerjava.core.DockerClientImpl;
+import com.github.dockerjava.zerodep.ZerodepDockerHttpClient;
 
 import io.quarkus.test.bootstrap.ServiceContext;
 import io.quarkus.test.services.quarkus.model.LaunchMode;
 
 public final class DockerUtils {
 
-    public static final String CONTAINER_REGISTY_URL_PROPERTY = "ts.container.registry-url";
+    public static final String CONTAINER_REGISTRY_URL_PROPERTY = "ts.container.registry-url";
 
     private static final String DOCKERFILE = "Dockerfile";
     private static final String DOCKERFILE_TEMPLATE = "/Dockerfile.%s";
-
     private static final String DOCKER = "docker";
+    private static final Object LOCK = new Object();
 
-    private static final DockerClient DOCKER_CLIENT = DockerClientBuilder
-            .getInstance(DefaultDockerClientConfig.createDefaultConfigBuilder().build()).build();
+    private static DockerClient dockerClientInstance;
 
     private DockerUtils() {
 
@@ -79,11 +81,25 @@ public final class DockerUtils {
         boolean removed = false;
         Image image = getImage(name, version);
         if (isVersion(image, version)) {
+            stopContainersByImage(image.getId());
+
             String id = image.getId().substring(image.getId().lastIndexOf(":") + 1);
-            DOCKER_CLIENT.removeImageCmd(id).withForce(true).exec();
+            dockerClient().removeImageCmd(id).withForce(true).exec();
             removed = true;
         }
         return removed;
+    }
+
+    /**
+     * Stop containers using the image ID.
+     * 
+     * @param imageId docker image ID.
+     */
+    public static void stopContainersByImage(String imageId) {
+        List<Container> containers = dockerClient().listContainersCmd().withAncestorFilter(Arrays.asList(imageId)).exec();
+        for (Container container : containers) {
+            dockerClient().stopContainerCmd(container.getId()).exec();
+        }
     }
 
     /**
@@ -95,7 +111,7 @@ public final class DockerUtils {
      */
     public static Image getImage(String name, String version) {
         Image result = new Image();
-        List<Image> images = DOCKER_CLIENT.listImagesCmd().withImageNameFilter(name).exec();
+        List<Image> images = dockerClient().listImagesCmd().withImageNameFilter(name).exec();
         for (Image image : images) {
             if (isVersion(image, version)) {
                 result = image;
@@ -105,8 +121,25 @@ public final class DockerUtils {
         return result;
     }
 
+    private static DockerClient dockerClient() {
+        if (dockerClientInstance == null) {
+            synchronized (LOCK) {
+                if (dockerClientInstance == null) {
+                    DefaultDockerClientConfig dockerClientConfig = DefaultDockerClientConfig.createDefaultConfigBuilder()
+                            .build();
+                    ZerodepDockerHttpClient dockerHttpClient = new ZerodepDockerHttpClient.Builder()
+                            .dockerHost(dockerClientConfig.getDockerHost())
+                            .sslConfig(dockerClientConfig.getSSLConfig()).build();
+                    dockerClientInstance = DockerClientImpl.getInstance(dockerClientConfig, dockerHttpClient);
+                }
+            }
+        }
+
+        return dockerClientInstance;
+    }
+
     private static void validateContainerRegistry() {
-        if (StringUtils.isEmpty(System.getProperty(CONTAINER_REGISTY_URL_PROPERTY))) {
+        if (StringUtils.isEmpty(System.getProperty(CONTAINER_REGISTRY_URL_PROPERTY))) {
             fail("Container Registry URL is not provided, use -Dts.container.registry-url=XXX");
         }
     }
@@ -121,7 +154,7 @@ public final class DockerUtils {
     }
 
     private static String pushToContainerRegistryUrl(ServiceContext service) {
-        String containerRegistryUrl = System.getProperty(CONTAINER_REGISTY_URL_PROPERTY);
+        String containerRegistryUrl = System.getProperty(CONTAINER_REGISTRY_URL_PROPERTY);
         try {
             String targetImage = containerRegistryUrl + "/" + getUniqueName(service);
             new Command(DOCKER, "tag", getUniqueName(service), targetImage).runAndWait();


### PR DESCRIPTION
The dependency `docker-java` was retrieving too many dependencies and making some necessary dependencies at compile to be `test` scope. This was affecting the native compilation to fail with class not found exceptions.

Moreover, we are now stopping the containers before deleting an image.