### PR TITLE
Move on to Kafka Quarkus apicurio registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,13 +496,34 @@ public class StrimziKafkaWithRegistryMessagingIT {
 }
 ```
 
+The registry default values as `Docker image / version` and Registry API `path` could be overwritten by the following annotation properties:
+
+- registryImage, this image follow the standard docker:version format as `quay.io/apicurio/apicurio-registry-mem:2.0.0.Final`  
+- registryPath
+
+This could be useful for some cases where the registry path has changed between Quarkus/Apicurio versions. 
+
+For example, 
+
+Quarkus 1.13.7.Final
+```
+ @KafkaContainer(vendor = KafkaVendor.STRIMZI, withRegistry = true)
+ static final KafkaService kafka = new KafkaService();
+```
+
+Quarkus 2.x.Final
+```
+@KafkaContainer(vendor = KafkaVendor.STRIMZI, withRegistry = true, registryPath = "/apis/registry/v2")
+static KafkaService kafka = new KafkaService();
+```
+
 We can also use a Confluent kafka container by doing:
 
 ```java
 @KafkaContainer(vendor = KafkaVendor.CONFLUENT)
 ```
 
-Note that this implemenation supports also registry, but not Kubernetes and OpenShift scenarios.
+Note that this implementation supports also registry, but not Kubernetes and OpenShift scenarios.
 
 #### AMQ Containers
 

--- a/examples/kafka-registry/pom.xml
+++ b/examples/kafka-registry/pom.xml
@@ -14,6 +14,7 @@
         <confluent.kafka-avro-serializer.version>6.2.0</confluent.kafka-avro-serializer.version>
         <quarkiverse.apicurio.registry.client.version>0.0.2</quarkiverse.apicurio.registry.client.version>
     </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/KafkaContainer.java
+++ b/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/KafkaContainer.java
@@ -21,5 +21,9 @@ public @interface KafkaContainer {
 
     boolean withRegistry() default false;
 
+    String registryImage() default "";
+
+    String registryPath() default "";
+
     Class<? extends ManagedResourceBuilder> builder() default KafkaContainerManagedResourceBuilder.class;
 }

--- a/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/BaseKafkaContainerManagedResource.java
+++ b/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/BaseKafkaContainerManagedResource.java
@@ -49,7 +49,7 @@ public abstract class BaseKafkaContainerManagedResource extends DockerContainerM
     }
 
     protected String getKafkaRegistryImage() {
-        return model.getVendor().getRegistry().getImage() + ":" + model.getVendor().getRegistry().getDefaultVersion();
+        return model.getRegistryImageVersion();
     }
 
     protected int getKafkaRegistryPort() {
@@ -106,9 +106,9 @@ public abstract class BaseKafkaContainerManagedResource extends DockerContainerM
     }
 
     private String getSchemaRegistryUrl() {
-        return "http://" + schemaRegistry.getContainerIpAddress()
-                + ":" + schemaRegistry.getMappedPort(model.getVendor().getRegistry().getPort())
-                + model.getVendor().getRegistry().getPath();
+        String path = StringUtils.defaultIfBlank(model.getRegistryPath(), model.getVendor().getRegistry().getPath());
+        String containerIp = schemaRegistry.getContainerIpAddress();
+        return String.format("http://%s:%s%s", containerIp, schemaRegistry.getMappedPort(getKafkaRegistryPort()), path);
     }
 
 }

--- a/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/KafkaContainerManagedResourceBuilder.java
+++ b/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/KafkaContainerManagedResourceBuilder.java
@@ -11,7 +11,6 @@ import io.quarkus.test.services.containers.model.KafkaVendor;
 import io.quarkus.test.utils.PropertiesUtils;
 
 public class KafkaContainerManagedResourceBuilder implements ManagedResourceBuilder {
-
     private final ServiceLoader<KafkaContainerManagedResourceBinding> managedResourceBindingsRegistry = ServiceLoader
             .load(KafkaContainerManagedResourceBinding.class);
 
@@ -20,6 +19,8 @@ public class KafkaContainerManagedResourceBuilder implements ManagedResourceBuil
     private String image;
     private String version;
     private boolean withRegistry;
+    private String registryImage;
+    private String registryPath;
 
     protected KafkaVendor getVendor() {
         return vendor;
@@ -41,6 +42,33 @@ public class KafkaContainerManagedResourceBuilder implements ManagedResourceBuil
         return withRegistry;
     }
 
+    protected String getDefaultRegistryImageVersion() {
+        String defaultImage = getVendor().getRegistry().getImage();
+        String defaultVersion = getVendor().getRegistry().getDefaultVersion();
+        return defaultImage + ":" + defaultVersion;
+    }
+
+    protected String getRegistryImage() {
+        return registryImage;
+    }
+
+    protected String getRegistryPath() {
+        return registryPath;
+    }
+
+    protected String getRegistryImageVersion() {
+        String registryImage = getDefaultRegistryImageVersion();
+        if (!getRegistryImage().isEmpty()) {
+            String defaultVersion = getVendor().getRegistry().getDefaultVersion();
+            registryImage = getRegistryImage();
+            if (!registryImage.contains(":")) {
+                registryImage += ":" + defaultVersion;
+            }
+        }
+
+        return registryImage.toLowerCase();
+    }
+
     @Override
     public void init(Annotation annotation) {
         KafkaContainer metadata = (KafkaContainer) annotation;
@@ -48,6 +76,8 @@ public class KafkaContainerManagedResourceBuilder implements ManagedResourceBuil
         this.image = PropertiesUtils.resolveProperty(metadata.image());
         this.version = PropertiesUtils.resolveProperty(metadata.version());
         this.withRegistry = metadata.withRegistry();
+        this.registryImage = PropertiesUtils.resolveProperty(metadata.registryImage());
+        this.registryPath = PropertiesUtils.resolveProperty(metadata.registryPath());
     }
 
     @Override

--- a/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/StrimziKafkaContainerManagedResource.java
+++ b/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/StrimziKafkaContainerManagedResource.java
@@ -2,6 +2,7 @@ package io.quarkus.test.services.containers;
 
 import org.testcontainers.containers.GenericContainer;
 
+import io.quarkus.test.services.containers.model.KafkaVendor;
 import io.strimzi.StrimziKafkaContainer;
 
 public class StrimziKafkaContainerManagedResource extends BaseKafkaContainerManagedResource {
@@ -12,7 +13,7 @@ public class StrimziKafkaContainerManagedResource extends BaseKafkaContainerMana
 
     @Override
     public String getDisplayName() {
-        return "quay.io/strimzi/kafka:" + getKafkaVersion();
+        return KafkaVendor.STRIMZI.getImage() + getKafkaVersion();
     }
 
     @Override


### PR DESCRIPTION
`quarkus-apicurio-registry-avro` was released and simplify the integration of Kafka + apicurio

The only dependency that now is required is the following one: 
```
 <dependency>
       <groupId>io.quarkus</groupId>
        <artifactId>quarkus-apicurio-registry-avro</artifactId>
 </dependency>
```