### PR TITLE
Delete Container Images on Stop

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,6 +484,11 @@ public class GreetingResourceIT {
 }
 ```
 
+#### Delete Container Images on Stop
+
+If you want to delete the images after use, you need to provide the property `ts.<YOUR SERVICE NAME>.container.delete.image.on.stop=true` or
+`ts.global.container.delete.image.on.stop=true` to apply this property to all the containers.
+
 #### Privileged Mode
 Some containers require `--privileged` mode to run properly. This mode can be enabled on a per-container basis via property `ts.<YOUR SERVICE NAME>.container.privileged-mode=true` or for all containers via property `ts.global.container.privileged-mode=true`. This property only affects containers which are both: 
 1) Deployed on bare metal, not in Kubernetes/OpenShift.

--- a/examples/consul/src/test/resources/test.properties
+++ b/examples/consul/src/test/resources/test.properties
@@ -1,2 +1,3 @@
 ts.consul.log.enable=true
+ts.consul.container.delete.image.on.stop=true
 ts.app.log.enable=true

--- a/pom.xml
+++ b/pom.xml
@@ -174,6 +174,11 @@
             </dependency>
             <dependency>
                 <groupId>com.github.docker-java</groupId>
+                <artifactId>docker-java-api</artifactId>
+                <version>${com.github.docker-java.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.docker-java</groupId>
                 <artifactId>docker-java-transport-zerodep</artifactId>
                 <version>${com.github.docker-java.version}</version>
             </dependency>

--- a/quarkus-test-containers/pom.xml
+++ b/quarkus-test-containers/pom.xml
@@ -14,6 +14,10 @@
             <artifactId>quarkus-test-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus.qe</groupId>
+            <artifactId>quarkus-test-images</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
         </dependency>

--- a/quarkus-test-containers/src/main/java/io/quarkus/test/services/containers/DockerContainerManagedResource.java
+++ b/quarkus-test-containers/src/main/java/io/quarkus/test/services/containers/DockerContainerManagedResource.java
@@ -17,9 +17,11 @@ import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.ServiceContext;
 import io.quarkus.test.logging.LoggingHandler;
 import io.quarkus.test.logging.TestContainersLoggingHandler;
+import io.quarkus.test.utils.DockerUtils;
 
 public abstract class DockerContainerManagedResource implements ManagedResource {
 
+    private static final String DELETE_IMAGE_ON_STOP_PROPERTY = "container.delete.image.on.stop";
     private static final String RESOURCE_PREFIX = "resource::";
 
     private final ServiceContext context;
@@ -58,9 +60,15 @@ public abstract class DockerContainerManagedResource implements ManagedResource 
             loggingHandler.stopWatching();
         }
 
+        String image = innerContainer.getImage().get();
+
         if (isRunning()) {
             innerContainer.stop();
             innerContainer = null;
+        }
+
+        if (context.getOwner().getConfiguration().isTrue(DELETE_IMAGE_ON_STOP_PROPERTY)) {
+            DockerUtils.removeImageById(image);
         }
     }
 

--- a/quarkus-test-images/src/main/java/io/quarkus/test/utils/DockerUtils.java
+++ b/quarkus-test-images/src/main/java/io/quarkus/test/utils/DockerUtils.java
@@ -82,12 +82,19 @@ public final class DockerUtils {
         Image image = getImage(name, version);
         if (isVersion(image, version)) {
             stopContainersByImage(image.getId());
-
-            String id = image.getId().substring(image.getId().lastIndexOf(":") + 1);
-            dockerClient().removeImageCmd(id).withForce(true).exec();
+            removeImageById(image.getId());
             removed = true;
         }
         return removed;
+    }
+
+    /**
+     * Remove docker image by image id. Example: quay.io/bitnami/consul:1.9.3
+     * 
+     * @param imageId docker image to delete.
+     */
+    public static void removeImageById(String imageId) {
+        dockerClient().removeImageCmd(imageId).withForce(true).exec();
     }
 
     /**


### PR DESCRIPTION
If you want to delete the images after use, you need to provide the property `ts.<YOUR SERVICE NAME>.container.delete.image.on.stop=true` or
`ts.global.container.delete.image.on.stop=true` to apply this property to all the containers.