### PR TITLE
Add Database Services for MySQL, MariaDB, PostgreSQL, DB2 and SqlServer

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,4 @@
+[allowlist]
+  description = "a description string for a global allowlist config"
+  ## SqlServerService in quarkus-test-service-database contains sensitive data that needs to be ignored
+  paths = ['''quarkus-test-service-database/*''']

--- a/README.md
+++ b/README.md
@@ -1185,6 +1185,51 @@ public class GreetingResourceIT {
 }
 ```
 
+#### Database Services
+
+The test framework have some utilities to ease the setup of database containers. In order to use these services, you need to 
+add the following dependency into your Maven configuration:
+
+```xml
+<dependency>
+    <groupId>io.quarkus.qe</groupId>
+    <artifactId>quarkus-test-service-database</artifactId>
+    <scope>test</scope>
+</dependency>
+```
+
+The supported database services are:
+
+- MySQL service
+- MariaDB service
+- DB2 service
+- SQL Server service (we can't set a custom user, password and database)
+- PostgreSQL service
+
+All the database services contain the following methods:
+
+- `getJdbcUrl`: to return the JDBC connection URL.
+- `getReactiveUrl`: to return the reactive way connection URL.
+
+Example usage:
+
+```java
+@QuarkusScenario
+public class MySqlDatabaseIT {
+
+    @Container(image = "mysql/mysql-server:8.0", port = MYSQL_PORT, expectedLog = "port: 3306  MySQL Community Server")
+    static MySqlService database = new MySqlService();
+
+    @QuarkusApplication
+    static RestService app = new RestService()
+            .withProperty("quarkus.datasource.username", database.getUser())
+            .withProperty("quarkus.datasource.password", database.getPassword())
+            .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl)
+            .withProperty("quarkus.datasource.reactive.url", database::getReactiveUrl);
+    
+    // ...
+}
+```
 
 ## More Features
 

--- a/examples/database-mysql/pom.xml
+++ b/examples/database-mysql/pom.xml
@@ -38,6 +38,11 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus.qe</groupId>
+            <artifactId>quarkus-test-service-database</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus.qe</groupId>
             <artifactId>quarkus-test-openshift</artifactId>
             <scope>test</scope>
         </dependency>

--- a/examples/database-mysql/src/test/java/io/quarkus/qe/database/mysql/MySqlDatabaseIT.java
+++ b/examples/database-mysql/src/test/java/io/quarkus/qe/database/mysql/MySqlDatabaseIT.java
@@ -1,6 +1,8 @@
 package io.quarkus.qe.database.mysql;
 
-import io.quarkus.test.bootstrap.DefaultService;
+import static io.quarkus.qe.database.mysql.DevModeMySqlDatabaseIT.MYSQL_PORT;
+
+import io.quarkus.test.bootstrap.MySqlService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.Container;
@@ -9,23 +11,14 @@ import io.quarkus.test.services.QuarkusApplication;
 @QuarkusScenario
 public class MySqlDatabaseIT extends AbstractSqlDatabaseIT {
 
-    static final String MYSQL_USER = "user";
-    static final String MYSQL_PASSWORD = "user";
-    static final String MYSQL_DATABASE = "mydb";
-    static final int MYSQL_PORT = 3306;
-
     @Container(image = "mysql/mysql-server:8.0", port = MYSQL_PORT, expectedLog = "port: 3306  MySQL Community Server")
-    static DefaultService database = new DefaultService()
-            .withProperty("MYSQL_USER", MYSQL_USER)
-            .withProperty("MYSQL_PASSWORD", MYSQL_PASSWORD)
-            .withProperty("MYSQL_DATABASE", MYSQL_DATABASE);
+    static MySqlService database = new MySqlService();
 
     @QuarkusApplication
     static RestService app = new RestService()
-            .withProperty("quarkus.datasource.username", MYSQL_USER)
-            .withProperty("quarkus.datasource.password", MYSQL_PASSWORD)
-            .withProperty("quarkus.datasource.jdbc.url",
-                    () -> database.getHost().replace("http", "jdbc:mysql") + ":" + database.getPort() + "/" + MYSQL_DATABASE);
+            .withProperty("quarkus.datasource.username", database.getUser())
+            .withProperty("quarkus.datasource.password", database.getPassword())
+            .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl);
 
     @Override
     protected RestService getApp() {

--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,11 @@
                 <version>${project.version}</version>
             </dependency>
             <dependency>
+                <groupId>io.quarkus.qe</groupId>
+                <artifactId>quarkus-test-service-database</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.jaegertracing</groupId>
                 <artifactId>jaeger-client</artifactId>
                 <version>${jaeger.version}</version>
@@ -357,6 +362,7 @@
                 <module>quarkus-test-service-kafka</module>
                 <module>quarkus-test-service-amq</module>
                 <module>quarkus-test-service-jaeger</module>
+                <module>quarkus-test-service-database</module>
             </modules>
         </profile>
         <profile>

--- a/quarkus-test-service-database/pom.xml
+++ b/quarkus-test-service-database/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus.qe</groupId>
+        <artifactId>quarkus-test-parent</artifactId>
+        <version>0.0.9-SNAPSHOT</version>
+    </parent>
+    <artifactId>quarkus-test-service-database</artifactId>
+    <name>Quarkus - Test Framework - Service - Database</name>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus.qe</groupId>
+            <artifactId>quarkus-test-core</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/DatabaseService.java
+++ b/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/DatabaseService.java
@@ -1,0 +1,56 @@
+package io.quarkus.test.bootstrap;
+
+public abstract class DatabaseService<T extends Service> extends BaseService<T> {
+
+    static final String USER_DEFAULT_VALUE = "user";
+    static final String PASSWORD_DEFAULT_VALUE = "user";
+    static final String DATABASE_DEFAULT_VALUE = "mydb";
+
+    private String user = USER_DEFAULT_VALUE;
+    private String password = PASSWORD_DEFAULT_VALUE;
+    private String database = DATABASE_DEFAULT_VALUE;
+
+    public String getUser() {
+        return user;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public String getDatabase() {
+        return database;
+    }
+
+    public String getJdbcUrl() {
+        return getHost().replace("http", "jdbc:" + getJdbcName()) + ":" + getPort() + "/" + getDatabase();
+    }
+
+    public String getReactiveUrl() {
+        return getHost().replace("http", getJdbcName()) + ":" + getPort() + "/" + getDatabase();
+    }
+
+    public T with(String user, String password, String database) {
+        withUser(user);
+        withPassword(password);
+        withDatabase(database);
+        return (T) this;
+    }
+
+    public T withUser(String user) {
+        this.user = user;
+        return (T) this;
+    }
+
+    public T withPassword(String password) {
+        this.password = password;
+        return (T) this;
+    }
+
+    public T withDatabase(String database) {
+        this.database = database;
+        return (T) this;
+    }
+
+    protected abstract String getJdbcName();
+}

--- a/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/Db2Service.java
+++ b/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/Db2Service.java
@@ -1,0 +1,26 @@
+package io.quarkus.test.bootstrap;
+
+public class Db2Service extends DatabaseService<Db2Service> {
+
+    static final String USER_PROPERTY = "DB2INSTANCE";
+    static final String PASSWORD_PROPERTY = "DB2INST1_PASSWORD";
+    static final String DATABASE_PROPERTY = "DBNAME";
+    static final String JDBC_NAME = "db2";
+
+    @Override
+    protected String getJdbcName() {
+        return JDBC_NAME;
+    }
+
+    @Override
+    public Db2Service onPreStart(Action action) {
+        withProperty(USER_PROPERTY, getUser());
+        withProperty(PASSWORD_PROPERTY, getPassword());
+        withProperty(DATABASE_PROPERTY, getDatabase());
+        withProperty("AUTOCONFIG", "false");
+        withProperty("ARCHIVE_LOGS", "false");
+        withProperty("LICENSE", "accept");
+
+        return super.onPreStart(action);
+    }
+}

--- a/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/MariaDbService.java
+++ b/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/MariaDbService.java
@@ -1,0 +1,32 @@
+package io.quarkus.test.bootstrap;
+
+public class MariaDbService extends DatabaseService<MariaDbService> {
+
+    static final String USER_PROPERTY = "MARIADB_USER";
+    static final String PASSWORD_PROPERTY = "MARIADB_PASSWORD";
+    static final String PASSWORD_ROOT_PROPERTY = "MARIADB_ROOT_PASSWORD";
+    static final String DATABASE_PROPERTY = "MARIADB_DATABASE";
+    static final String JDBC_NAME = "mariadb";
+
+    @Override
+    protected String getJdbcName() {
+        return JDBC_NAME;
+    }
+
+    @Override
+    public MariaDbService onPreStart(Action action) {
+        // Some MariaDB images need MariaDB, some others MySql ones... So, we provide both:
+        // - MySQL properties
+        withProperty(MySqlService.USER_PROPERTY, getUser());
+        withProperty(MySqlService.PASSWORD_PROPERTY, getPassword());
+        withProperty(MySqlService.PASSWORD_ROOT_PROPERTY, getPassword());
+        withProperty(MySqlService.DATABASE_PROPERTY, getDatabase());
+        // - MariaDB properties
+        withProperty(USER_PROPERTY, getUser());
+        withProperty(PASSWORD_PROPERTY, getPassword());
+        withProperty(PASSWORD_ROOT_PROPERTY, getPassword());
+        withProperty(DATABASE_PROPERTY, getDatabase());
+
+        return super.onPreStart(action);
+    }
+}

--- a/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/MySqlService.java
+++ b/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/MySqlService.java
@@ -1,0 +1,25 @@
+package io.quarkus.test.bootstrap;
+
+public class MySqlService extends DatabaseService<MySqlService> {
+
+    static final String USER_PROPERTY = "MYSQL_USER";
+    static final String PASSWORD_PROPERTY = "MYSQL_PASSWORD";
+    static final String PASSWORD_ROOT_PROPERTY = "MYSQL_ROOT_PASSWORD";
+    static final String DATABASE_PROPERTY = "MYSQL_DATABASE";
+    static final String JDBC_NAME = "mysql";
+
+    @Override
+    protected String getJdbcName() {
+        return JDBC_NAME;
+    }
+
+    @Override
+    public MySqlService onPreStart(Action action) {
+        withProperty(USER_PROPERTY, getUser());
+        withProperty(PASSWORD_PROPERTY, getPassword());
+        withProperty(PASSWORD_ROOT_PROPERTY, getPassword());
+        withProperty(DATABASE_PROPERTY, getDatabase());
+
+        return super.onPreStart(action);
+    }
+}

--- a/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/PostgresqlService.java
+++ b/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/PostgresqlService.java
@@ -1,0 +1,23 @@
+package io.quarkus.test.bootstrap;
+
+public class PostgresqlService extends DatabaseService<PostgresqlService> {
+
+    static final String USER_PROPERTY = "POSTGRESQL_USER";
+    static final String PASSWORD_PROPERTY = "POSTGRESQL_PASSWORD";
+    static final String DATABASE_PROPERTY = "POSTGRESQL_DATABASE";
+    static final String JDBC_NAME = "postgresql";
+
+    @Override
+    protected String getJdbcName() {
+        return JDBC_NAME;
+    }
+
+    @Override
+    public PostgresqlService onPreStart(Action action) {
+        withProperty(USER_PROPERTY, getUser());
+        withProperty(PASSWORD_PROPERTY, getPassword());
+        withProperty(DATABASE_PROPERTY, getDatabase());
+
+        return super.onPreStart(action);
+    }
+}

--- a/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/SqlServerService.java
+++ b/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/SqlServerService.java
@@ -1,0 +1,49 @@
+package io.quarkus.test.bootstrap;
+
+public class SqlServerService extends DatabaseService<SqlServerService> {
+
+    static final String USER = "sa";
+    static final String PASSWORD = "My1337p@ssworD";
+    static final String DATABASE = "mydb";
+    static final String JDBC_NAME = "sqlserver";
+
+    @Override
+    public String getUser() {
+        return USER;
+    }
+
+    @Override
+    public String getPassword() {
+        return PASSWORD;
+    }
+
+    @Override
+    public String getDatabase() {
+        return DATABASE;
+    }
+
+    @Override
+    public String getJdbcUrl() {
+        return getHost().replace("http", "jdbc:" + getJdbcName()) + ":" + getPort() + ";" + getDatabase();
+    }
+
+    @Override
+    public SqlServerService withUser(String user) {
+        throw new UnsupportedOperationException("No supported using SQL Server");
+    }
+
+    @Override
+    public SqlServerService withPassword(String password) {
+        throw new UnsupportedOperationException("No supported using Sql Server");
+    }
+
+    @Override
+    public SqlServerService withDatabase(String database) {
+        throw new UnsupportedOperationException("No supported using Sql Server");
+    }
+
+    @Override
+    protected String getJdbcName() {
+        return JDBC_NAME;
+    }
+}


### PR DESCRIPTION
The test framework have some utilities to ease the setup of database containers. In order to use these services, you need to 
add the following dependency into your Maven configuration:

```xml
<dependency>
    <groupId>io.quarkus.qe</groupId>
    <artifactId>quarkus-test-service-database</artifactId>
    <scope>test</scope>
</dependency>
```

The supported database services are:

- MySQL service
- MariaDB service
- DB2 service
- SQL Server service (we can't set a custom user, password and database)
- PostgreSQL service

All the database services contain the following methods:

- `getJdbcUrl`: to return the JDBC connection URL.
- `getReactiveUrl`: to return the reactive way connection URL.

Example usage:

```java
@QuarkusScenario
public class MySqlDatabaseIT {

    @Container(image = "mysql/mysql-server:8.0", port = MYSQL_PORT, expectedLog = "port: 3306  MySQL Community Server")
    static MySqlService database = new MySqlService();

    @QuarkusApplication
    static RestService app = new RestService()
            .withProperty("quarkus.datasource.username", database.getUser())
            .withProperty("quarkus.datasource.password", database.getPassword())
            .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl)
            .withProperty("quarkus.datasource.reactive.url", database::getReactiveUrl);
    
    // ...
}
```