### PR TITLE
Add `podsInService` in  OpenShift and Kubernetes clients

### DIFF
--- a/quarkus-test-kubernetes/src/main/java/io/quarkus/test/bootstrap/inject/KubectlClient.java
+++ b/quarkus-test-kubernetes/src/main/java/io/quarkus/test/bootstrap/inject/KubectlClient.java
@@ -132,6 +132,13 @@ public final class KubectlClient {
     }
 
     /**
+     * Get the running pods in the current service.
+     */
+    public List<Pod> podsInService(Service service) {
+        return client.pods().withLabel(LABEL_TO_WATCH_FOR_LOGS, service.getName()).list().getItems();
+    }
+
+    /**
      * Get all the logs for all the pods within the current namespace.
      *
      * @return
@@ -154,7 +161,7 @@ public final class KubectlClient {
      */
     public Map<String, String> logs(Service service) {
         Map<String, String> logs = new HashMap<>();
-        for (Pod pod : client.pods().withLabel(LABEL_TO_WATCH_FOR_LOGS, service.getName()).list().getItems()) {
+        for (Pod pod : podsInService(service)) {
             if (isPodRunning(pod)) {
                 String podName = pod.getMetadata().getName();
                 logs.put(podName, client.pods().withName(podName).getLog());

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
@@ -283,6 +283,13 @@ public final class OpenShiftClient {
     }
 
     /**
+     * Get the running pods in the current service.
+     */
+    public List<Pod> podsInService(Service service) {
+        return client.pods().withLabel(LABEL_TO_WATCH_FOR_LOGS, service.getName()).list().getItems();
+    }
+
+    /**
      * Get all the logs for all the pods.
      *
      * @return
@@ -305,7 +312,7 @@ public final class OpenShiftClient {
      */
     public Map<String, String> logs(Service service) {
         Map<String, String> logs = new HashMap<>();
-        for (Pod pod : client.pods().withLabel(LABEL_TO_WATCH_FOR_LOGS, service.getName()).list().getItems()) {
+        for (Pod pod : podsInService(service)) {
             if (isPodRunning(pod)) {
                 String podName = pod.getMetadata().getName();
                 logs.put(podName, client.pods().withName(podName).getLog());


### PR DESCRIPTION
This method is useful to get the running pods for a concrete service.