### PR TITLE
Add Oracle service in quarkus-test-service-database

### DIFF
--- a/README.md
+++ b/README.md
@@ -1240,6 +1240,7 @@ The supported database services are:
 - DB2 service
 - SQL Server service (we can't set a custom user, password and database)
 - PostgreSQL service
+- Oracle service
 
 All the database services contain the following methods:
 

--- a/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/OracleService.java
+++ b/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/OracleService.java
@@ -1,0 +1,36 @@
+package io.quarkus.test.bootstrap;
+
+public class OracleService extends DatabaseService<OracleService> {
+
+    static final String USER_DEFAULT_VALUE = "myuser";
+    static final String USER_PROPERTY = "APP_USER";
+    static final String USER_PASSWORD_PROPERTY = "APP_USER_PASSWORD";
+    static final String PASSWORD_PROPERTY = "ORACLE_PASSWORD";
+    static final String DATABASE_PROPERTY = "ORACLE_DATABASE";
+    static final String JDBC_NAME = "oracle";
+
+    public OracleService() {
+        // Oracle disallows to use "user", so we use "myuser" as default user name.
+        withUser(USER_DEFAULT_VALUE);
+    }
+
+    @Override
+    protected String getJdbcName() {
+        return JDBC_NAME;
+    }
+
+    @Override
+    public String getJdbcUrl() {
+        return getHost().replace("http://", "jdbc:" + getJdbcName() + ":thin:@") + ":" + getPort() + "/" + getDatabase();
+    }
+
+    @Override
+    public OracleService onPreStart(Action action) {
+        withProperty(USER_PROPERTY, getUser());
+        withProperty(PASSWORD_PROPERTY, getPassword());
+        withProperty(USER_PASSWORD_PROPERTY, getPassword());
+        withProperty(DATABASE_PROPERTY, getDatabase());
+
+        return super.onPreStart(action);
+    }
+}


### PR DESCRIPTION
Tested in quarkus-test-suite:

```
@QuarkusScenario
public class OracleDatabaseIT extends AbstractSqlDatabaseIT {

    @Container(image = "gvenzl/oracle-xe:18.4.0-slim", port = 1521, expectedLog = "DATABASE IS READY TO USE!")
    static OracleService database = new OracleService();

    @QuarkusApplication
    static RestService app = new RestService().withProperties("oracle_app.properties")
            .withProperty("quarkus.datasource.username", database.getUser())
            .withProperty("quarkus.datasource.password", database.getPassword())
            .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl);
}

```