### PR TITLE
Change default Maven propagate properties strategy to ALL properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,20 @@ ts.global.port.range.max=49151
 ts.global.port.resolution.strategy=incremental
 ```
 
+- Maven
+
+The framework will use Maven commands for some scenarios like Dev Mode and Remote Dev Mode. We can configure the properties we want to propagate to these internal Maven commands using:
+
+```
+# Propagate Properties strategy to use in all Maven commands: 
+## - all: by default
+## - none
+## - only-quarkus: only properties starting with "quarkus."
+ts.global.maven.propagate-properties-strategy=all
+# When selecting the `all` strategy, the properties that start with any of the next list will be ignored:
+ts.global.maven.propagate-properties-strategy.all.exclude=sun.,awt.,java.,surefire.,user.,os.,jdk.,file.,basedir,line.,path.
+```
+
 ### Native
 
 The `@QuarkusScenario` annotation is also compatible with Native. This means that if we run our tests using Native build:

--- a/quarkus-test-core/src/main/java/io/quarkus/test/configuration/PropertyLookup.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/configuration/PropertyLookup.java
@@ -1,5 +1,10 @@
 package io.quarkus.test.configuration;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import org.apache.commons.lang3.StringUtils;
 
 import io.quarkus.test.bootstrap.ServiceContext;
@@ -67,5 +72,14 @@ public class PropertyLookup {
     public Integer getAsInteger() {
         String value = get();
         return Integer.parseInt(value);
+    }
+
+    public List<String> getAsList() {
+        String value = get();
+        if (StringUtils.isEmpty(value)) {
+            return Collections.emptyList();
+        }
+
+        return Stream.of(value.split(",")).collect(Collectors.toList());
     }
 }

--- a/quarkus-test-core/src/main/resources/global.properties
+++ b/quarkus-test-core/src/main/resources/global.properties
@@ -39,3 +39,10 @@ ts.global.port.resolution.strategy=incremental
 ###############
 # Default Quarkus expected successful output
 ts.global.quarkus.expected.log=Installed features
+
+###############
+### Maven ###
+###############
+# Propagate Properties strategy to use in all Maven commands: all, none, only-quarkus
+ts.global.maven.propagate-properties-strategy=all
+ts.global.maven.propagate-properties-strategy.all.exclude=sun.,awt.,java.,surefire.,user.,os.,jdk.,file.,basedir,line.,path.


### PR DESCRIPTION
The framework will use Maven commands for some scenarios like Dev Mode and Remote Dev Mode. We can configure the properties we want to propagate to these internal Maven commands using:

```
# Propagate Properties strategy to use in all Maven commands: 
## - all: by default
## - none
## - only-quarkus: only properties starting with "quarkus."
ts.global.maven.propagate-properties-strategy=all
```

Fix https://github.com/quarkus-qe/quarkus-test-framework/issues/289