### PR TITLE
Exclude org.apache.tomcat.embed:tomcat-embed-core from jaeger-client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,13 @@
                 <groupId>io.jaegertracing</groupId>
                 <artifactId>jaeger-client</artifactId>
                 <version>${jaeger.version}</version>
+                <exclusions>
+                    <!-- CVE-2020-1938 // https://github.com/jaegertracing/jaeger-client-java/issues/800-->
+                    <exclusion>
+                        <groupId>org.apache.tomcat.embed</groupId>
+                        <artifactId>tomcat-embed-core</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>net.sourceforge.htmlunit</groupId>


### PR DESCRIPTION
This transitive dependency exposes a vulnerability, and looks like is not used by our tracer. 

Fix #261
