### PR TITLE
Fix forced dependencies when using 999-SNAPSHOT (future 2.3)

### DIFF
--- a/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/QuarkusScenarioBootstrap.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/QuarkusScenarioBootstrap.java
@@ -55,7 +55,7 @@ public class QuarkusScenarioBootstrap
     public void beforeAll(ExtensionContext context) {
         // Init scenario context
         scenario = new ScenarioContext(context);
-        Log.info("Scenario ID: '%s'", scenario.getId());
+        Log.debug("Scenario ID: '%s'", scenario.getId());
 
         // Init extensions
         extensions = initExtensions();

--- a/quarkus-test-core/src/main/java/io/quarkus/test/utils/ReflectionUtils.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/utils/ReflectionUtils.java
@@ -2,6 +2,7 @@ package io.quarkus.test.utils;
 
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -50,6 +51,21 @@ public final class ReflectionUtils {
         fields.addAll(findAllFields(clazz.getSuperclass()));
         fields.addAll(Arrays.asList(clazz.getDeclaredFields()));
         return fields;
+    }
+
+    public static <T> T createInstance(Class<T> clazz, Object... args) {
+        for (Constructor<?> constructor : clazz.getDeclaredConstructors()) {
+            if (constructor.getParameterCount() == args.length) {
+                try {
+                    return (T) constructor.newInstance(args);
+                } catch (Exception ex) {
+                    fail("Constructor failed to be called. Caused by " + ex.getMessage());
+                }
+            }
+        }
+
+        fail("Constructor not found for " + clazz);
+        return null;
     }
 
     public static Object invokeMethod(Object instance, String methodName, Object... args) {


### PR DESCRIPTION
This issue is caused by https://github.com/quarkusio/quarkus/pull/20070
Which is a breaking change and not backward compatible.