### PR TITLE
Change expected output from "features" to "Installed features"

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,12 @@ All the properties can be configured globally by replacing `<YOUR SERVICE NAME>`
 
 The current configuration options are: 
 
+- Quarkus Expected Output:
+
+```
+ts.global.quarkus.expected.log=Installed features
+```
+
 - Enable/Disable logging (enabled by default):
 
 ```

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusManagedResource.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusManagedResource.java
@@ -5,13 +5,15 @@ import java.util.List;
 
 import io.quarkus.test.bootstrap.ManagedResource;
 import io.quarkus.test.bootstrap.ServiceContext;
+import io.quarkus.test.configuration.PropertyLookup;
 import io.quarkus.test.logging.LoggingHandler;
 import io.quarkus.test.services.quarkus.model.LaunchMode;
 import io.quarkus.test.services.quarkus.model.QuarkusProperties;
 
 public abstract class QuarkusManagedResource implements ManagedResource {
 
-    private static final String EXPECTED_OUTPUT_FROM_SUCCESSFULLY_STARTED = "features";
+    private static final String EXPECTED_OUTPUT_DEFAULT = "Installed features";
+    private static final PropertyLookup EXPECTED_OUTPUT = new PropertyLookup("quarkus.expected.log", EXPECTED_OUTPUT_DEFAULT);
     private static final List<String> ERRORS = Arrays.asList("Failed to start application",
             "Failed to load config value of type class",
             "Quarkus may already be running or the port is used by another application",
@@ -21,10 +23,12 @@ public abstract class QuarkusManagedResource implements ManagedResource {
 
     private final ServiceContext serviceContext;
     private final LaunchMode launchMode;
+    private final String expectedOutput;
 
     public QuarkusManagedResource(ServiceContext serviceContext) {
         this.serviceContext = serviceContext;
         this.launchMode = detectLaunchMode(serviceContext);
+        this.expectedOutput = EXPECTED_OUTPUT.get(serviceContext);
     }
 
     @Override
@@ -34,7 +38,7 @@ public abstract class QuarkusManagedResource implements ManagedResource {
 
     @Override
     public boolean isRunning() {
-        if (getLoggingHandler() != null && getLoggingHandler().logsContains(EXPECTED_OUTPUT_FROM_SUCCESSFULLY_STARTED)) {
+        if (getLoggingHandler() != null && getLoggingHandler().logsContains(expectedOutput)) {
             getLoggingHandler().flush();
             return true;
         }

--- a/quarkus-test-core/src/main/resources/global.properties
+++ b/quarkus-test-core/src/main/resources/global.properties
@@ -17,3 +17,5 @@ ts.global.port.range.min=1100
 ts.global.port.range.max=49151
 ## incremental (default) or random
 ts.global.port.resolution.strategy=incremental
+# Default Quarkus expected successful output
+ts.global.quarkus.expected.log=Installed features


### PR DESCRIPTION
And allow to define a custom expected output log via configuration:

```
ts.global.quarkus.expected.log=Installed features
```

Fix https://github.com/quarkus-qe/quarkus-test-framework/issues/249