### PR TITLE
Support Kubernetes Extension strategy

### DIFF
--- a/examples/pingpong/pom.xml
+++ b/examples/pingpong/pom.xml
@@ -56,5 +56,18 @@
                 </dependency>
             </dependencies>
         </profile>
+        <profile>
+            <id>deploy-to-kubernetes-using-extension</id>
+            <dependencies>
+                <dependency>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-kubernetes</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-container-image-jib</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 </project>

--- a/examples/pingpong/src/test/java/io/quarkus/qe/KubernetesPingPongResourceIT.java
+++ b/examples/pingpong/src/test/java/io/quarkus/qe/KubernetesPingPongResourceIT.java
@@ -1,7 +1,0 @@
-package io.quarkus.qe;
-
-import io.quarkus.test.scenarios.KubernetesScenario;
-
-@KubernetesScenario
-public class KubernetesPingPongResourceIT extends PingPongResourceIT {
-}

--- a/examples/pingpong/src/test/java/io/quarkus/qe/KubernetesUsingContainerRegistryPingPongResourceIT.java
+++ b/examples/pingpong/src/test/java/io/quarkus/qe/KubernetesUsingContainerRegistryPingPongResourceIT.java
@@ -1,0 +1,8 @@
+package io.quarkus.qe;
+
+import io.quarkus.test.scenarios.KubernetesDeploymentStrategy;
+import io.quarkus.test.scenarios.KubernetesScenario;
+
+@KubernetesScenario(deployment = KubernetesDeploymentStrategy.UsingContainerRegistry)
+public class KubernetesUsingContainerRegistryPingPongResourceIT extends PingPongResourceIT {
+}

--- a/examples/pingpong/src/test/java/io/quarkus/qe/KubernetesUsingExtensionPingPongResourceIT.java
+++ b/examples/pingpong/src/test/java/io/quarkus/qe/KubernetesUsingExtensionPingPongResourceIT.java
@@ -1,0 +1,21 @@
+package io.quarkus.qe;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.KubernetesDeploymentStrategy;
+import io.quarkus.test.scenarios.KubernetesScenario;
+import io.quarkus.test.services.QuarkusApplication;
+
+@KubernetesScenario(deployment = KubernetesDeploymentStrategy.UsingKubernetesExtension)
+public class KubernetesUsingExtensionPingPongResourceIT {
+
+    @QuarkusApplication
+    static final RestService pingpong = new RestService()
+            .withProperty("quarkus.kubernetes.service-type", "LoadBalancer");
+
+    @Test
+    public void shouldPingPongIsUpAndRunning() {
+        pingpong.logs().forQuarkus().installedFeatures().contains("kubernetes");
+    }
+}

--- a/quarkus-test-kubernetes/pom.xml
+++ b/quarkus-test-kubernetes/pom.xml
@@ -22,6 +22,10 @@
             <artifactId>openshift-client</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus.qe</groupId>
             <artifactId>quarkus-test-containers</artifactId>
             <optional>true</optional>

--- a/quarkus-test-kubernetes/src/main/java/io/quarkus/test/scenarios/KubernetesDeploymentStrategy.java
+++ b/quarkus-test-kubernetes/src/main/java/io/quarkus/test/scenarios/KubernetesDeploymentStrategy.java
@@ -1,0 +1,34 @@
+package io.quarkus.test.scenarios;
+
+import java.util.function.Function;
+
+import io.quarkus.test.services.quarkus.ContainerRegistryKubernetesQuarkusApplicationManagedResource;
+import io.quarkus.test.services.quarkus.ExtensionKubernetesQuarkusApplicationManagedResource;
+import io.quarkus.test.services.quarkus.KubernetesQuarkusApplicationManagedResource;
+import io.quarkus.test.services.quarkus.ProdQuarkusApplicationManagedResourceBuilder;
+
+/**
+ * Kubernetes Deployment strategies.
+ */
+public enum KubernetesDeploymentStrategy {
+    /**
+     * Will build the Quarkus app image and push it into a Container Registry to be accessed by Kubernetes to deploy the app.
+     */
+    UsingContainerRegistry(ContainerRegistryKubernetesQuarkusApplicationManagedResource::new),
+    /**
+     * Will use the OpenShift Quarkus extension to build and deploy into Kubernetes.
+     */
+    UsingKubernetesExtension(ExtensionKubernetesQuarkusApplicationManagedResource::new);
+
+    private final Function<ProdQuarkusApplicationManagedResourceBuilder, KubernetesQuarkusApplicationManagedResource> supplier;
+
+    KubernetesDeploymentStrategy(
+            Function<ProdQuarkusApplicationManagedResourceBuilder, KubernetesQuarkusApplicationManagedResource> supplier) {
+        this.supplier = supplier;
+    }
+
+    public KubernetesQuarkusApplicationManagedResource getManagedResource(
+            ProdQuarkusApplicationManagedResourceBuilder builder) {
+        return supplier.apply(builder);
+    }
+}

--- a/quarkus-test-kubernetes/src/main/java/io/quarkus/test/scenarios/KubernetesScenario.java
+++ b/quarkus-test-kubernetes/src/main/java/io/quarkus/test/scenarios/KubernetesScenario.java
@@ -15,4 +15,5 @@ import io.quarkus.test.bootstrap.QuarkusScenarioBootstrap;
 @ExtendWith(QuarkusScenarioBootstrap.class)
 @Inherited
 public @interface KubernetesScenario {
+    KubernetesDeploymentStrategy deployment() default KubernetesDeploymentStrategy.UsingContainerRegistry;
 }

--- a/quarkus-test-kubernetes/src/main/java/io/quarkus/test/services/quarkus/ContainerRegistryKubernetesQuarkusApplicationManagedResource.java
+++ b/quarkus-test-kubernetes/src/main/java/io/quarkus/test/services/quarkus/ContainerRegistryKubernetesQuarkusApplicationManagedResource.java
@@ -1,0 +1,72 @@
+package io.quarkus.test.services.quarkus;
+
+import static io.quarkus.test.services.quarkus.QuarkusApplicationManagedResourceBuilder.HTTP_PORT_DEFAULT;
+import static io.quarkus.test.services.quarkus.QuarkusApplicationManagedResourceBuilder.QUARKUS_HTTP_PORT_PROPERTY;
+import static java.util.regex.Pattern.quote;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+
+import io.quarkus.test.utils.DockerUtils;
+
+public class ContainerRegistryKubernetesQuarkusApplicationManagedResource
+        extends KubernetesQuarkusApplicationManagedResource<ArtifactQuarkusApplicationManagedResourceBuilder> {
+
+    private static final String DEPLOYMENT_SERVICE_PROPERTY = "kubernetes.service";
+    private static final String DEPLOYMENT_TEMPLATE_PROPERTY = "kubernetes.template";
+    private static final String QUARKUS_KUBERNETES_TEMPLATE = "/quarkus-app-kubernetes-template.yml";
+    private static final String DEPLOYMENT = "kubernetes.yml";
+
+    private String image;
+
+    public ContainerRegistryKubernetesQuarkusApplicationManagedResource(
+            ArtifactQuarkusApplicationManagedResourceBuilder model) {
+        super(model);
+    }
+
+    @Override
+    protected void doInit() {
+        image = createImageAndPush();
+        loadDeployment();
+    }
+
+    @Override
+    protected void doUpdate() {
+        loadDeployment();
+    }
+
+    protected Map<String, String> addExtraTemplateProperties() {
+        return Collections.emptyMap();
+    }
+
+    private String createImageAndPush() {
+        return DockerUtils.createImageAndPush(model.getContext(), getLaunchMode(), model.getArtifact());
+    }
+
+    private void loadDeployment() {
+        String deploymentFile = model.getContext().getOwner().getConfiguration().getOrDefault(DEPLOYMENT_TEMPLATE_PROPERTY,
+                QUARKUS_KUBERNETES_TEMPLATE);
+        client.applyServiceProperties(model.getContext().getOwner(), deploymentFile,
+                this::replaceDeploymentContent,
+                addExtraTemplateProperties(),
+                model.getContext().getServiceFolder().resolve(DEPLOYMENT));
+    }
+
+    private String replaceDeploymentContent(String content) {
+        String customServiceName = model.getContext().getOwner().getConfiguration().get(DEPLOYMENT_SERVICE_PROPERTY);
+        if (StringUtils.isNotEmpty(customServiceName)) {
+            // replace it by the service owner name
+            content = content.replaceAll(quote(customServiceName), model.getContext().getName());
+        }
+
+        return content
+                .replaceAll(quote("${IMAGE}"), image)
+                .replaceAll(quote("${SERVICE_NAME}"), model.getContext().getName())
+                .replaceAll(quote("${ARTIFACT}"), model.getArtifact().getFileName().toString())
+                .replaceAll(quote("${INTERNAL_PORT}"),
+                        model.getContext().getOwner().getProperty(QUARKUS_HTTP_PORT_PROPERTY, "" + HTTP_PORT_DEFAULT));
+    }
+
+}

--- a/quarkus-test-kubernetes/src/main/java/io/quarkus/test/services/quarkus/ExtensionKubernetesQuarkusApplicationManagedResource.java
+++ b/quarkus-test-kubernetes/src/main/java/io/quarkus/test/services/quarkus/ExtensionKubernetesQuarkusApplicationManagedResource.java
@@ -1,0 +1,166 @@
+package io.quarkus.test.services.quarkus;
+
+import static io.quarkus.test.utils.DockerUtils.CONTAINER_REGISTRY_URL_PROPERTY;
+import static io.quarkus.test.utils.MavenUtils.BATCH_MODE;
+import static io.quarkus.test.utils.MavenUtils.DISPLAY_VERSION;
+import static io.quarkus.test.utils.MavenUtils.PACKAGE_GOAL;
+import static io.quarkus.test.utils.MavenUtils.SKIP_CHECKSTYLE;
+import static io.quarkus.test.utils.MavenUtils.SKIP_ITS;
+import static io.quarkus.test.utils.MavenUtils.SKIP_TESTS;
+import static io.quarkus.test.utils.MavenUtils.installParentPomsIfNeeded;
+import static io.quarkus.test.utils.MavenUtils.mvnCommand;
+import static io.quarkus.test.utils.MavenUtils.withProperty;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang3.StringUtils;
+
+import io.quarkus.test.bootstrap.inject.KubectlClient;
+import io.quarkus.test.utils.Command;
+import io.quarkus.test.utils.FileUtils;
+import io.quarkus.test.utils.PropertiesUtils;
+
+public class ExtensionKubernetesQuarkusApplicationManagedResource
+        extends KubernetesQuarkusApplicationManagedResource<ProdQuarkusApplicationManagedResourceBuilder> {
+
+    private static final String USING_EXTENSION_PROFILE = "-Pdeploy-to-kubernetes-using-extension";
+    private static final String QUARKUS_PLUGIN_DEPLOY = "-Dquarkus.kubernetes.deploy=true";
+    private static final String QUARKUS_PLUGIN_INGRESS_EXPOSE = "-Dquarkus.kubernetes.ingress.expose=true";
+    private static final String QUARKUS_CONTAINER_NAME = "quarkus.application.name";
+    private static final String QUARKUS_CONTAINER_IMAGE_REGISTRY = "quarkus.container-image.registry";
+    private static final String QUARKUS_CONTAINER_IMAGE_GROUP = "quarkus.container-image.group";
+    private static final String QUARKUS_KUBERNETES_CLIENT_NAMESPACE = "quarkus.kubernetes-client.namespace";
+    private static final String QUARKUS_KUBERNETES_CLIENT_TRUST_CERTS = "quarkus.kubernetes-client.trust-certs";
+    private static final String QUARKUS_KUBERNETES_ENV_VARS = "quarkus.kubernetes.env.vars.";
+    private static final String QUARKUS_KUBERNETES_LABELS = "quarkus.kubernetes.labels.";
+    private static final Path RESOURCES_FOLDER = Paths.get("src", "main", "resources", "application.properties");
+
+    public ExtensionKubernetesQuarkusApplicationManagedResource(ProdQuarkusApplicationManagedResourceBuilder model) {
+        super(model);
+    }
+
+    @Override
+    protected void doInit() {
+        cloneProjectToServiceAppFolder();
+        copyBuildPropertiesIntoAppFolder();
+        deployProjectUsingMavenCommand();
+    }
+
+    @Override
+    protected void doUpdate() {
+        client.applyServicePropertiesUsingDeploymentConfig(model.getContext().getOwner());
+    }
+
+    @Override
+    public boolean needsBuildArtifact() {
+        return false;
+    }
+
+    @Override
+    public void validate() {
+        super.validate();
+
+        if (model.requiresCustomBuild()) {
+            fail("Custom source classes or forced dependencies is not supported by `UsingKubernetesExtension`");
+        }
+    }
+
+    protected void withAdditionalArguments(List<String> args) {
+
+    }
+
+    private void copyBuildPropertiesIntoAppFolder() {
+        Map<String, String> buildProperties = model.getBuildProperties();
+        if (buildProperties.isEmpty()) {
+            return;
+        }
+
+        Path applicationPropertiesPath = model.getComputedApplicationProperties();
+        if (Files.exists(applicationPropertiesPath)) {
+            buildProperties.putAll(PropertiesUtils.toMap(applicationPropertiesPath));
+        }
+
+        PropertiesUtils.fromMap(buildProperties, getContext().getServiceFolder().resolve(RESOURCES_FOLDER));
+        model.createSnapshotOfBuildProperties();
+    }
+
+    private void deployProjectUsingMavenCommand() {
+        installParentPomsIfNeeded();
+
+        String namespace = client.namespace();
+
+        List<String> args = mvnCommand(model.getContext());
+        args.addAll(Arrays.asList(USING_EXTENSION_PROFILE, BATCH_MODE, DISPLAY_VERSION, PACKAGE_GOAL,
+                QUARKUS_PLUGIN_DEPLOY, QUARKUS_PLUGIN_INGRESS_EXPOSE,
+                SKIP_TESTS, SKIP_ITS, SKIP_CHECKSTYLE));
+        propagateContainerRegistryIfSet(args);
+        args.add(withContainerName());
+        args.add(withKubernetesClientNamespace(namespace));
+        args.add(withKubernetesClientTrustCerts());
+        args.add(withLabelsForWatching());
+        args.add(withLabelsForScenarioId());
+        withEnvVars(args, model.getContext().getOwner().getProperties());
+        withAdditionalArguments(args);
+
+        try {
+            new Command(args).onDirectory(model.getContext().getServiceFolder()).runAndWait();
+        } catch (Exception e) {
+            fail("Failed to run maven command. Caused by " + e.getMessage());
+        }
+    }
+
+    private void propagateContainerRegistryIfSet(List<String> args) {
+        String containerRegistry = System.getProperty(CONTAINER_REGISTRY_URL_PROPERTY);
+        if (StringUtils.isNotEmpty(containerRegistry)) {
+            int lastSlash = containerRegistry.lastIndexOf("/");
+            String registryHost = containerRegistry.substring(0, lastSlash);
+            String registryGroup = containerRegistry.substring(lastSlash + 1);
+            args.add(withProperty(QUARKUS_CONTAINER_IMAGE_REGISTRY, registryHost));
+            args.add(withProperty(QUARKUS_CONTAINER_IMAGE_GROUP, registryGroup));
+        }
+    }
+
+    private String withLabelsForWatching() {
+        return withLabels(KubectlClient.LABEL_TO_WATCH_FOR_LOGS, model.getContext().getOwner().getName());
+    }
+
+    private String withLabelsForScenarioId() {
+        return withLabels(KubectlClient.LABEL_SCENARIO_ID, client.getScenarioId());
+    }
+
+    private String withLabels(String label, String value) {
+        return withProperty(QUARKUS_KUBERNETES_LABELS + label, value);
+    }
+
+    private String withContainerName() {
+        return withProperty(QUARKUS_CONTAINER_NAME, model.getContext().getName());
+    }
+
+    private String withKubernetesClientNamespace(String namespace) {
+        return withProperty(QUARKUS_KUBERNETES_CLIENT_NAMESPACE, namespace);
+    }
+
+    private String withKubernetesClientTrustCerts() {
+        return withProperty(QUARKUS_KUBERNETES_CLIENT_TRUST_CERTS, Boolean.TRUE.toString());
+    }
+
+    private void withEnvVars(List<String> args, Map<String, String> envVars) {
+        for (Entry<String, String> envVar : envVars.entrySet()) {
+            String envVarKey = envVar.getKey().replaceAll(Pattern.quote("."), "-");
+            args.add(withProperty(QUARKUS_KUBERNETES_ENV_VARS + envVarKey, envVar.getValue()));
+        }
+    }
+
+    private void cloneProjectToServiceAppFolder() {
+        FileUtils.copyCurrentDirectoryTo(model.getContext().getServiceFolder());
+    }
+
+}

--- a/quarkus-test-kubernetes/src/main/java/io/quarkus/test/services/quarkus/KubernetesQuarkusApplicationManagedResourceBinding.java
+++ b/quarkus-test-kubernetes/src/main/java/io/quarkus/test/services/quarkus/KubernetesQuarkusApplicationManagedResourceBinding.java
@@ -12,7 +12,9 @@ public class KubernetesQuarkusApplicationManagedResourceBinding implements Quark
 
     @Override
     public QuarkusManagedResource init(ProdQuarkusApplicationManagedResourceBuilder builder) {
-        return new KubernetesQuarkusApplicationManagedResource(builder);
+        KubernetesScenario annotation = builder.getContext().getTestContext().getRequiredTestClass()
+                .getAnnotation(KubernetesScenario.class);
+        return annotation.deployment().getManagedResource(builder);
     }
 
 }

--- a/quarkus-test-kubernetes/src/main/java/io/quarkus/test/services/quarkus/RemoteDevModeKubernetesQuarkusApplicationManagedResource.java
+++ b/quarkus-test-kubernetes/src/main/java/io/quarkus/test/services/quarkus/RemoteDevModeKubernetesQuarkusApplicationManagedResource.java
@@ -14,7 +14,8 @@ import io.quarkus.test.logging.Log;
 import io.quarkus.test.logging.LoggingHandler;
 import io.quarkus.test.utils.ProcessUtils;
 
-public class RemoteDevModeKubernetesQuarkusApplicationManagedResource extends KubernetesQuarkusApplicationManagedResource {
+public class RemoteDevModeKubernetesQuarkusApplicationManagedResource extends
+        ContainerRegistryKubernetesQuarkusApplicationManagedResource {
 
     private static final String REMOTE_DEV_LOG_OUTPUT_FILE = "remote-dev-out.log";
 


### PR DESCRIPTION
#### Deployment Strategies

Kubernetes needs a container registry where to push and pull images, so we need to provide a property like:

```
mvn clean verify -Dts.container.registry-url=quay.io/<your username>
```

The container registry must automatically expose the containers publicly.

These tests can be disabled if the above system property is not set using the `@DisabledIfNotContainerRegistry` annotation.

The same applies for all the deployment strategies available:

- **(Default) Container Registry**

This strategy will build the image locally and push it to an intermediary container registry (provided by a system property). Then, the image will be pulled from the container registry into Kubernetes.

```java
@KubernetesScenario(deployment = KubernetesDeploymentStrategy.UsingContainerRegistry)
public class KubernetesPingPongResourceIT {
    // ...
}
```

- **Kubernetes Extension**

This strategy will delegate the deployment into the Quarkus Kubernetes extension, so it will trigger a Maven command to run it.

Example:

```java
@KubernetesScenario(deployment = KubernetesDeploymentStrategy.UsingKubernetesExtension)
public class KubernetesPingPongResourceIT {
    // ...
}
```

In order to use this strategy, you need to add this Maven profile into the pom.xml:

```xml
<profile>
    <id>deploy-to-kubernetes-using-extension</id>
    <dependencies>
        <dependency>
            <groupId>io.quarkus</groupId>
            <artifactId>quarkus-kubernetes</artifactId>
        </dependency>
        <dependency>
            <groupId>io.quarkus</groupId>
            <artifactId>quarkus-container-image-jib</artifactId>
        </dependency>
    </dependencies>
</profile>
```

| Important note: This strategy does not support custom sources to be selected, this means that the whole Maven module will be deployed. Therefore, if we have:

Take into account that we have used the `quarkus-container-image-jib` dependency to build the Quarkus image, but we can use any from [https://quarkus.io/guides/container-image](https://quarkus.io/guides/container-image).

```java
@KubernetesScenario(deployment = KubernetesDeploymentStrategy.UsingKubernetesExtension)
public class KubernetesPingPongResourceIT {
    @QuarkusApplication(classes = PingResource.class)
    static final RestService pingPongApp = new RestService();
    
    // ...
}
```

The test case will fail saying that this is not supported using the Using Kubernetes extension strategy.