### PR TITLE
Support Remote Dev testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,41 @@ app.modifyFile("src/main/java/io/quarkus/qe/GreetingResource.java",content -> co
 app.copyFile("src/test/resources/jose.properties", "src/main/resources/application.properties");
 ```
 
+### Remote Dev
+
+The test framework supports the Remote DEV mode in Quarkus for baremetal, OpenShift and Kubernetes. 
+Basically, we can deploy a Quarkus application in Remote DEV and after applying changes in the source code, these changes
+will be automatically deployed in the running application.
+
+```java
+@QuarkusScenario
+public class RemoteDevGreetingResourceIT {
+
+    static final String VICTOR_NAME = "victor";
+
+    static final String HELLO_IN_ENGLISH = "Hello";
+    static final String HELLO_IN_SPANISH = "Hola";
+
+    @RemoteDevModeQuarkusApplication
+    static DevModeQuarkusService app = new DevModeQuarkusService();
+
+    @Test
+    public void shouldUpdateResourcesAndSources() {
+        // Should say first Victor (the default name)
+        app.given().get("/greeting").then().statusCode(HttpStatus.SC_OK).body(is(HELLO_IN_ENGLISH + ", I'm " + VICTOR_NAME));
+
+        // Modify default name to manuel
+        app.modifyFile("src/main/java/io/quarkus/qe/GreetingResource.java",
+                content -> content.replace(HELLO_IN_ENGLISH, HELLO_IN_SPANISH));
+
+        // Now, the app should say Manuel
+        AwaitilityUtils.untilAsserted(
+                () -> app.given().get("/greeting").then().statusCode(HttpStatus.SC_OK)
+                        .body(is(HELLO_IN_SPANISH + ", I'm " + VICTOR_NAME)));
+    }
+}
+```
+
 ### Quarkus CLI
 
 The Quarkus Test Framework supports the usage of [the Quarkus CLI tool](https://quarkus.io/version/main/guides/cli-tooling):

--- a/examples/greetings/src/test/java/io/quarkus/qe/KubernetesRemoteDevGreetingResourceIT.java
+++ b/examples/greetings/src/test/java/io/quarkus/qe/KubernetesRemoteDevGreetingResourceIT.java
@@ -1,0 +1,9 @@
+package io.quarkus.qe;
+
+import io.quarkus.test.scenarios.KubernetesScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnNative;
+
+@KubernetesScenario
+@DisabledOnNative
+public class KubernetesRemoteDevGreetingResourceIT extends RemoteDevGreetingResourceIT {
+}

--- a/examples/greetings/src/test/java/io/quarkus/qe/OpenShiftRemoteDevGreetingResourceIT.java
+++ b/examples/greetings/src/test/java/io/quarkus/qe/OpenShiftRemoteDevGreetingResourceIT.java
@@ -1,0 +1,9 @@
+package io.quarkus.qe;
+
+import io.quarkus.test.scenarios.OpenShiftScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnNative;
+
+@OpenShiftScenario
+@DisabledOnNative
+public class OpenShiftRemoteDevGreetingResourceIT extends RemoteDevGreetingResourceIT {
+}

--- a/examples/greetings/src/test/java/io/quarkus/qe/RemoteDevGreetingResourceIT.java
+++ b/examples/greetings/src/test/java/io/quarkus/qe/RemoteDevGreetingResourceIT.java
@@ -1,0 +1,45 @@
+package io.quarkus.qe;
+
+import static org.hamcrest.Matchers.is;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.DevModeQuarkusService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnNative;
+import io.quarkus.test.services.RemoteDevModeQuarkusApplication;
+import io.quarkus.test.utils.AwaitilityUtils;
+
+@QuarkusScenario
+@DisabledOnNative
+public class RemoteDevGreetingResourceIT {
+
+    static final String VICTOR_NAME = "victor";
+
+    static final String HELLO_IN_ENGLISH = "Hello";
+    static final String HELLO_IN_SPANISH = "Hola";
+
+    @RemoteDevModeQuarkusApplication
+    static DevModeQuarkusService app = new DevModeQuarkusService();
+
+    @Test
+    public void shouldUpdateResourcesAndSources() {
+        // Should say first Victor (the default name)
+        app.given().get("/greeting").then().statusCode(HttpStatus.SC_OK).body(is(HELLO_IN_ENGLISH + ", I'm " + VICTOR_NAME));
+
+        // Modify default name to manuel
+        app.modifyFile("src/main/java/io/quarkus/qe/GreetingResource.java",
+                content -> content.replace(HELLO_IN_ENGLISH, HELLO_IN_SPANISH));
+
+        // Now, the app should say Manuel
+        AwaitilityUtils.untilAsserted(
+                () -> app.given().get("/greeting").then().statusCode(HttpStatus.SC_OK)
+                        .body(is(HELLO_IN_SPANISH + ", I'm " + VICTOR_NAME)));
+    }
+
+    @Test
+    public void shouldLoadResources() {
+        app.given().get("/greeting/file").then().statusCode(HttpStatus.SC_OK).body(is("found!"));
+    }
+}

--- a/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/DevModeQuarkusService.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/DevModeQuarkusService.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.List;
@@ -21,8 +20,6 @@ import com.gargoylesoftware.htmlunit.WebClient;
 import com.gargoylesoftware.htmlunit.html.HtmlElement;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 
-import io.quarkus.test.services.DevModeQuarkusApplication;
-
 public class DevModeQuarkusService extends RestService {
     public static final String DEV_UI_PATH = "/q/dev";
 
@@ -35,7 +32,7 @@ public class DevModeQuarkusService extends RestService {
     public DevModeQuarkusService enableContinuousTesting() {
         HtmlPage webDevUi = webDevUiPage();
 
-        // If the enable continuous testing btn is not found, we assume it's already enabled it.
+        // If the "enable continuous testing" btn is not found, we assume it's already enabled it.
         if (isContinuousTestingBtnDisabled(webDevUi)) {
             clickOnElement(getContinuousTestingBtn(webDevUi));
         }
@@ -65,13 +62,6 @@ public class DevModeQuarkusService extends RestService {
             targetPath.setLastModified(System.currentTimeMillis());
         } catch (IOException e) {
             Assertions.fail("Error copying file. Caused by " + e.getMessage());
-        }
-    }
-
-    @Override
-    public void validate(Field field) {
-        if (!field.isAnnotationPresent(DevModeQuarkusApplication.class)) {
-            Assertions.fail("DevModeQuarkusService service is not annotated with DevModeQuarkusApplication");
         }
     }
 
@@ -113,10 +103,6 @@ public class DevModeQuarkusService extends RestService {
         }
     }
 
-    private void waitUntilLoaded(HtmlPage page) {
-        page.getEnclosingWindow().getJobManager().waitForJobs(JAVASCRIPT_WAIT_TIMEOUT_MILLIS);
-    }
-
     public HtmlPage webPage(String path) {
         try {
             return webClient().getPage(getHost() + ":" + getPort() + path);
@@ -146,11 +132,7 @@ public class DevModeQuarkusService extends RestService {
         return webClient;
     }
 
-    private static void sleep(int millis) {
-        try {
-            Thread.sleep(millis);
-        } catch (InterruptedException ignored) {
-
-        }
+    private void waitUntilLoaded(HtmlPage page) {
+        page.getEnclosingWindow().getJobManager().waitForJobs(JAVASCRIPT_WAIT_TIMEOUT_MILLIS);
     }
 }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/RemoteDevModeQuarkusApplication.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/RemoteDevModeQuarkusApplication.java
@@ -1,0 +1,12 @@
+package io.quarkus.test.services;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RemoteDevModeQuarkusApplication {
+    String password() default "qe";
+}

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/ArtifactQuarkusApplicationManagedResourceBuilder.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/ArtifactQuarkusApplicationManagedResourceBuilder.java
@@ -1,0 +1,7 @@
+package io.quarkus.test.services.quarkus;
+
+import java.nio.file.Path;
+
+public abstract class ArtifactQuarkusApplicationManagedResourceBuilder extends QuarkusApplicationManagedResourceBuilder {
+    protected abstract Path getArtifact();
+}

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/LocalhostQuarkusApplicationManagedResource.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/LocalhostQuarkusApplicationManagedResource.java
@@ -55,11 +55,14 @@ public abstract class LocalhostQuarkusApplicationManagedResource extends Quarkus
             List<String> command = prepareCommand(getPropertiesForCommand());
             Log.info("Running command: %s", String.join(" ", command));
 
-            process = ProcessBuilderProvider.command(command)
+            ProcessBuilder pb = ProcessBuilderProvider.command(command)
                     .redirectErrorStream(true)
-                    .redirectOutput(logOutputFile)
-                    .directory(getApplicationFolder().toFile())
-                    .start();
+                    .redirectOutput(getLogOutputFile())
+                    .directory(getApplicationFolder().toFile());
+
+            onPreStart(pb);
+
+            process = pb.start();
 
             loggingHandler = new FileServiceLoggingHandler(model.getContext().getOwner(), logOutputFile);
             loggingHandler.startWatching();
@@ -121,8 +124,16 @@ public abstract class LocalhostQuarkusApplicationManagedResource extends Quarkus
         return loggingHandler;
     }
 
+    protected File getLogOutputFile() {
+        return logOutputFile;
+    }
+
     protected Path getApplicationFolder() {
         return model.getContext().getServiceFolder();
+    }
+
+    protected void onPreStart(ProcessBuilder pb) {
+
     }
 
     private void assignPorts() {

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/ProdQuarkusApplicationManagedResourceBuilder.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/ProdQuarkusApplicationManagedResourceBuilder.java
@@ -25,7 +25,7 @@ import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.test.services.quarkus.model.QuarkusProperties;
 import io.quarkus.test.utils.ReflectionUtils;
 
-public class ProdQuarkusApplicationManagedResourceBuilder extends QuarkusApplicationManagedResourceBuilder {
+public class ProdQuarkusApplicationManagedResourceBuilder extends ArtifactQuarkusApplicationManagedResourceBuilder {
 
     protected static final String TARGET = "target";
 
@@ -41,6 +41,7 @@ public class ProdQuarkusApplicationManagedResourceBuilder extends QuarkusApplica
     private Path artifact;
     private QuarkusManagedResource managedResource;
 
+    @Override
     protected Path getArtifact() {
         return artifact;
     }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusManagedResource.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusManagedResource.java
@@ -16,7 +16,8 @@ public abstract class QuarkusManagedResource implements ManagedResource {
             "Failed to load config value of type class",
             "Quarkus may already be running or the port is used by another application",
             "One or more configuration errors have prevented the application from starting",
-            "Attempting to start live reload endpoint to recover from previous Quarkus startup failure");
+            "Attempting to start live reload endpoint to recover from previous Quarkus startup failure",
+            "Dev mode process did not complete successfully");
 
     private final ServiceContext serviceContext;
     private final LaunchMode launchMode;

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/RemoteDevModeLocalhostQuarkusApplicationManagedResource.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/RemoteDevModeLocalhostQuarkusApplicationManagedResource.java
@@ -1,0 +1,87 @@
+package io.quarkus.test.services.quarkus;
+
+import static io.quarkus.test.services.quarkus.RemoteDevModeQuarkusApplicationManagedResourceBuilder.EXPECTED_OUTPUT_FROM_REMOTE_DEV_DAEMON;
+import static io.quarkus.test.services.quarkus.RemoteDevModeQuarkusApplicationManagedResourceBuilder.QUARKUS_LAUNCH_DEV_MODE;
+import static io.quarkus.test.services.quarkus.RemoteDevModeQuarkusApplicationManagedResourceBuilder.QUARKUS_LIVE_RELOAD_PASSWORD;
+import static io.quarkus.test.utils.MavenUtils.withProperty;
+
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
+
+import io.quarkus.test.logging.Log;
+import io.quarkus.test.services.quarkus.model.LaunchMode;
+import io.quarkus.test.utils.ProcessUtils;
+
+public class RemoteDevModeLocalhostQuarkusApplicationManagedResource extends LocalhostQuarkusApplicationManagedResource {
+
+    private static final String JAVA = "java";
+
+    private final RemoteDevModeQuarkusApplicationManagedResourceBuilder model;
+
+    private Process remoteDevProcess;
+
+    public RemoteDevModeLocalhostQuarkusApplicationManagedResource(
+            RemoteDevModeQuarkusApplicationManagedResourceBuilder model) {
+        super(model);
+        this.model = model;
+    }
+
+    @Override
+    public boolean isRunning() {
+        if (super.isRunning()) {
+            // We need to wait for the remote dev daemon to be started
+            if (remoteDevProcess == null) {
+                startRemoteDevProcess();
+            }
+
+            if (getLoggingHandler().logsContains(EXPECTED_OUTPUT_FROM_REMOTE_DEV_DAEMON)) {
+                getLoggingHandler().flush();
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    @Override
+    public void stop() {
+        super.stop();
+        ProcessUtils.destroy(remoteDevProcess);
+    }
+
+    @Override
+    protected LaunchMode getLaunchMode() {
+        return LaunchMode.REMOTE_DEV;
+    }
+
+    protected List<String> prepareCommand(List<String> systemProperties) {
+        List<String> command = new LinkedList<>();
+        command.add(JAVA);
+        command.add(withProperty(QUARKUS_LIVE_RELOAD_PASSWORD, model.getLiveReloadPassword()));
+        command.addAll(systemProperties);
+        command.add("-jar");
+        command.add(model.getArtifact().toAbsolutePath().toString());
+        return command;
+    }
+
+    @Override
+    protected void onPreStart(ProcessBuilder pb) {
+        super.onPreStart(pb);
+
+        pb.environment().put(QUARKUS_LAUNCH_DEV_MODE, Boolean.TRUE.toString());
+    }
+
+    private synchronized void startRemoteDevProcess() {
+        if (remoteDevProcess == null) {
+            ProcessBuilder pb = model.prepareRemoteDevProcess();
+            pb.redirectOutput(ProcessBuilder.Redirect.appendTo(getLogOutputFile()));
+
+            try {
+                remoteDevProcess = pb.start();
+            } catch (IOException e) {
+                Log.error(getContext().getOwner(), "Failed to start the remote dev process. Caused by " + e.getMessage());
+            }
+        }
+    }
+}

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/RemoteDevModeQuarkusApplicationAnnotationBinding.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/RemoteDevModeQuarkusApplicationAnnotationBinding.java
@@ -1,0 +1,25 @@
+package io.quarkus.test.services.quarkus;
+
+import java.lang.reflect.Field;
+
+import io.quarkus.test.bootstrap.AnnotationBinding;
+import io.quarkus.test.bootstrap.ManagedResourceBuilder;
+import io.quarkus.test.services.RemoteDevModeQuarkusApplication;
+
+public class RemoteDevModeQuarkusApplicationAnnotationBinding implements AnnotationBinding {
+
+    @Override
+    public boolean isFor(Field field) {
+        return field.isAnnotationPresent(RemoteDevModeQuarkusApplication.class);
+    }
+
+    @Override
+    public ManagedResourceBuilder createBuilder(Field field) {
+        RemoteDevModeQuarkusApplication metadata = field.getAnnotation(RemoteDevModeQuarkusApplication.class);
+
+        ManagedResourceBuilder builder = new RemoteDevModeQuarkusApplicationManagedResourceBuilder();
+        builder.init(metadata);
+        return builder;
+    }
+
+}

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/RemoteDevModeQuarkusApplicationManagedResourceBinding.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/RemoteDevModeQuarkusApplicationManagedResourceBinding.java
@@ -1,0 +1,19 @@
+package io.quarkus.test.services.quarkus;
+
+import io.quarkus.test.bootstrap.ServiceContext;
+
+public interface RemoteDevModeQuarkusApplicationManagedResourceBinding {
+    /**
+     * @param context
+     * @return if the current managed resource applies for the current context.
+     */
+    boolean appliesFor(ServiceContext context);
+
+    /**
+     * Init and return the managed resource for the current context.
+     *
+     * @param builder
+     * @return
+     */
+    QuarkusManagedResource init(RemoteDevModeQuarkusApplicationManagedResourceBuilder builder);
+}

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/RemoteDevModeQuarkusApplicationManagedResourceBuilder.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/RemoteDevModeQuarkusApplicationManagedResourceBuilder.java
@@ -1,0 +1,132 @@
+package io.quarkus.test.services.quarkus;
+
+import static io.quarkus.test.utils.FileUtils.findTargetFile;
+import static io.quarkus.test.utils.MavenUtils.SKIP_CHECKSTYLE;
+import static io.quarkus.test.utils.MavenUtils.SKIP_ITS;
+import static io.quarkus.test.utils.MavenUtils.SKIP_TESTS;
+import static io.quarkus.test.utils.MavenUtils.installParentPomsIfNeeded;
+import static io.quarkus.test.utils.MavenUtils.withProperty;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.lang.annotation.Annotation;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.ServiceLoader;
+
+import io.quarkus.test.bootstrap.ManagedResource;
+import io.quarkus.test.bootstrap.Protocol;
+import io.quarkus.test.bootstrap.ServiceContext;
+import io.quarkus.test.logging.Log;
+import io.quarkus.test.services.RemoteDevModeQuarkusApplication;
+import io.quarkus.test.services.quarkus.model.QuarkusProperties;
+import io.quarkus.test.utils.FileUtils;
+import io.quarkus.test.utils.MavenUtils;
+import io.quarkus.test.utils.ProcessBuilderProvider;
+
+public class RemoteDevModeQuarkusApplicationManagedResourceBuilder extends ArtifactQuarkusApplicationManagedResourceBuilder {
+
+    public static final String QUARKUS_LIVE_RELOAD_PASSWORD = "quarkus.live-reload.password";
+    public static final String QUARKUS_LAUNCH_DEV_MODE = "QUARKUS_LAUNCH_DEVMODE";
+    public static final String EXPECTED_OUTPUT_FROM_REMOTE_DEV_DAEMON = "Connected to remote server";
+
+    private static final String QUARKUS_LIVE_RELOAD_URL = "quarkus.live-reload.url";
+    private static final String QUARKUS_APP = "quarkus-app";
+    private static final String QUARKUS_RUN = "quarkus-run.jar";
+    private static final String TARGET = "target";
+    private static final String RUNNER = "runner";
+
+    private final ServiceLoader<RemoteDevModeQuarkusApplicationManagedResourceBinding> bindings = ServiceLoader
+            .load(RemoteDevModeQuarkusApplicationManagedResourceBinding.class);
+
+    private String liveReloadPassword;
+    private Path artifact;
+    private QuarkusManagedResource managedResource;
+
+    @Override
+    public void init(Annotation annotation) {
+        RemoteDevModeQuarkusApplication metadata = (RemoteDevModeQuarkusApplication) annotation;
+        liveReloadPassword = metadata.password();
+    }
+
+    @Override
+    public ManagedResource build(ServiceContext context) {
+        setContext(context);
+        configureLogging();
+        managedResource = findManagedResource();
+        build();
+
+        managedResource.validate();
+        return managedResource;
+    }
+
+    @Override
+    protected void build() {
+        try {
+            FileUtils.copyCurrentDirectoryTo(getContext().getServiceFolder());
+            copyResourcesToAppFolder();
+
+            // Create mutable jar
+            installParentPomsIfNeeded();
+            MavenUtils.build(getContext(), Arrays.asList(SKIP_ITS, SKIP_TESTS, SKIP_CHECKSTYLE,
+                    withProperty(QuarkusProperties.PACKAGE_TYPE_NAME, QuarkusProperties.MUTABLE_JAR)));
+
+            // Move artifact to an isolated location
+            FileUtils.copyDirectoryTo(getContext().getServiceFolder().resolve(TARGET),
+                    getContext().getServiceFolder().resolve(RUNNER));
+
+            // Locate artifacts
+            Path target = getContext().getServiceFolder().resolve(RUNNER).resolve(QUARKUS_APP);
+            Optional<String> artifactLocation = findTargetFile(target, QUARKUS_RUN);
+            if (artifactLocation.isEmpty()) {
+                fail("Quarkus runner could not be found for mutable-jar type");
+            }
+
+            this.artifact = Path.of(artifactLocation.get());
+        } catch (Exception ex) {
+            fail("Failed to build Quarkus artifacts. Caused by " + ex);
+        }
+    }
+
+    @Override
+    protected Path getResourcesApplicationFolder() {
+        return super.getResourcesApplicationFolder().resolve(RESOURCES_FOLDER);
+    }
+
+    @Override
+    protected Path getArtifact() {
+        return artifact;
+    }
+
+    protected String getLiveReloadPassword() {
+        return liveReloadPassword;
+    }
+
+    protected QuarkusManagedResource findManagedResource() {
+        for (RemoteDevModeQuarkusApplicationManagedResourceBinding binding : bindings) {
+            if (binding.appliesFor(getContext())) {
+                return binding.init(this);
+            }
+        }
+
+        return new RemoteDevModeLocalhostQuarkusApplicationManagedResource(this);
+    }
+
+    protected ProcessBuilder prepareRemoteDevProcess() {
+        Log.info("Running Remote Dev daemon to watch changes");
+
+        List<String> command = MavenUtils.mvnCommand(getContext());
+        command.add(withProperty(QuarkusProperties.PACKAGE_TYPE_NAME, QuarkusProperties.MUTABLE_JAR));
+        command.add(withProperty(QUARKUS_LIVE_RELOAD_PASSWORD, liveReloadPassword));
+        command.add(withProperty(QUARKUS_LIVE_RELOAD_URL,
+                managedResource.getHost(Protocol.HTTP) + ":" + managedResource.getPort(Protocol.HTTP)));
+        command.add("quarkus:remote-dev");
+
+        Log.info("Running command: %s", String.join(" ", command));
+
+        return ProcessBuilderProvider.command(command)
+                .redirectErrorStream(true)
+                .directory(getApplicationFolder().toFile());
+    }
+}

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/model/LaunchMode.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/model/LaunchMode.java
@@ -4,7 +4,8 @@ public enum LaunchMode {
     LEGACY_JAR("legacy-jar"),
     NATIVE("native"),
     JVM("jvm"),
-    DEV("dev");
+    DEV("dev"),
+    REMOTE_DEV("remote-dev");
 
     private final String name;
 

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/model/QuarkusProperties.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/model/QuarkusProperties.java
@@ -8,7 +8,9 @@ import io.quarkus.test.configuration.PropertyLookup;
 
 public final class QuarkusProperties {
 
-    public static final PropertyLookup PACKAGE_TYPE = new PropertyLookup("quarkus.package.type");
+    public static final String PACKAGE_TYPE_NAME = "quarkus.package.type";
+    public static final String MUTABLE_JAR = "mutable-jar";
+    public static final PropertyLookup PACKAGE_TYPE = new PropertyLookup(PACKAGE_TYPE_NAME);
     public static final List<String> PACKAGE_TYPE_NATIVE_VALUES = Arrays.asList("native", "native-sources");
     public static final List<String> PACKAGE_TYPE_LEGACY_JAR_VALUES = Arrays.asList("legacy-jar", "uber-jar", "mutable-jar");
     public static final List<String> PACKAGE_TYPE_JVM_VALUES = Arrays.asList("fast-jar", "jar");

--- a/quarkus-test-core/src/main/java/io/quarkus/test/utils/FileUtils.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/utils/FileUtils.java
@@ -14,7 +14,6 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.StringUtils;
 
 public final class FileUtils {
 
@@ -92,13 +91,16 @@ public final class FileUtils {
         }
     }
 
-    public static void copyCurrentDirectoryTo(Path target) {
+    public static void copyDirectoryTo(Path source, Path target) {
         try {
-            org.apache.commons.io.FileUtils.copyDirectory(Paths.get(".").toFile(), target.toFile(),
-                    path -> !StringUtils.contains(path.toString(), TARGET));
+            org.apache.commons.io.FileUtils.copyDirectory(source.toFile(), target.toFile());
         } catch (IOException e) {
             fail("Could not copy project. Caused by " + e.getMessage());
         }
+    }
+
+    public static void copyCurrentDirectoryTo(Path target) {
+        copyDirectoryTo(Paths.get("."), target);
     }
 
     public static void deletePath(Path folder) {

--- a/quarkus-test-core/src/main/java/io/quarkus/test/utils/MavenUtils.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/utils/MavenUtils.java
@@ -39,9 +39,15 @@ public final class MavenUtils {
 
     }
 
+    public static void build(ServiceContext serviceContext, List<String> extraMavenArgs) {
+        build(serviceContext, serviceContext.getServiceFolder(), extraMavenArgs);
+    }
+
     public static void build(ServiceContext serviceContext, Path basePath, List<String> extraMavenArgs) {
         List<String> command = mvnCommand(serviceContext);
         command.addAll(extraMavenArgs);
+        command.add(DISPLAY_ERRORS);
+        command.add(DISPLAY_VERSION);
         command.add(PACKAGE_GOAL);
         try {
             new Command(command)

--- a/quarkus-test-core/src/main/resources/META-INF/services/io.quarkus.test.bootstrap.AnnotationBinding
+++ b/quarkus-test-core/src/main/resources/META-INF/services/io.quarkus.test.bootstrap.AnnotationBinding
@@ -1,3 +1,4 @@
 io.quarkus.test.services.quarkus.QuarkusApplicationAnnotationBinding
 io.quarkus.test.services.quarkus.DevModeQuarkusApplicationAnnotationBinding
+io.quarkus.test.services.quarkus.RemoteDevModeQuarkusApplicationAnnotationBinding
 io.quarkus.test.services.quarkus.GitRepositoryQuarkusApplicationAnnotationBinding

--- a/quarkus-test-core/src/main/resources/build-time-list
+++ b/quarkus-test-core/src/main/resources/build-time-list
@@ -71,6 +71,7 @@ quarkus.opentelemetry.enabled
 quarkus.opentelemetry.tracer.enabled
 quarkus.opentelemetry.tracer.exporter.jaeger.enabled
 quarkus.opentelemetry.tracer.exporter.otlp.enabled
+quarkus.package.type
 quarkus.reactive-messaging.health.enabled
 quarkus.reactive-messaging.kafka.serializer-autodetection.enabled
 quarkus.reactive-messaging.metrics.enabled

--- a/quarkus-test-kubernetes/src/main/java/io/quarkus/test/bootstrap/inject/KubectlClient.java
+++ b/quarkus-test-kubernetes/src/main/java/io/quarkus/test/bootstrap/inject/KubectlClient.java
@@ -6,6 +6,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -92,12 +93,19 @@ public final class KubectlClient {
     /**
      * Update the file and then apply the file into Kubernetes.
      * A copy of the end template will be placed in the target location.
-     *
-     * @param file
      */
     public void applyServiceProperties(Service service, String file, UnaryOperator<String> update, Path target) {
+        applyServiceProperties(service, file, update, Collections.emptyMap(), target);
+    }
+
+    /**
+     * Update the file with extra template properties and then apply the file into Kubernetes.
+     * A copy of the end template will be placed in the target location.
+     */
+    public void applyServiceProperties(Service service, String file, UnaryOperator<String> update,
+            Map<String, String> extraTemplateProperties, Path target) {
         String content = FileUtils.loadFile(file);
-        content = enrichTemplate(service, update.apply(content));
+        content = enrichTemplate(service, update.apply(content), extraTemplateProperties);
         apply(service, FileUtils.copyContentTo(content, target));
     }
 
@@ -238,7 +246,7 @@ public final class KubectlClient {
         return client.load(new ByteArrayInputStream(template.getBytes())).get();
     }
 
-    private String enrichTemplate(Service service, String template) {
+    private String enrichTemplate(Service service, String template, Map<String, String> extraTemplateProperties) {
         List<HasMetadata> objs = loadYaml(template);
         for (HasMetadata obj : objs) {
             // set namespace
@@ -258,6 +266,7 @@ public final class KubectlClient {
 
                 // add env var properties
                 Map<String, String> enrichProperties = enrichProperties(service.getProperties(), d);
+                enrichProperties.putAll(extraTemplateProperties);
                 d.getSpec().getTemplate().getSpec().getContainers()
                         .forEach(container -> enrichProperties.entrySet().forEach(property -> {
                             String key = property.getKey();

--- a/quarkus-test-kubernetes/src/main/java/io/quarkus/test/services/quarkus/KubernetesQuarkusApplicationManagedResource.java
+++ b/quarkus-test-kubernetes/src/main/java/io/quarkus/test/services/quarkus/KubernetesQuarkusApplicationManagedResource.java
@@ -5,7 +5,9 @@ import static io.quarkus.test.services.quarkus.QuarkusApplicationManagedResource
 import static java.util.regex.Pattern.quote;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -23,7 +25,7 @@ public class KubernetesQuarkusApplicationManagedResource extends QuarkusManagedR
     private static final String QUARKUS_KUBERNETES_TEMPLATE = "/quarkus-app-kubernetes-template.yml";
     private static final String DEPLOYMENT = "kubernetes.yml";
 
-    private final ProdQuarkusApplicationManagedResourceBuilder model;
+    private final ArtifactQuarkusApplicationManagedResourceBuilder model;
     private final KubectlClient client;
 
     private LoggingHandler loggingHandler;
@@ -31,7 +33,7 @@ public class KubernetesQuarkusApplicationManagedResource extends QuarkusManagedR
     private boolean running;
     private String image;
 
-    public KubernetesQuarkusApplicationManagedResource(ProdQuarkusApplicationManagedResourceBuilder model) {
+    public KubernetesQuarkusApplicationManagedResource(ArtifactQuarkusApplicationManagedResourceBuilder model) {
         super(model.getContext());
         this.model = model;
         this.client = model.getContext().get(KubernetesExtensionBootstrap.CLIENT);
@@ -100,6 +102,10 @@ public class KubernetesQuarkusApplicationManagedResource extends QuarkusManagedR
         return loggingHandler;
     }
 
+    protected Map<String, String> addExtraTemplateProperties() {
+        return Collections.emptyMap();
+    }
+
     private void validateProtocol(Protocol protocol) {
         if (protocol == Protocol.HTTPS) {
             fail("SSL is not supported for Kubernetes tests yet");
@@ -116,7 +122,9 @@ public class KubernetesQuarkusApplicationManagedResource extends QuarkusManagedR
         String deploymentFile = model.getContext().getOwner().getConfiguration().getOrDefault(DEPLOYMENT_TEMPLATE_PROPERTY,
                 QUARKUS_KUBERNETES_TEMPLATE);
         client.applyServiceProperties(model.getContext().getOwner(), deploymentFile,
-                this::replaceDeploymentContent, model.getContext().getServiceFolder().resolve(DEPLOYMENT));
+                this::replaceDeploymentContent,
+                addExtraTemplateProperties(),
+                model.getContext().getServiceFolder().resolve(DEPLOYMENT));
     }
 
     private String replaceDeploymentContent(String content) {

--- a/quarkus-test-kubernetes/src/main/java/io/quarkus/test/services/quarkus/KubernetesRemoteDevModeQuarkusApplicationManagedResourceBinding.java
+++ b/quarkus-test-kubernetes/src/main/java/io/quarkus/test/services/quarkus/KubernetesRemoteDevModeQuarkusApplicationManagedResourceBinding.java
@@ -1,0 +1,18 @@
+package io.quarkus.test.services.quarkus;
+
+import io.quarkus.test.bootstrap.ServiceContext;
+import io.quarkus.test.scenarios.KubernetesScenario;
+
+public class KubernetesRemoteDevModeQuarkusApplicationManagedResourceBinding
+        implements RemoteDevModeQuarkusApplicationManagedResourceBinding {
+
+    @Override
+    public boolean appliesFor(ServiceContext context) {
+        return context.getTestContext().getRequiredTestClass().isAnnotationPresent(KubernetesScenario.class);
+    }
+
+    @Override
+    public QuarkusManagedResource init(RemoteDevModeQuarkusApplicationManagedResourceBuilder builder) {
+        return new RemoteDevModeKubernetesQuarkusApplicationManagedResource(builder);
+    }
+}

--- a/quarkus-test-kubernetes/src/main/java/io/quarkus/test/services/quarkus/RemoteDevModeKubernetesQuarkusApplicationManagedResource.java
+++ b/quarkus-test-kubernetes/src/main/java/io/quarkus/test/services/quarkus/RemoteDevModeKubernetesQuarkusApplicationManagedResource.java
@@ -1,0 +1,88 @@
+package io.quarkus.test.services.quarkus;
+
+import static io.quarkus.test.services.quarkus.RemoteDevModeQuarkusApplicationManagedResourceBuilder.EXPECTED_OUTPUT_FROM_REMOTE_DEV_DAEMON;
+import static io.quarkus.test.services.quarkus.RemoteDevModeQuarkusApplicationManagedResourceBuilder.QUARKUS_LAUNCH_DEV_MODE;
+import static io.quarkus.test.services.quarkus.RemoteDevModeQuarkusApplicationManagedResourceBuilder.QUARKUS_LIVE_RELOAD_PASSWORD;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import io.quarkus.test.logging.FileServiceLoggingHandler;
+import io.quarkus.test.logging.Log;
+import io.quarkus.test.logging.LoggingHandler;
+import io.quarkus.test.utils.ProcessUtils;
+
+public class RemoteDevModeKubernetesQuarkusApplicationManagedResource extends KubernetesQuarkusApplicationManagedResource {
+
+    private static final String REMOTE_DEV_LOG_OUTPUT_FILE = "remote-dev-out.log";
+
+    private final RemoteDevModeQuarkusApplicationManagedResourceBuilder model;
+
+    private Process remoteDevProcess;
+    private File remoteDevLogFile;
+    private LoggingHandler remoteDevLoggingHandler;
+
+    public RemoteDevModeKubernetesQuarkusApplicationManagedResource(
+            RemoteDevModeQuarkusApplicationManagedResourceBuilder model) {
+        super(model);
+
+        this.model = model;
+        this.remoteDevLogFile = new File(model.getContext().getServiceFolder().resolve(REMOTE_DEV_LOG_OUTPUT_FILE).toString());
+    }
+
+    @Override
+    public boolean isRunning() {
+        if (super.isRunning()) {
+            // We need to wait for the remote dev daemon to be started
+            if (remoteDevProcess == null) {
+                startRemoteDevProcess();
+            }
+
+            if (remoteDevLoggingHandler != null
+                    && remoteDevLoggingHandler.logsContains(EXPECTED_OUTPUT_FROM_REMOTE_DEV_DAEMON)) {
+                remoteDevLoggingHandler.flush();
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    @Override
+    public void stop() {
+        super.stop();
+        if (remoteDevLoggingHandler != null) {
+            remoteDevLoggingHandler.stopWatching();
+        }
+
+        ProcessUtils.destroy(remoteDevProcess);
+    }
+
+    @Override
+    protected Map<String, String> addExtraTemplateProperties() {
+        Map<String, String> templateProperties = new HashMap<>();
+        templateProperties.putAll(super.addExtraTemplateProperties());
+        templateProperties.put(QUARKUS_LAUNCH_DEV_MODE, Boolean.TRUE.toString());
+        templateProperties.put(QUARKUS_LIVE_RELOAD_PASSWORD, model.getLiveReloadPassword());
+
+        return templateProperties;
+    }
+
+    private synchronized void startRemoteDevProcess() {
+        if (remoteDevProcess == null) {
+            ProcessBuilder pb = model.prepareRemoteDevProcess();
+            pb.redirectOutput(remoteDevLogFile);
+
+            try {
+                remoteDevProcess = pb.start();
+
+                remoteDevLoggingHandler = new FileServiceLoggingHandler(model.getContext().getOwner(), remoteDevLogFile);
+                remoteDevLoggingHandler.startWatching();
+            } catch (IOException e) {
+                Log.error(getContext().getOwner(), "Failed to start the remote dev process. Caused by " + e.getMessage());
+            }
+        }
+    }
+}

--- a/quarkus-test-kubernetes/src/main/resources/META-INF/services/io.quarkus.test.services.quarkus.RemoteDevModeQuarkusApplicationManagedResourceBinding
+++ b/quarkus-test-kubernetes/src/main/resources/META-INF/services/io.quarkus.test.services.quarkus.RemoteDevModeQuarkusApplicationManagedResourceBinding
@@ -1,0 +1,1 @@
+io.quarkus.test.services.quarkus.KubernetesRemoteDevModeQuarkusApplicationManagedResourceBinding

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
@@ -13,6 +13,7 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -154,12 +155,19 @@ public final class OpenShiftClient {
     /**
      * Update the file and then apply the file into Kubernetes.
      * A copy of the end template will be placed in the target location.
-     *
-     * @param file
      */
     public void applyServicePropertiesUsingTemplate(Service service, String file, UnaryOperator<String> update, Path target) {
+        applyServicePropertiesUsingTemplate(service, file, update, Collections.emptyMap(), target);
+    }
+
+    /**
+     * Update the file with extra template properties, and then apply the file into Kubernetes.
+     * A copy of the end template will be placed in the target location.
+     */
+    public void applyServicePropertiesUsingTemplate(Service service, String file, UnaryOperator<String> update,
+            Map<String, String> extraTemplateProperties, Path target) {
         String content = FileUtils.loadFile(file);
-        content = enrichTemplate(service, update.apply(content));
+        content = enrichTemplate(service, update.apply(content), extraTemplateProperties);
         apply(FileUtils.copyContentTo(content, target));
     }
 
@@ -520,7 +528,7 @@ public final class OpenShiftClient {
         }
     }
 
-    private String enrichTemplate(Service service, String template) {
+    private String enrichTemplate(Service service, String template, Map<String, String> extraTemplateProperties) {
         List<HasMetadata> objs = loadYaml(template);
         for (HasMetadata obj : objs) {
             // set namespace
@@ -540,6 +548,7 @@ public final class OpenShiftClient {
 
                 // add env var properties
                 Map<String, String> enrichProperties = enrichProperties(service.getProperties(), dc);
+                enrichProperties.putAll(extraTemplateProperties);
                 dc.getSpec().getTemplate().getSpec().getContainers()
                         .forEach(container -> enrichProperties.entrySet().forEach(
                                 property -> {

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/BuildOpenShiftQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/BuildOpenShiftQuarkusApplicationManagedResource.java
@@ -10,7 +10,7 @@ import io.quarkus.test.configuration.PropertyLookup;
 import io.quarkus.test.utils.Command;
 
 public class BuildOpenShiftQuarkusApplicationManagedResource
-        extends TemplateOpenShiftQuarkusApplicationManagedResource<ProdQuarkusApplicationManagedResourceBuilder> {
+        extends TemplateOpenShiftQuarkusApplicationManagedResource<ArtifactQuarkusApplicationManagedResourceBuilder> {
 
     private static final String S2I_DEFAULT_VERSION = "latest";
 
@@ -23,7 +23,7 @@ public class BuildOpenShiftQuarkusApplicationManagedResource
     private static final PropertyLookup UBI_QUARKUS_NATIVE_S2I = new PropertyLookup("quarkus.s2i.base-native-image",
             "quay.io/quarkus/ubi-quarkus-native-binary-s2i:1.0");
 
-    public BuildOpenShiftQuarkusApplicationManagedResource(ProdQuarkusApplicationManagedResourceBuilder model) {
+    public BuildOpenShiftQuarkusApplicationManagedResource(ArtifactQuarkusApplicationManagedResourceBuilder model) {
         super(model);
     }
 
@@ -56,7 +56,7 @@ public class BuildOpenShiftQuarkusApplicationManagedResource
     private void startBuild() {
         String fromArg = "--from-dir=" + model.getArtifact().toAbsolutePath().getParent().toString();
         if (isNativeTest()) {
-            fromArg = "--from-file=" + model.getArtifact().toAbsolutePath().toString();
+            fromArg = "--from-file=" + model.getArtifact().toAbsolutePath();
         }
 
         try {

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftRemoteDevModeQuarkusApplicationManagedResourceBinding.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftRemoteDevModeQuarkusApplicationManagedResourceBinding.java
@@ -1,0 +1,18 @@
+package io.quarkus.test.services.quarkus;
+
+import io.quarkus.test.bootstrap.ServiceContext;
+import io.quarkus.test.scenarios.OpenShiftScenario;
+
+public class OpenShiftRemoteDevModeQuarkusApplicationManagedResourceBinding
+        implements RemoteDevModeQuarkusApplicationManagedResourceBinding {
+
+    @Override
+    public boolean appliesFor(ServiceContext context) {
+        return context.getTestContext().getRequiredTestClass().isAnnotationPresent(OpenShiftScenario.class);
+    }
+
+    @Override
+    public QuarkusManagedResource init(RemoteDevModeQuarkusApplicationManagedResourceBuilder builder) {
+        return new RemoteDevModeBuildOpenShiftQuarkusApplicationManagedResource(builder);
+    }
+}

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/RemoteDevModeBuildOpenShiftQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/RemoteDevModeBuildOpenShiftQuarkusApplicationManagedResource.java
@@ -1,0 +1,89 @@
+package io.quarkus.test.services.quarkus;
+
+import static io.quarkus.test.services.quarkus.RemoteDevModeQuarkusApplicationManagedResourceBuilder.EXPECTED_OUTPUT_FROM_REMOTE_DEV_DAEMON;
+import static io.quarkus.test.services.quarkus.RemoteDevModeQuarkusApplicationManagedResourceBuilder.QUARKUS_LAUNCH_DEV_MODE;
+import static io.quarkus.test.services.quarkus.RemoteDevModeQuarkusApplicationManagedResourceBuilder.QUARKUS_LIVE_RELOAD_PASSWORD;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import io.quarkus.test.logging.FileServiceLoggingHandler;
+import io.quarkus.test.logging.Log;
+import io.quarkus.test.logging.LoggingHandler;
+import io.quarkus.test.utils.ProcessUtils;
+
+public class RemoteDevModeBuildOpenShiftQuarkusApplicationManagedResource
+        extends BuildOpenShiftQuarkusApplicationManagedResource {
+
+    private static final String REMOTE_DEV_LOG_OUTPUT_FILE = "remote-dev-out.log";
+
+    private final RemoteDevModeQuarkusApplicationManagedResourceBuilder model;
+
+    private Process remoteDevProcess;
+    private File remoteDevLogFile;
+    private LoggingHandler remoteDevLoggingHandler;
+
+    public RemoteDevModeBuildOpenShiftQuarkusApplicationManagedResource(
+            RemoteDevModeQuarkusApplicationManagedResourceBuilder model) {
+        super(model);
+
+        this.model = model;
+        this.remoteDevLogFile = new File(model.getContext().getServiceFolder().resolve(REMOTE_DEV_LOG_OUTPUT_FILE).toString());
+    }
+
+    @Override
+    public boolean isRunning() {
+        if (super.isRunning()) {
+            // We need to wait for the remote dev daemon to be started
+            if (remoteDevProcess == null) {
+                startRemoteDevProcess();
+            }
+
+            if (remoteDevLoggingHandler != null
+                    && remoteDevLoggingHandler.logsContains(EXPECTED_OUTPUT_FROM_REMOTE_DEV_DAEMON)) {
+                remoteDevLoggingHandler.flush();
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    @Override
+    public void stop() {
+        super.stop();
+        if (remoteDevLoggingHandler != null) {
+            remoteDevLoggingHandler.stopWatching();
+        }
+
+        ProcessUtils.destroy(remoteDevProcess);
+    }
+
+    @Override
+    protected Map<String, String> addExtraTemplateProperties() {
+        Map<String, String> templateProperties = new HashMap<>();
+        templateProperties.putAll(super.addExtraTemplateProperties());
+        templateProperties.put(QUARKUS_LAUNCH_DEV_MODE, Boolean.TRUE.toString());
+        templateProperties.put(QUARKUS_LIVE_RELOAD_PASSWORD, model.getLiveReloadPassword());
+
+        return templateProperties;
+    }
+
+    private synchronized void startRemoteDevProcess() {
+        if (remoteDevProcess == null) {
+            ProcessBuilder pb = model.prepareRemoteDevProcess();
+            pb.redirectOutput(remoteDevLogFile);
+
+            try {
+                remoteDevProcess = pb.start();
+
+                remoteDevLoggingHandler = new FileServiceLoggingHandler(model.getContext().getOwner(), remoteDevLogFile);
+                remoteDevLoggingHandler.startWatching();
+            } catch (IOException e) {
+                Log.error(getContext().getOwner(), "Failed to start the remote dev process. Caused by " + e.getMessage());
+            }
+        }
+    }
+}

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/TemplateOpenShiftQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/TemplateOpenShiftQuarkusApplicationManagedResource.java
@@ -2,6 +2,9 @@ package io.quarkus.test.services.quarkus;
 
 import static java.util.regex.Pattern.quote;
 
+import java.util.Collections;
+import java.util.Map;
+
 import org.apache.commons.lang3.StringUtils;
 
 import io.quarkus.test.logging.Log;
@@ -46,12 +49,17 @@ public abstract class TemplateOpenShiftQuarkusApplicationManagedResource<T exten
         return INTERNAL_PORT_DEFAULT;
     }
 
+    protected Map<String, String> addExtraTemplateProperties() {
+        return Collections.emptyMap();
+    }
+
     private void applyTemplate() {
         String deploymentFile = model.getContext().getOwner().getConfiguration().getOrDefault(DEPLOYMENT_TEMPLATE_PROPERTY,
                 getDefaultTemplate());
 
         client.applyServicePropertiesUsingTemplate(model.getContext().getOwner(), deploymentFile,
                 this::internalReplaceDeploymentContent,
+                addExtraTemplateProperties(),
                 model.getContext().getServiceFolder().resolve(DEPLOYMENT));
     }
 

--- a/quarkus-test-openshift/src/main/resources/META-INF/services/io.quarkus.test.services.quarkus.RemoteDevModeQuarkusApplicationManagedResourceBinding
+++ b/quarkus-test-openshift/src/main/resources/META-INF/services/io.quarkus.test.services.quarkus.RemoteDevModeQuarkusApplicationManagedResourceBinding
@@ -1,0 +1,1 @@
+io.quarkus.test.services.quarkus.OpenShiftRemoteDevModeQuarkusApplicationManagedResourceBinding


### PR DESCRIPTION
The test framework supports the Remote DEV mode in Quarkus for baremetal, OpenShift and Kubernetes. 
Basically, we can deploy a Quarkus application in Remote DEV and after applying changes in the source code, these changes
will be automatically deployed in the running application.

```java
@QuarkusScenario
public class RemoteDevGreetingResourceIT {

    static final String VICTOR_NAME = "victor";

    static final String HELLO_IN_ENGLISH = "Hello";
    static final String HELLO_IN_SPANISH = "Hola";

    @RemoteDevModeQuarkusApplication
    static DevModeQuarkusService app = new DevModeQuarkusService();

    @Test
    public void shouldUpdateResourcesAndSources() {
        // Should say first Victor (the default name)
        app.given().get("/greeting").then().statusCode(HttpStatus.SC_OK).body(is(HELLO_IN_ENGLISH + ", I'm " + VICTOR_NAME));

        // Modify default name to manuel
        app.modifyFile("src/main/java/io/quarkus/qe/GreetingResource.java",
                content -> content.replace(HELLO_IN_ENGLISH, HELLO_IN_SPANISH));

        // Now, the app should say Manuel
        AwaitilityUtils.untilAsserted(
                () -> app.given().get("/greeting").then().statusCode(HttpStatus.SC_OK)
                        .body(is(HELLO_IN_SPANISH + ", I'm " + VICTOR_NAME)));
    }
}
```