### PR TITLE
Add MongoDB service in quarkus-test-service-database

### DIFF
--- a/README.md
+++ b/README.md
@@ -1241,6 +1241,7 @@ The supported database services are:
 - SQL Server service (we can't set a custom user, password and database)
 - PostgreSQL service
 - Oracle service
+- MongoDB service
 
 All the database services contain the following methods:
 

--- a/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/MongoDbService.java
+++ b/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/MongoDbService.java
@@ -1,0 +1,55 @@
+package io.quarkus.test.bootstrap;
+
+public class MongoDbService extends DatabaseService<MongoDbService> {
+    static final String JDBC_NAME = "mongodb";
+
+    @Override
+    protected String getJdbcName() {
+        return JDBC_NAME;
+    }
+
+    @Override
+    public String getJdbcUrl() {
+        return getHost().replace("http", getJdbcName()) + ":" + getPort();
+    }
+
+    @Override
+    public String getReactiveUrl() {
+        return getJdbcUrl();
+    }
+
+    @Override
+    public String getUser() {
+        throw new UnsupportedOperationException("No supported using MongoDB");
+    }
+
+    @Override
+    public String getPassword() {
+        throw new UnsupportedOperationException("No supported using MongoDB");
+    }
+
+    @Override
+    public String getDatabase() {
+        throw new UnsupportedOperationException("No supported using MongoDB");
+    }
+
+    @Override
+    public MongoDbService with(String user, String password, String database) {
+        throw new UnsupportedOperationException("No supported using MongoDB");
+    }
+
+    @Override
+    public MongoDbService withUser(String user) {
+        throw new UnsupportedOperationException("No supported using MongoDB");
+    }
+
+    @Override
+    public MongoDbService withPassword(String password) {
+        throw new UnsupportedOperationException("No supported using MongoDB");
+    }
+
+    @Override
+    public MongoDbService withDatabase(String database) {
+        throw new UnsupportedOperationException("No supported using MongoDB");
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/quarkus-qe/quarkus-test-framework/issues/236.

Example usage in `quarkus-test-suite`:

```
@QuarkusScenario
public class MongoDbIT {

    @Container(image = "quay.io/bitnami/mongodb:5.0.2", port = 27017, expectedLog = "Waiting for connections")
    static MongoDbService database = new MongoDbService();

    @QuarkusApplication
    static RestService app = new RestService()
            .withProperty("quarkus.mongodb.connection-string", database::getJdbcUrl);

    ...
}
```