### PR TITLE
Compute all the properties when getting them using the Service

### DIFF
--- a/examples/pingpong/src/main/resources/application.properties
+++ b/examples/pingpong/src/main/resources/application.properties
@@ -1,3 +1,5 @@
+property.without.profile=A
+%ComputedValuesPingPongResourceIT.property.with.profile=B
 
 %OpenShiftUsingExtensionAndServerlessPingPongResourceIT.quarkus.kubernetes.deployment-target=knative
 %OpenShiftUsingExtensionAndServerlessPingPongResourceIT.quarkus.container-image.registry=image-registry.openshift-image-registry.svc:5000

--- a/examples/pingpong/src/test/java/io/quarkus/qe/ComputedValuesPingPongResourceIT.java
+++ b/examples/pingpong/src/test/java/io/quarkus/qe/ComputedValuesPingPongResourceIT.java
@@ -1,0 +1,25 @@
+package io.quarkus.qe;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.QuarkusApplication;
+
+@QuarkusScenario
+public class ComputedValuesPingPongResourceIT {
+
+    @QuarkusApplication
+    static final RestService pingpong = new RestService();
+
+    @Test
+    public void shouldGetComputedValues() {
+        assertFalse(pingpong.getProperty("property.not.exists").isPresent());
+        assertEquals("A", pingpong.getProperty("property.without.profile").get());
+        assertEquals("B", pingpong.getProperty("property.with.profile").get());
+    }
+
+}

--- a/examples/pingpong/src/test/java/io/quarkus/qe/PingPongResourceIT.java
+++ b/examples/pingpong/src/test/java/io/quarkus/qe/PingPongResourceIT.java
@@ -10,10 +10,10 @@ import io.quarkus.test.scenarios.QuarkusScenario;
 
 @QuarkusScenario
 public class PingPongResourceIT {
+
     @Test
     public void shouldPingPongWorks() {
         given().get("/ping").then().statusCode(HttpStatus.SC_OK).body(is("ping"));
         given().get("/pong").then().statusCode(HttpStatus.SC_OK).body(is("pong"));
     }
-
 }

--- a/quarkus-test-cli/src/main/java/io/quarkus/test/services/quarkus/CliDevModeLocalhostQuarkusApplicationManagedResource.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/services/quarkus/CliDevModeLocalhostQuarkusApplicationManagedResource.java
@@ -124,11 +124,9 @@ public class CliDevModeLocalhostQuarkusApplicationManagedResource extends Quarku
     }
 
     private int getOrAssignPortByProperty(String property) {
-        String port = serviceContext.getOwner().getProperties().get(property);
-        if (StringUtils.isEmpty(port)) {
-            return SocketUtils.findAvailablePort();
-        }
-
-        return Integer.parseInt(port);
+        return serviceContext.getOwner().getProperty(property)
+                .filter(StringUtils::isNotEmpty)
+                .map(Integer::parseInt)
+                .orElseGet(SocketUtils::findAvailablePort);
     }
 }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/ManagedResourceBuilder.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/ManagedResourceBuilder.java
@@ -2,6 +2,8 @@ package io.quarkus.test.bootstrap;
 
 import java.lang.annotation.Annotation;
 
+import org.apache.commons.lang3.StringUtils;
+
 public interface ManagedResourceBuilder {
 
     /**
@@ -16,5 +18,12 @@ public interface ManagedResourceBuilder {
      */
     default void init(Annotation annotation) {
 
+    }
+
+    /**
+     * @return computed property that depends on the managed resource builder implementation.
+     */
+    default String getComputedProperty(String property) {
+        return StringUtils.EMPTY;
     }
 }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/Service.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/Service.java
@@ -3,8 +3,8 @@ package io.quarkus.test.bootstrap;
 import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
-import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 import io.quarkus.test.configuration.Configuration;
@@ -21,6 +21,12 @@ public interface Service extends ExtensionContext.Store.CloseableResource {
     Configuration getConfiguration();
 
     Map<String, String> getProperties();
+
+    default Optional<String> getProperty(String property) {
+        return Optional.ofNullable(getProperty(property, null));
+    }
+
+    String getProperty(String property, String defaultValue);
 
     List<String> getLogs();
 
@@ -52,14 +58,5 @@ public interface Service extends ExtensionContext.Store.CloseableResource {
     @Override
     default void close() {
         stop();
-    }
-
-    default String getProperty(String property, String defaultValue) {
-        String value = getProperties().get(property);
-        if (StringUtils.isNotBlank(value)) {
-            return value;
-        }
-
-        return defaultValue;
     }
 }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/configuration/PropertyLookup.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/configuration/PropertyLookup.java
@@ -38,13 +38,9 @@ public class PropertyLookup {
         }
 
         // Or from service properties
-        value = service.getOwner().getProperties().get(value);
-        if (StringUtils.isNotBlank(value)) {
-            return value;
-        }
-
-        // Or from system properties
-        return get();
+        return service.getOwner().getProperty(propertyKey)
+                // Or from system properties
+                .orElseGet(this::get);
     }
 
     public String get() {

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/LocalhostQuarkusApplicationManagedResource.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/LocalhostQuarkusApplicationManagedResource.java
@@ -148,12 +148,10 @@ public abstract class LocalhostQuarkusApplicationManagedResource extends Quarkus
     }
 
     private int getOrAssignPortByProperty(String property) {
-        String port = model.getContext().getOwner().getProperties().get(property);
-        if (StringUtils.isEmpty(port)) {
-            return SocketUtils.findAvailablePort();
-        }
-
-        return Integer.parseInt(port);
+        return model.getContext().getOwner().getProperty(property)
+                .filter(StringUtils::isNotEmpty)
+                .map(Integer::parseInt)
+                .orElseGet(SocketUtils::findAvailablePort);
     }
 
     private List<String> getPropertiesForCommand() {

--- a/quarkus-test-kubernetes/src/main/java/io/quarkus/test/bootstrap/inject/KubectlClient.java
+++ b/quarkus-test-kubernetes/src/main/java/io/quarkus/test/bootstrap/inject/KubectlClient.java
@@ -273,10 +273,6 @@ public final class KubectlClient {
         }
     }
 
-    private String extractNamespace(String namespace) {
-        return namespace.split(":")[1];
-    }
-
     private boolean isPodRunning(Pod pod) {
         return pod.getStatus().getPhase().equals("Running");
     }

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
@@ -329,7 +329,7 @@ public final class OpenShiftClient {
         for (Pod pod : podsInService(service)) {
             if (isPodRunning(pod)) {
                 String podName = pod.getMetadata().getName();
-                logs.put(podName, client.pods().withName(podName).getLog());
+                logs.put(podName, client.pods().withName(podName).inContainer(service.getName()).getLog());
             }
         }
 

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/TemplateOpenShiftQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/TemplateOpenShiftQuarkusApplicationManagedResource.java
@@ -41,12 +41,10 @@ public abstract class TemplateOpenShiftQuarkusApplicationManagedResource<T exten
     }
 
     protected int getInternalPort() {
-        String internalPort = model.getContext().getOwner().getProperties().get(QUARKUS_HTTP_PORT_PROPERTY);
-        if (StringUtils.isNotBlank(internalPort)) {
-            return Integer.parseInt(internalPort);
-        }
-
-        return INTERNAL_PORT_DEFAULT;
+        return model.getContext().getOwner().getProperty(QUARKUS_HTTP_PORT_PROPERTY)
+                .filter(StringUtils::isNotBlank)
+                .map(Integer::parseInt)
+                .orElse(INTERNAL_PORT_DEFAULT);
     }
 
     protected Map<String, String> addExtraTemplateProperties() {


### PR DESCRIPTION
Before, when doing `service.getProperty(X)`, this only returned the value from `service.withProperty(X)` regardless if the property X was defined in the `application.properties`.

Now, the service will return the final computed value from either the user entered or from the application properties or some custom properties added by the managed resource builders.