### PR TITLE
Improve s2i properties to use the standard ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -1001,6 +1001,8 @@ public class OpenShiftPingPongResourceIT {
 }
 ```
 
+By default, the base native image to be used by this method is `quay.io/quarkus/ubi-quarkus-native-binary-s2i:1.0` and can be configured using the property `-Dts.global.quarkus.s2i.base-native-binary-image`.
+
 The default template used by this strategy can be overwritten using the property `ts.global.openshift.template`. 
 
 - **OpenShift Extension**
@@ -1081,12 +1083,7 @@ public class OpenShiftS2iQuickstartIT {
     //
 ```
 
-This scenario will work for JVM and Native builds. In order to manage the base image in use, you need to provide the properties:
-- For JVM: `ts.global.s2i.quarkus.jvm.builder.image`
-- For Native: `ts.global.s2i.quarkus.native.builder.image`
-
-The way these properties are up to users. In the examples, we supply this configuration in the pom.xml as part of system properties (in the Maven failsafe plugin). 
-But we can provide a custom property by service in the `test.properties` file. For further information about how to customise the properties, go to the [Configuration](#configuration) section.
+This scenario will work for JVM and Native builds.
 
 It's important to note that, by default, OpenShift will build the application's source code using the Red Hat maven repository `https://maven.repository.redhat.com/ga/`. However, some applications might require some dependencies from other remote Maven repositories. In order to allow us to add another remote Maven repository, you can use `-Dts.global.s2i.maven.remote.repository=http://host:port/repo/name`. If you only want to configure different maven repositories by service, you can do it by replacing `global` to the service name, for example: `-Dts.pingPong.s2i.maven.remote.repository=...`.
 

--- a/examples/pingpong/src/test/java/io/quarkus/qe/OpenShiftUsingContainerRegistryPingPongResourceIT.java
+++ b/examples/pingpong/src/test/java/io/quarkus/qe/OpenShiftUsingContainerRegistryPingPongResourceIT.java
@@ -4,7 +4,7 @@ import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.scenarios.annotations.EnabledIfOpenShiftScenarioPropertyIsTrue;
 
-@OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingContainerRegistry)
 @EnabledIfOpenShiftScenarioPropertyIsTrue
+@OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingContainerRegistry)
 public class OpenShiftUsingContainerRegistryPingPongResourceIT extends PingPongResourceIT {
 }

--- a/pom.xml
+++ b/pom.xml
@@ -61,9 +61,6 @@
         <checkstyle.version>9.0.1</checkstyle.version>
         <!-- Code Coverage Properties-->
         <jacoco.agent.argLine />
-        <!-- S2i configuration -->
-        <ts.global.s2i.quarkus.jvm.builder.image>registry.access.redhat.com/ubi8/openjdk-11:latest</ts.global.s2i.quarkus.jvm.builder.image>
-        <ts.global.s2i.quarkus.native.builder.image>quay.io/quarkus/ubi-quarkus-native-s2i:21.2-java11</ts.global.s2i.quarkus.native.builder.image>
     </properties>
     <distributionManagement>
         <snapshotRepository>
@@ -213,16 +210,6 @@
                 <plugin>
                     <artifactId>maven-failsafe-plugin</artifactId>
                     <version>${surefire-plugin.version}</version>
-                    <executions>
-                        <execution>
-                            <configuration>
-                                <systemProperties>
-                                    <ts.global.s2i.quarkus.jvm.builder.image>${ts.global.s2i.quarkus.jvm.builder.image}</ts.global.s2i.quarkus.jvm.builder.image>
-                                    <ts.global.s2i.quarkus.native.builder.image>${ts.global.s2i.quarkus.native.builder.image}</ts.global.s2i.quarkus.native.builder.image>
-                                </systemProperties>
-                            </configuration>
-                        </execution>
-                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/model/QuarkusProperties.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/model/QuarkusProperties.java
@@ -19,6 +19,10 @@ public final class QuarkusProperties {
     public static final List<String> PACKAGE_TYPE_NATIVE_VALUES = Arrays.asList("native", "native-sources");
     public static final List<String> PACKAGE_TYPE_LEGACY_JAR_VALUES = Arrays.asList("legacy-jar", "uber-jar", "mutable-jar");
     public static final List<String> PACKAGE_TYPE_JVM_VALUES = Arrays.asList("fast-jar", "jar");
+    public static final PropertyLookup QUARKUS_JVM_S2I = new PropertyLookup("quarkus.s2i.base-jvm-image",
+            "registry.access.redhat.com/ubi8/openjdk-11:latest");
+    public static final PropertyLookup QUARKUS_NATIVE_S2I = new PropertyLookup("quarkus.s2i.base-native-image",
+            "quay.io/quarkus/ubi-quarkus-native-binary-s2i:1.0");
 
     private QuarkusProperties() {
 

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/BuildOpenShiftQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/BuildOpenShiftQuarkusApplicationManagedResource.java
@@ -1,6 +1,8 @@
 package io.quarkus.test.services.quarkus;
 
 import static io.quarkus.test.services.quarkus.QuarkusApplicationManagedResourceBuilder.HTTP_PORT_DEFAULT;
+import static io.quarkus.test.services.quarkus.model.QuarkusProperties.QUARKUS_JVM_S2I;
+import static io.quarkus.test.services.quarkus.model.QuarkusProperties.QUARKUS_NATIVE_S2I;
 import static java.util.regex.Pattern.quote;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -15,13 +17,7 @@ public class BuildOpenShiftQuarkusApplicationManagedResource
     private static final String S2I_DEFAULT_VERSION = "latest";
 
     private static final String QUARKUS_OPENSHIFT_TEMPLATE = "/quarkus-build-openshift-template.yml";
-
     private static final String IMAGE_TAG_SEPARATOR = ":";
-
-    private static final PropertyLookup UBI_QUARKUS_JVM_S2I = new PropertyLookup("quarkus.s2i.base-jvm-image",
-            "registry.access.redhat.com/ubi8/openjdk-11:latest");
-    private static final PropertyLookup UBI_QUARKUS_NATIVE_S2I = new PropertyLookup("quarkus.s2i.base-native-image",
-            "quay.io/quarkus/ubi-quarkus-native-binary-s2i:1.0");
 
     public BuildOpenShiftQuarkusApplicationManagedResource(ArtifactQuarkusApplicationManagedResourceBuilder model) {
         super(model);
@@ -76,11 +72,8 @@ public class BuildOpenShiftQuarkusApplicationManagedResource
     }
 
     private String getS2iImage() {
-        PropertyLookup s2iImageProperty = UBI_QUARKUS_JVM_S2I;
-        if (isNativeTest()) {
-            s2iImageProperty = UBI_QUARKUS_NATIVE_S2I;
-        }
-
-        return s2iImageProperty.get(model.getContext());
+        PropertyLookup s2iImageProperty = isNativeTest() ? QUARKUS_NATIVE_S2I : QUARKUS_JVM_S2I;
+        return model.getContext().getOwner().getProperty(s2iImageProperty.getPropertyKey())
+                .orElseGet(() -> s2iImageProperty.get(model.getContext()));
     }
 }


### PR DESCRIPTION
The properties `ts.global.s2i.quarkus.jvm.builder.image` and `ts.global.s2i.quarkus.native.builder.image` properties have been deleted in favour of the Quarkus official ones:
- quarkus.s2i.base-jvm-image
- quarkus.s2i.base-native-image

Moreover, when using the OpenShift extension, if the user does not supply the `quarkus.openshift.base-xxx-image`, the framework will use the ones from `quarkus.s2i.base-xxx-image`.