### PR TITLE
Allow to use a custom application.properties per test scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,30 @@ public class PingPongResourceIT {
 
 As seen in the above example, everything is bounded to a Service object that will contain everything needed to interact with our resources.
 
+### Application properties
+
+By default, the test framework will use the `application.properties` file at `src/main/resources` folder. The service interface provides multiple methods to add properties at test scope only:
+- `service.withProperties(path)`
+- `service.withProperty(key, value)`
+
+If you want to use a different application properties file for all the tests, you can add the `application.properties` file at `src/test/resources` and the test framework will use this instead.
+
+Moreover, if you want to select a concrete application properties file for a single test scenario, then you can configure your Quarkus application using:
+
+```java
+@QuarkusScenario
+public class PingPongResourceIT {
+
+    // Now, the application will use the file `my-custom-properties.properties` instead of the `application.properties` 
+    @QuarkusApplication(properties = "my-custom-properties.properties")
+    static final RestService pingpong = new RestService();
+}
+```
+
+This option is available also for Dev Mode, Remote Dev mode and remote git applications, and works for JVM, Native, OpenShift and Kubernetes. 
+
+| Note that the test framework does not support the usage of YAML files yet [#240](https://github.com/quarkus-qe/quarkus-test-framework/issues/240)
+
 ### Forced Dependencies
 
 We can also specify dependencies that are not part of the pom.xml by doing:

--- a/examples/pingpong/src/test/java/io/quarkus/qe/ComputedValuesUsingCustomPropertiesPingPongResourceIT.java
+++ b/examples/pingpong/src/test/java/io/quarkus/qe/ComputedValuesUsingCustomPropertiesPingPongResourceIT.java
@@ -1,0 +1,22 @@
+package io.quarkus.qe;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.QuarkusApplication;
+
+@QuarkusScenario
+public class ComputedValuesUsingCustomPropertiesPingPongResourceIT {
+
+    @QuarkusApplication(properties = "custom.properties")
+    static final RestService pingpong = new RestService();
+
+    @Test
+    public void shouldGetComputedValuesFromCustomPropertiesFile() {
+        assertEquals("C", pingpong.getProperty("property.exists.only.in.custom.properties").get());
+    }
+
+}

--- a/examples/pingpong/src/test/java/io/quarkus/qe/DevModeComputedValuesUsingCustomPropertiesPingPongResourceIT.java
+++ b/examples/pingpong/src/test/java/io/quarkus/qe/DevModeComputedValuesUsingCustomPropertiesPingPongResourceIT.java
@@ -1,0 +1,22 @@
+package io.quarkus.qe;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.DevModeQuarkusApplication;
+
+@QuarkusScenario
+public class DevModeComputedValuesUsingCustomPropertiesPingPongResourceIT {
+
+    @DevModeQuarkusApplication(properties = "custom.properties")
+    static final RestService pingpong = new RestService();
+
+    @Test
+    public void shouldGetComputedValuesFromCustomPropertiesFile() {
+        assertEquals("C", pingpong.getProperty("property.exists.only.in.custom.properties").get());
+    }
+
+}

--- a/examples/pingpong/src/test/java/io/quarkus/qe/OpenShiftUsingExtensionComputedValuesUsingCustomPropertiesPingPongResourceIT.java
+++ b/examples/pingpong/src/test/java/io/quarkus/qe/OpenShiftUsingExtensionComputedValuesUsingCustomPropertiesPingPongResourceIT.java
@@ -1,0 +1,9 @@
+package io.quarkus.qe;
+
+import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
+import io.quarkus.test.scenarios.OpenShiftScenario;
+
+@OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
+public class OpenShiftUsingExtensionComputedValuesUsingCustomPropertiesPingPongResourceIT
+        extends ComputedValuesUsingCustomPropertiesPingPongResourceIT {
+}

--- a/examples/pingpong/src/test/resources/custom.properties
+++ b/examples/pingpong/src/test/resources/custom.properties
@@ -1,0 +1,1 @@
+property.exists.only.in.custom.properties=C

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/DevModeQuarkusApplication.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/DevModeQuarkusApplication.java
@@ -12,6 +12,11 @@ public @interface DevModeQuarkusApplication {
     Class<?>[] classes() default {};
 
     /**
+     * @return the properties file to use to configure the Quarkus application.
+     */
+    String properties() default "application.properties";
+
+    /**
      * Enable GRPC configuration. This property will map the gPRC service to a random port.
      */
     boolean grpc() default false;

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/GitRepositoryQuarkusApplication.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/GitRepositoryQuarkusApplication.java
@@ -17,4 +17,9 @@ public @interface GitRepositoryQuarkusApplication {
     String mavenArgs() default "-DskipTests=true -DskipITs=true -Dquarkus.platform.version=${QUARKUS_VERSION}";
 
     boolean devMode() default false;
+
+    /**
+     * @return the properties file to use to configure the Quarkus application.
+     */
+    String properties() default "application.properties";
 }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/QuarkusApplication.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/QuarkusApplication.java
@@ -17,6 +17,11 @@ public @interface QuarkusApplication {
     Class<? extends ManagedResourceBuilder> builder() default ProdQuarkusApplicationManagedResourceBuilder.class;
 
     /**
+     * @return the properties file to use to configure the Quarkus application.
+     */
+    String properties() default "application.properties";
+
+    /**
      * Add forced dependencies.
      */
     Dependency[] dependencies() default {};

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/RemoteDevModeQuarkusApplication.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/RemoteDevModeQuarkusApplication.java
@@ -9,4 +9,9 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface RemoteDevModeQuarkusApplication {
     String password() default "qe";
+
+    /**
+     * @return the properties file to use to configure the Quarkus application.
+     */
+    String properties() default "application.properties";
 }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/DevModeQuarkusApplicationManagedResourceBuilder.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/DevModeQuarkusApplicationManagedResourceBuilder.java
@@ -16,6 +16,7 @@ public class DevModeQuarkusApplicationManagedResourceBuilder extends QuarkusAppl
     public void init(Annotation annotation) {
         DevModeQuarkusApplication metadata = (DevModeQuarkusApplication) annotation;
         initAppClasses(metadata.classes());
+        setPropertiesFile(metadata.properties());
         setGrpcEnabled(metadata.grpc());
     }
 

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/GitRepositoryQuarkusApplicationManagedResourceBuilder.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/GitRepositoryQuarkusApplicationManagedResourceBuilder.java
@@ -57,6 +57,7 @@ public class GitRepositoryQuarkusApplicationManagedResourceBuilder extends ProdQ
         mavenArgs = metadata.mavenArgs();
         devMode = metadata.devMode();
         initAppClasses(new Class[0]);
+        setPropertiesFile(metadata.properties());
     }
 
     @Override

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/ProdQuarkusApplicationManagedResourceBuilder.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/ProdQuarkusApplicationManagedResourceBuilder.java
@@ -49,6 +49,7 @@ public class ProdQuarkusApplicationManagedResourceBuilder extends ArtifactQuarku
     @Override
     public void init(Annotation annotation) {
         QuarkusApplication metadata = (QuarkusApplication) annotation;
+        setPropertiesFile(metadata.properties());
         setSslEnabled(metadata.ssl());
         setGrpcEnabled(metadata.grpc());
         initAppClasses(metadata.classes());

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/RemoteDevModeQuarkusApplicationManagedResourceBuilder.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/RemoteDevModeQuarkusApplicationManagedResourceBuilder.java
@@ -48,6 +48,7 @@ public class RemoteDevModeQuarkusApplicationManagedResourceBuilder extends Artif
     public void init(Annotation annotation) {
         RemoteDevModeQuarkusApplication metadata = (RemoteDevModeQuarkusApplication) annotation;
         liveReloadPassword = metadata.password();
+        setPropertiesFile(metadata.properties());
     }
 
     @Override

--- a/quarkus-test-core/src/main/java/io/quarkus/test/utils/FileUtils.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/utils/FileUtils.java
@@ -1,5 +1,6 @@
 package io.quarkus.test.utils;
 
+import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
@@ -53,7 +54,7 @@ public final class FileUtils {
             fail("Could not load file " + file + " . Caused by " + e.getMessage());
         }
 
-        return null;
+        return EMPTY;
     }
 
     public static void recreateDirectory(Path folder) {

--- a/quarkus-test-core/src/main/java/io/quarkus/test/utils/PropertiesUtils.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/utils/PropertiesUtils.java
@@ -7,6 +7,7 @@ import java.io.InputStream;
 import java.io.PrintWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
 
@@ -53,7 +54,7 @@ public final class PropertiesUtils {
             fail("Could not load map from system resource. Caused by " + e);
         }
 
-        return null;
+        return Collections.emptyMap();
     }
 
     public static Map<String, String> toMap(Path path) {
@@ -63,7 +64,7 @@ public final class PropertiesUtils {
             fail("Could not load map from path. Caused by " + e);
         }
 
-        return null;
+        return Collections.emptyMap();
     }
 
     public static Map<String, String> toMap(InputStream is) {

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/ExtensionOpenShiftQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/ExtensionOpenShiftQuarkusApplicationManagedResource.java
@@ -42,8 +42,6 @@ public class ExtensionOpenShiftQuarkusApplicationManagedResource
     private static final String QUARKUS_KUBERNETES_DEPLOYMENT_TARGET = "quarkus.kubernetes.deployment-target";
     private static final String KNATIVE = "knative";
 
-    private static final String APPLICATION_PROPERTIES_PATH = "src/main/resources/application.properties";
-
     public ExtensionOpenShiftQuarkusApplicationManagedResource(ProdQuarkusApplicationManagedResourceBuilder model) {
         super(model);
     }
@@ -84,7 +82,7 @@ public class ExtensionOpenShiftQuarkusApplicationManagedResource
             return;
         }
 
-        Path applicationPropertiesPath = model.getContext().getServiceFolder().resolve(APPLICATION_PROPERTIES_PATH);
+        Path applicationPropertiesPath = model.getComputedApplicationProperties();
         if (Files.exists(applicationPropertiesPath)) {
             buildProperties.putAll(PropertiesUtils.toMap(applicationPropertiesPath));
         }


### PR DESCRIPTION
By default, the test framework will use the `application.properties` file at `src/main/resources` folder. The service interface provides multiple methods to add properties in the scenario:
- `service.withProperties(path)`
- `service.withProperty(key, value)`

If you want to use a different application properties file for all the tests, you can add the `application.properties` file at `src/test/resources` and the test framework will use this instead.

Moreover, if you want to select a concrete application properties file for a single test scenario, then you can configure your Quarkus application using:

```java
@QuarkusScenario
public class PingPongResourceIT {

    @QuarkusApplication(properties = "my-custom-properties.properties")
    static final RestService pingpong = new RestService();
}
```

This option is available also for Dev Mode, Remote Dev mode and remote git applications, and works for JVM, Native, OpenShift and Kubernetes. 

| Note that the test framework does not support the usage of YAML files yet [#240](https://github.com/quarkus-qe/quarkus-test-framework/issues/240)