### PR TITLE
Change port resolution strategy from random to incremental

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,17 @@ In a Multi-Module Maven test suite, if we want to configure the timeouts, we can
 - Increase the startup timeout only: `mvn clean verify -Dts.global.startup.timeout=20m`
 - Increase all the timeouts at once using the factor: `mvn clean verify -Dts.global.factor.timeout=2.5`
 
+- Ports
+
+The framework will allocate ports to deploy the services. We can configure the port range and the strategy to find an available port using:
+
+```
+ts.global.port.range.min=1100
+ts.global.port.range.max=49151
+## incremental (default) or random
+ts.global.port.resolution.strategy=incremental
+```
+
 ### Native
 
 The `@QuarkusScenario` annotation is also compatible with Native. This means that if we run our tests using Native build:

--- a/quarkus-test-core/src/main/java/io/quarkus/test/configuration/PropertyLookup.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/configuration/PropertyLookup.java
@@ -67,4 +67,9 @@ public class PropertyLookup {
         String value = get();
         return Boolean.TRUE.toString().equalsIgnoreCase(value);
     }
+
+    public Integer getAsInteger() {
+        String value = get();
+        return Integer.parseInt(value);
+    }
 }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/utils/SocketUtils.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/utils/SocketUtils.java
@@ -1,22 +1,38 @@
 package io.quarkus.test.utils;
 
-import java.net.InetAddress;
+import java.io.IOException;
 import java.net.ServerSocket;
 import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
 
-import javax.net.ServerSocketFactory;
+import io.quarkus.test.configuration.PropertyLookup;
 
 public final class SocketUtils {
 
-    private static final int PORT_RANGE_MIN = 1024;
-    private static final int PORT_RANGE_MAX = 65535;
+    private static final PropertyLookup PORT_RANGE_MIN_PROPERTY = new PropertyLookup("port.range.min", "1100");
+    private static final PropertyLookup PORT_RANGE_MAX_PROPERTY = new PropertyLookup("port.range.max", "49151");
+    private static final PropertyLookup PORT_RESOLUTION_STRATEGY_PROPERTY = new PropertyLookup("port.resolution.strategy");
+
+    private static final int PORT_RANGE_MIN = PORT_RANGE_MIN_PROPERTY.getAsInteger();
+    private static final int PORT_RANGE_MAX = PORT_RANGE_MAX_PROPERTY.getAsInteger();
+    private static final String PORT_RESOLUTION_RANDOM_STRATEGY = "random";
+
+    private static final AtomicInteger CURRENT_MIN_PORT = new AtomicInteger(PORT_RANGE_MIN);
     private static final Random RND = new Random(System.nanoTime());
 
     private SocketUtils() {
 
     }
 
-    public static int findAvailablePort() {
+    public static synchronized int findAvailablePort() {
+        if (PORT_RESOLUTION_RANDOM_STRATEGY.equals(PORT_RESOLUTION_STRATEGY_PROPERTY.get())) {
+            return findRandomAvailablePort();
+        }
+
+        return findNextAvailablePort();
+    }
+
+    public static int findRandomAvailablePort() {
         int portRange = PORT_RANGE_MAX - PORT_RANGE_MIN;
         int candidatePort;
         int searchCounter = 0;
@@ -26,27 +42,40 @@ public final class SocketUtils {
                         String.format("Could not find an available port in the range [%d, %d] after %d attempts",
                                 PORT_RANGE_MIN, PORT_RANGE_MAX, searchCounter));
             }
-            candidatePort = findRandomPort(PORT_RANGE_MIN, PORT_RANGE_MAX);
+
+            candidatePort = PORT_RANGE_MIN + RND.nextInt((PORT_RANGE_MAX - PORT_RANGE_MIN) + 1);
             searchCounter++;
         } while (!isPortAvailable(candidatePort));
 
         return candidatePort;
     }
 
-    private static int findRandomPort(int minPort, int maxPort) {
-        int portRange = maxPort - minPort;
-        return minPort + RND.nextInt(portRange + 1);
+    public static synchronized int findNextAvailablePort() {
+        int candidate;
+        do {
+            candidate = CURRENT_MIN_PORT.incrementAndGet();
+            if (isPortAvailable(candidate)) {
+                return candidate;
+            }
+        } while (candidate <= PORT_RANGE_MAX);
+
+        throw new IllegalStateException(String.format("Could not find an available port in the range [%d, %d]",
+                PORT_RANGE_MIN, PORT_RANGE_MAX));
     }
 
     private static boolean isPortAvailable(int port) {
-        try {
-            ServerSocket serverSocket = ServerSocketFactory.getDefault().createServerSocket(port, 1,
-                    InetAddress.getByName("localhost"));
-            serverSocket.close();
-            return true;
-        } catch (Exception ex) {
-            return false;
+        if (port < PORT_RANGE_MIN || port > PORT_RANGE_MAX) {
+            throw new IllegalArgumentException("Invalid start port: " + port);
         }
+
+        try (ServerSocket ss = new ServerSocket(port)) {
+            ss.setReuseAddress(true);
+            return true;
+        } catch (IOException ignored) {
+            // do nothing: port not available
+        }
+
+        return false;
     }
 
 }

--- a/quarkus-test-core/src/main/resources/global.properties
+++ b/quarkus-test-core/src/main/resources/global.properties
@@ -12,3 +12,8 @@ ts.global.imagestream.install.timeout=5m
 ts.global.factor.timeout=1
 # Create default Quarkus application if no other services are defined within the scenario
 ts.global.generated-service.enabled=true
+# Port resolution
+ts.global.port.range.min=1100
+ts.global.port.range.max=49151
+## incremental (default) or random
+ts.global.port.resolution.strategy=incremental


### PR DESCRIPTION
The previous port resolution was based on Spring implementation and it was random. The problem is that we were hitting in port conflicts sometimes. 

This commit addresses the situation by changing the strategy to find an available port in an incremental manner. This implementation is based on the Apache Camel implementation.