### PR TITLE
Fix File Logging for Scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ The same with the formatter log message and the target file:
 
 ```
 ts.global.log.format=%d{HH:mm:ss,SSS} %-5p %s%e%n
-ts.global.log.file.output=target/logs/tests.log
+ts.global.log.file.output=target/logs
 ```
 
 Moreover, we can turn on/off (on by default) the logging by services using :

--- a/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/ScenarioContext.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/ScenarioContext.java
@@ -1,6 +1,11 @@
 package io.quarkus.test.bootstrap;
 
+import static io.quarkus.test.logging.Log.LOG_FILE_OUTPUT;
+import static io.quarkus.test.logging.Log.LOG_SUFFIX;
+
 import java.lang.annotation.Annotation;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Optional;
 
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -13,6 +18,7 @@ public final class ScenarioContext {
     private final String id;
     private final ExtensionContext.Namespace testNamespace;
     private ExtensionContext methodTestContext;
+    private boolean failed;
 
     protected ScenarioContext(ExtensionContext testContext) {
         this.testContext = testContext;
@@ -22,6 +28,10 @@ public final class ScenarioContext {
 
     public String getId() {
         return id;
+    }
+
+    public boolean isFailed() {
+        return failed;
     }
 
     public String getRunningTestClassName() {
@@ -54,6 +64,18 @@ public final class ScenarioContext {
 
     public void setMethodTestContext(ExtensionContext methodTestContext) {
         this.methodTestContext = methodTestContext;
+    }
+
+    public Path getLogFolder() {
+        return Paths.get(LOG_FILE_OUTPUT.get());
+    }
+
+    public Path getLogFile() {
+        return getLogFolder().resolve(getRunningTestClassName() + LOG_SUFFIX);
+    }
+
+    protected void markScenarioAsFailed() {
+        failed = true;
     }
 
     private static String generateScenarioId(ExtensionContext context) {

--- a/quarkus-test-core/src/main/resources/global.properties
+++ b/quarkus-test-core/src/main/resources/global.properties
@@ -5,7 +5,7 @@ ts.global.log.enable=true
 # Possible values are: INFO, FINE, WARNING, SEVERE
 ts.global.log.level=INFO
 ts.global.log.format=%d{HH:mm:ss,SSS} %-5p %s%e%n
-ts.global.log.file.output=target/logs/tests.log
+ts.global.log.file.output=target/logs
 
 ##############
 ## Timeouts ##

--- a/quarkus-test-kubernetes/src/main/java/io/quarkus/test/bootstrap/KubernetesExtensionBootstrap.java
+++ b/quarkus-test-kubernetes/src/main/java/io/quarkus/test/bootstrap/KubernetesExtensionBootstrap.java
@@ -1,5 +1,6 @@
 package io.quarkus.test.bootstrap;
 
+import java.nio.file.Path;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
@@ -53,7 +54,11 @@ public class KubernetesExtensionBootstrap implements ExtensionBootstrap {
     public void onError(ScenarioContext context, Throwable throwable) {
         Map<String, String> logs = client.logs();
         for (Entry<String, String> podLog : logs.entrySet()) {
-            FileUtils.copyContentTo(podLog.getValue(), Log.LOG_OUTPUT_DIRECTORY.resolve(podLog.getKey() + Log.LOG_SUFFIX));
+            FileUtils.copyContentTo(podLog.getValue(), logsTestFolder(context).resolve(podLog.getKey() + Log.LOG_SUFFIX));
         }
+    }
+
+    private Path logsTestFolder(ScenarioContext context) {
+        return context.getLogFolder().resolve(context.getRunningTestClassName());
     }
 }

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/OpenShiftExtensionBootstrap.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/OpenShiftExtensionBootstrap.java
@@ -81,7 +81,7 @@ public class OpenShiftExtensionBootstrap implements ExtensionBootstrap {
     }
 
     private Path logsTestFolder(ScenarioContext context) {
-        return Log.LOG_OUTPUT_DIRECTORY.resolve(context.getRunningTestClassName());
+        return context.getLogFolder().resolve(context.getRunningTestClassName());
     }
 
     private void installOperators(ScenarioContext context) {


### PR DESCRIPTION
Before, only the last scenario kept in the target/logs/tests.out file which made difficult to troubleshoot failures.

Now, all the scenarios will be logged in a separated log file and we will only keep only the log files when the scenario failed (test failures).