### PR TITLE
Fix Serverless deployments ++ OpenShift deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1330,8 +1330,7 @@ and run all your tests in your current namespace.
 
 Full example command: `mvn clean verify -Popenshift -Dts.openshift.ephemeral.namespaces.enabled=false`
 
-Default value: `ts.openshift.ephemeral.namespaces.enabled=true`
-**Note:** this feature doesn't support operators
+**Note:** this feature is not supported for operators
 
 - Partial SSL support
 

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/OperatorService.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/OperatorService.java
@@ -16,11 +16,6 @@ public class OperatorService<T extends Service> extends BaseService<T> {
         return crds;
     }
 
-    public OperatorService<T> withCrd(String name, String crdFile) {
-        crds.add(new CustomResourceDefinition(name, crdFile));
-        return this;
-    }
-
     public OperatorService<T> withCrd(String name, String crdFile,
             Class<? extends CustomResource<CustomResourceSpec, CustomResourceStatus>> type) {
         crds.add(new CustomResourceDefinition(name, crdFile, type));

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
@@ -42,6 +42,7 @@ import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.client.dsl.ExecListener;
 import io.fabric8.kubernetes.client.dsl.ExecWatch;
+import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.fabric8.kubernetes.client.utils.Serialization;
 import io.fabric8.openshift.api.model.DeploymentConfig;
 import io.fabric8.openshift.api.model.ImageStream;
@@ -312,7 +313,10 @@ public final class OpenShiftClient {
         Map<String, String> logs = new HashMap<>();
         for (Pod pod : client.pods().list().getItems()) {
             String podName = pod.getMetadata().getName();
-            logs.put(podName, client.pods().withName(podName).getLog());
+            PodResource<Pod> resource = client.pods().withName(podName);
+            for (Container container : pod.getSpec().getContainers()) {
+                logs.put(podName + "-" + container.getName(), resource.inContainer(container.getName()).getLog());
+            }
         }
 
         return logs;
@@ -329,7 +333,10 @@ public final class OpenShiftClient {
         for (Pod pod : podsInService(service)) {
             if (isPodRunning(pod)) {
                 String podName = pod.getMetadata().getName();
-                logs.put(podName, client.pods().withName(podName).inContainer(service.getName()).getLog());
+                PodResource<Pod> resource = client.pods().withName(podName);
+                for (Container container : pod.getSpec().getContainers()) {
+                    logs.put(podName + "-" + container.getName(), resource.inContainer(container.getName()).getLog());
+                }
             }
         }
 

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
@@ -232,7 +232,7 @@ public final class OpenShiftClient {
 
         try {
             new Command(OC, "expose", "svc/" + serviceName, "--port=" + port, "-n", currentNamespace,
-                    "-l " + LABEL_SCENARIO_ID + "=" + getScenarioId()).runAndWait();
+                    "-l" + LABEL_SCENARIO_ID + "=" + getScenarioId()).runAndWait();
         } catch (Exception e) {
             fail("Service failed to be exposed. Caused by " + e.getMessage());
         }

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/scenarios/OpenShiftDeploymentStrategy.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/scenarios/OpenShiftDeploymentStrategy.java
@@ -1,10 +1,13 @@
 package io.quarkus.test.scenarios;
 
+import java.util.function.Function;
+
 import io.quarkus.test.services.quarkus.BuildOpenShiftQuarkusApplicationManagedResource;
 import io.quarkus.test.services.quarkus.ContainerRegistryOpenShiftQuarkusApplicationManagedResource;
 import io.quarkus.test.services.quarkus.ExtensionOpenShiftQuarkusApplicationManagedResource;
 import io.quarkus.test.services.quarkus.ExtensionOpenShiftUsingDockerBuildStrategyQuarkusApplicationManagedResource;
 import io.quarkus.test.services.quarkus.OpenShiftQuarkusApplicationManagedResource;
+import io.quarkus.test.services.quarkus.ProdQuarkusApplicationManagedResourceBuilder;
 
 /**
  * OpenShift Deployment strategies.
@@ -13,28 +16,29 @@ public enum OpenShiftDeploymentStrategy {
     /**
      * Will push the artifacts into OpenShift and build the image that will be used to run the pods.
      */
-    Build(BuildOpenShiftQuarkusApplicationManagedResource.class),
+    Build(BuildOpenShiftQuarkusApplicationManagedResource::new),
     /**
      * Will build the Quarkus app image and push it into a Container Registry to be accessed by OpenShift to deploy the app.
      */
-    UsingContainerRegistry(ContainerRegistryOpenShiftQuarkusApplicationManagedResource.class),
+    UsingContainerRegistry(ContainerRegistryOpenShiftQuarkusApplicationManagedResource::new),
     /**
      * Will use the OpenShift Quarkus extension to build and deploy into OpenShift.
      */
-    UsingOpenShiftExtension(ExtensionOpenShiftQuarkusApplicationManagedResource.class),
+    UsingOpenShiftExtension(ExtensionOpenShiftQuarkusApplicationManagedResource::new),
     /**
      * Will use the OpenShift Quarkus extension to build within Docker and then deploy into OpenShift.
      */
     UsingOpenShiftExtensionAndDockerBuildStrategy(
-            ExtensionOpenShiftUsingDockerBuildStrategyQuarkusApplicationManagedResource.class);
+            ExtensionOpenShiftUsingDockerBuildStrategyQuarkusApplicationManagedResource::new);
 
-    private final Class<? extends OpenShiftQuarkusApplicationManagedResource> strategyClass;
+    private final Function<ProdQuarkusApplicationManagedResourceBuilder, OpenShiftQuarkusApplicationManagedResource> supplier;
 
-    OpenShiftDeploymentStrategy(Class<? extends OpenShiftQuarkusApplicationManagedResource> strategyClass) {
-        this.strategyClass = strategyClass;
+    OpenShiftDeploymentStrategy(
+            Function<ProdQuarkusApplicationManagedResourceBuilder, OpenShiftQuarkusApplicationManagedResource> supplier) {
+        this.supplier = supplier;
     }
 
-    public Class<? extends OpenShiftQuarkusApplicationManagedResource> getStrategyClass() {
-        return strategyClass;
+    public OpenShiftQuarkusApplicationManagedResource getManagedResource(ProdQuarkusApplicationManagedResourceBuilder builder) {
+        return supplier.apply(builder);
     }
 }

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/operator/OperatorManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/operator/OperatorManagedResource.java
@@ -1,5 +1,6 @@
 package io.quarkus.test.services.operator;
 
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -80,17 +81,16 @@ public class OperatorManagedResource implements ManagedResource {
 
     private void applyCRD(CustomResourceDefinition crd) {
         ServiceContext serviceContext = model.getContext();
+        Path crdFileDefinition = serviceContext.getServiceFolder().resolve(crd.getName());
         String content = FileUtils.loadFile(crd.getFile());
+        FileUtils.copyContentTo(content, crdFileDefinition);
 
-        client.apply(FileUtils.copyContentTo(content, serviceContext.getServiceFolder().resolve(crd.getName())));
-
-        if (crd.getType().isPresent()) {
-            crdsToWatch.add(crd);
-        }
+        client.apply(crdFileDefinition);
+        crdsToWatch.add(crd);
     }
 
     private boolean customResourcesAreReady() {
-        return crdsToWatch.stream().allMatch(crd -> client.isCustomResourceReady(crd.getName(), crd.getType().get()));
+        return crdsToWatch.stream().allMatch(crd -> client.isCustomResourceReady(crd.getName(), crd.getType()));
     }
 
     private void installOperator() {

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/operator/model/CustomResourceDefinition.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/operator/model/CustomResourceDefinition.java
@@ -1,23 +1,17 @@
 package io.quarkus.test.services.operator.model;
 
-import java.util.Optional;
-
 import io.fabric8.kubernetes.client.CustomResource;
 
 public class CustomResourceDefinition {
     private final String name;
     private final String file;
-    private final Optional<Class<? extends CustomResource<CustomResourceSpec, CustomResourceStatus>>> type;
-
-    public CustomResourceDefinition(String name, String file) {
-        this(name, file, null);
-    }
+    private final Class<? extends CustomResource<CustomResourceSpec, CustomResourceStatus>> type;
 
     public CustomResourceDefinition(String name, String file,
             Class<? extends CustomResource<CustomResourceSpec, CustomResourceStatus>> type) {
         this.name = name;
         this.file = file;
-        this.type = Optional.ofNullable(type);
+        this.type = type;
     }
 
     public String getName() {
@@ -28,7 +22,7 @@ public class CustomResourceDefinition {
         return file;
     }
 
-    public Optional<Class<? extends CustomResource<CustomResourceSpec, CustomResourceStatus>>> getType() {
+    public Class<? extends CustomResource<CustomResourceSpec, CustomResourceStatus>> getType() {
         return type;
     }
 }

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftQuarkusApplicationManagedResourceBinding.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftQuarkusApplicationManagedResourceBinding.java
@@ -1,7 +1,5 @@
 package io.quarkus.test.services.quarkus;
 
-import static org.junit.jupiter.api.Assertions.fail;
-
 import io.quarkus.test.bootstrap.ServiceContext;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
@@ -17,15 +15,7 @@ public class OpenShiftQuarkusApplicationManagedResourceBinding implements Quarku
         OpenShiftScenario annotation = builder.getContext().getTestContext().getRequiredTestClass()
                 .getAnnotation(OpenShiftScenario.class);
 
-        try {
-            return annotation.deployment().getStrategyClass()
-                    .getDeclaredConstructor(ProdQuarkusApplicationManagedResourceBuilder.class)
-                    .newInstance(builder);
-        } catch (Exception exception) {
-            fail("Failed to load OpenShift strategy. Caused by " + exception.getMessage());
-        }
-
-        return null;
+        return annotation.deployment().getManagedResource(builder);
     }
 
 }


### PR DESCRIPTION
++ Minor refinements for Operators
++ Refactor OpenShift strategies handler to not use Reflection
++ Fix OpenShift exposed routes labels
++ Add labels and env vars properties for Knative deployments: This also fixes the issue to delete serverless resources when the ephemeral namespaces flag is disabled.

FIx https://github.com/quarkus-qe/quarkus-test-framework/issues/237
