### PR TITLE
Adapt quarkus test core to bootstrap setForcedDependencies change

### DIFF
--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/ProdQuarkusApplicationManagedResourceBuilder.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/ProdQuarkusApplicationManagedResourceBuilder.java
@@ -131,8 +131,12 @@ public class ProdQuarkusApplicationManagedResourceBuilder extends ArtifactQuarku
                     .setIsolateDeployment(true)
                     .setProjectRoot(testLocation)
                     .setBaseName(getContext().getName())
-                    .setForcedDependencies(getForcedDependencies())
                     .setTargetDirectory(appFolder);
+
+            // The method setForcedDependencies signature changed from `List<AppDependency>` to `List<Dependency>` where
+            // Dependency is an interface of AppDependency, so it should be fine. However, the compiler fails to cast it,
+            // so we need to use reflection to sort it out for the most recent version and older versions.
+            ReflectionUtils.invokeMethod(builder, "setForcedDependencies", getForcedDependencies());
 
             // The method `setLocalProjectDiscovery` signature changed from `Boolean` to `boolean` and this might make
             // to fail the tests at runtime when using different versions.


### PR DESCRIPTION
The method setForcedDependencies signature changed from `List<AppDependency>` to `List<Dependency>` where Dependency is an interface of AppDependency, so it should be fine. However, the compiler fails to cast it, so we need to use reflection to sort it out for the most recent version and older versions.

This change in upstream was added as part of this commit: https://github.com/quarkusio/quarkus/commit/657ae2965955ba1bd015d2049e4830dc223c1b36