### PR TITLE
Adopt OpenJDK got moved to Eclipse Temurin

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -23,7 +23,9 @@ jobs:
       - name: Install JDK {{ matrix.java }}
         uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
         with:
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
+          check-latest: true
       - name: Build Quarkus main
         run: |
           git clone https://github.com/quarkusio/quarkus.git && cd quarkus && ./mvnw -B -s .github/mvn-settings.xml clean install -Dquickly
@@ -55,7 +57,9 @@ jobs:
       - name: Install JDK {{ matrix.java }}
         uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
         with:
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
+          check-latest: true
       - name: Build
         run: |
           if [[ "${{ matrix.quarkus-version }}" = 1.* ]]; then
@@ -98,7 +102,9 @@ jobs:
       - name: Install JDK {{ matrix.java }}
         uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
         with:
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
+          check-latest: true
       - name: Download Maven Repo
         uses: actions/download-artifact@v1
         with:
@@ -199,7 +205,9 @@ jobs:
       - name: Install JDK {{ matrix.java }}
         uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
         with:
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
+          check-latest: true
       - name: Download Maven Repo
         uses: actions/download-artifact@v1
         with:
@@ -248,7 +256,9 @@ jobs:
       - name: Install JDK {{ matrix.java }}
         uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
         with:
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
+          check-latest: true
       - name: Download Maven Repo
         uses: actions/download-artifact@v1
         with:
@@ -293,7 +303,9 @@ jobs:
       - name: Install JDK {{ matrix.java }}
         uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
         with:
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
+          check-latest: true
       - name: Download Maven Repo
         uses: actions/download-artifact@v1
         with:
@@ -354,7 +366,9 @@ jobs:
       - name: Install JDK {{ matrix.java }}
         uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
         with:
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
+          check-latest: true
       - uses: engineerd/setup-kind@v0.5.0
         with:
           version: "v0.11.1"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -19,7 +19,9 @@ jobs:
       - name: Install JDK {{ matrix.java }}
         uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
         with:
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
+          check-latest: true
       - name: Build with Maven
         run: |
           mvn -V -B -s .github/mvn-settings.xml verify -Pframework,examples -Dvalidate-format -DskipTests -DskipITs
@@ -43,7 +45,9 @@ jobs:
       - name: Install JDK {{ matrix.java }}
         uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
         with:
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
+          check-latest: true
       - name: Build Quarkus main
         run: |
           git clone https://github.com/quarkusio/quarkus.git && cd quarkus && ./mvnw -B -s .github/mvn-settings.xml clean install -Dquickly
@@ -76,7 +80,9 @@ jobs:
       - name: Install JDK {{ matrix.java }}
         uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
         with:
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
+          check-latest: true
       - name: Build in JVM mode
         run: |
           if [[ "${{ matrix.quarkus-version }}" = 1.* ]]; then
@@ -117,7 +123,9 @@ jobs:
       - name: Install JDK {{ matrix.java }}
         uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
         with:
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
+          check-latest: true
       - name: Download Maven Repo
         uses: actions/download-artifact@v1
         with:
@@ -166,7 +174,9 @@ jobs:
       - name: Install JDK {{ matrix.java }}
         uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
         with:
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
+          check-latest: true
       - name: Download Maven Repo
         uses: actions/download-artifact@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,9 @@ jobs:
 
       - uses: actions/setup-java@v1.4.3
         with:
-          java-version: 11
+          distribution: 'temurin'
+          java-version: ${{ matrix.java }}
+          check-latest: true
 
       - name: Configure Git author
         run: |


### PR DESCRIPTION
Adopt OpenJDK got moved to Eclipse Temurin and won't be updated anymore
More details: https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/