### PR TITLE
Refactor logging solution to work with other logging frameworks (jboss)

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,23 @@ The current configuration options are:
 ts.global.quarkus.expected.log=Installed features
 ```
 
-- Enable/Disable logging (enabled by default):
+- Logging
+
+In order to set the logging level (INFO by default), use:
+
+```
+# Possible values are: INFO, FINE, WARNING, SEVERE
+ts.global.log.level=INFO 
+```
+
+The same with the formatter log message and the target file:
+
+```
+ts.global.log.format=%d{HH:mm:ss,SSS} %-5p %s%e%n
+ts.global.log.file.output=target/logs/tests.log
+```
+
+Moreover, we can turn on/off (on by default) the logging by services using :
 
 ```
 ts.<YOUR SERVICE NAME>.log.enable=true

--- a/quarkus-test-core/src/main/resources/global.properties
+++ b/quarkus-test-core/src/main/resources/global.properties
@@ -1,5 +1,9 @@
-# Enable logging for all services by default
+# Logging
 ts.global.log.enable=true
+# Possible values are: INFO, FINE, WARNING, SEVERE
+ts.global.log.level=INFO
+ts.global.log.format=%d{HH:mm:ss,SSS} %-5p %s%e%n
+ts.global.log.file.output=target/logs/tests.log
 # Default startup timeout for services is 5 minutes
 ts.global.startup.timeout=5m
 # Default startup check poll interval is every 2 seconds

--- a/quarkus-test-core/src/main/resources/logging.properties
+++ b/quarkus-test-core/src/main/resources/logging.properties
@@ -1,14 +1,4 @@
-handlers = java.util.logging.ConsoleHandler,java.util.logging.FileHandler
-# Console
-java.util.logging.ConsoleHandler.level = INFO
-java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
-# File
-java.util.logging.FileHandler.level = INFO
-java.util.logging.FileHandler.pattern=target/logs/tests.log
-java.util.logging.FileHandler.formatter=java.util.logging.SimpleFormatter
-# Format
-java.util.logging.SimpleFormatter.format=%1$tH:%1$tM:%1$tS.%1$tL %4$-5s %5$s%6$s%n
 # Levels
-okhttp3.level = WARNING
+okhttp3.level=WARNING
 org.apache.http.level=WARNING
 com.gargoylesoftware.htmlunit.level=OFF


### PR DESCRIPTION
- Logging

In order to set the logging level (INFO by default), use:

```
# Possible values are: INFO, FINE, WARNING, SEVERE
ts.global.log.level=FINE 
```

The same with the formatter log message and the target file:

```
ts.global.log.format=%d{HH:mm:ss,SSS} %-5p %s%e%n
ts.global.log.file.output=target/logs/tests.log
```

Moreover, we can turn on/off (on by default) the logging by services using :

```
ts.<YOUR SERVICE NAME>.log.enable=true
```

Fix https://github.com/quarkus-qe/quarkus-test-framework/issues/234