### PR TITLE
Expose getServiceFolder() method as public

### DIFF
--- a/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/BaseService.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/BaseService.java
@@ -240,7 +240,7 @@ public class BaseService<T extends Service> implements Service {
         return new LogsVerifier(this);
     }
 
-    protected Path getServiceFolder() {
+    public Path getServiceFolder() {
         return context.getServiceFolder();
     }
 


### PR DESCRIPTION
Expose getServiceFolder() method as public

Allows checks like `app.getServiceFolder().resolve("target/jacoco-quarkus.exec").toFile().exists()`