### PR TITLE
keycloak multi-tenant (multi-realm)

### DIFF
--- a/examples/keycloak/src/test/java/io/quarkus/qe/BaseSecurityResourceIT.java
+++ b/examples/keycloak/src/test/java/io/quarkus/qe/BaseSecurityResourceIT.java
@@ -8,7 +8,6 @@ import org.keycloak.authorization.client.AuthzClient;
 
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.RestService;
-import io.quarkus.test.services.Container;
 
 public abstract class BaseSecurityResourceIT {
 
@@ -17,12 +16,11 @@ public abstract class BaseSecurityResourceIT {
     static final String CLIENT_SECRET_DEFAULT = "test-application-client-secret";
     static final String NORMAL_USER = "test-normal-user";
 
-    @Container(image = "quay.io/keycloak/keycloak:14.0.0", expectedLog = "Admin console listening", port = 8080)
-    static final KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT);
-
-    private AuthzClient authzClient;
+    protected AuthzClient authzClient;
 
     protected abstract RestService getApp();
+
+    protected abstract KeycloakService getKeycloak();
 
     @BeforeEach
     public void setup() {
@@ -39,8 +37,8 @@ public abstract class BaseSecurityResourceIT {
                 .body(equalTo("Hello, user test-normal-user"));
     }
 
-    private void initAuthzClient() {
-        authzClient = keycloak.createAuthzClient(CLIENT_ID_DEFAULT, CLIENT_SECRET_DEFAULT);
+    protected void initAuthzClient() {
+        authzClient = getKeycloak().createAuthzClient(CLIENT_ID_DEFAULT, CLIENT_SECRET_DEFAULT);
     }
 
     private String getTokenByTestNormalUser() {

--- a/examples/keycloak/src/test/java/io/quarkus/qe/DevModeSecurityResourceIT.java
+++ b/examples/keycloak/src/test/java/io/quarkus/qe/DevModeSecurityResourceIT.java
@@ -1,19 +1,30 @@
 package io.quarkus.qe;
 
+import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.Container;
 import io.quarkus.test.services.DevModeQuarkusApplication;
 
 @QuarkusScenario
 public class DevModeSecurityResourceIT extends BaseSecurityResourceIT {
+
+    @Container(image = "quay.io/keycloak/keycloak:14.0.0", expectedLog = "Admin console listening", port = 8080)
+    static final KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT);
+
     @DevModeQuarkusApplication
     static final RestService app = new RestService()
-            .withProperty("quarkus.oidc.auth-server-url", () -> keycloak.getRealmUrl())
+            .withProperty("quarkus.oidc.auth-server-url", () -> keycloak.getRealmUrl(REALM_DEFAULT))
             .withProperty("quarkus.oidc.client-id", CLIENT_ID_DEFAULT)
             .withProperty("quarkus.oidc.credentials.secret", CLIENT_SECRET_DEFAULT);
 
     @Override
     public RestService getApp() {
         return app;
+    }
+
+    @Override
+    protected KeycloakService getKeycloak() {
+        return keycloak;
     }
 }

--- a/examples/keycloak/src/test/java/io/quarkus/qe/MultiRealmResourceIT.java
+++ b/examples/keycloak/src/test/java/io/quarkus/qe/MultiRealmResourceIT.java
@@ -1,5 +1,7 @@
 package io.quarkus.qe;
 
+import java.util.List;
+
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
@@ -7,14 +9,18 @@ import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @QuarkusScenario
-public class SecurityResourceIT extends BaseSecurityResourceIT {
+public class MultiRealmResourceIT extends BaseSecurityResourceIT {
+    static final String SELECTED_REALM = "test-two-realm";
+    static final List<String> DEFAULT_REALMS = List.of("test-realm", SELECTED_REALM);
+    static final String CLIENT_ID_DEFAULT = "test-application-client";
+    static final String CLIENT_SECRET_DEFAULT = "test-application-client-secret";
 
     @Container(image = "quay.io/keycloak/keycloak:14.0.0", expectedLog = "Admin console listening", port = 8080)
-    static final KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT);
+    static final KeycloakService keycloak = new KeycloakService(DEFAULT_REALMS, "/realms");
 
     @QuarkusApplication
     static final RestService app = new RestService()
-            .withProperty("quarkus.oidc.auth-server-url", () -> keycloak.getRealmUrl(REALM_DEFAULT))
+            .withProperty("quarkus.oidc.auth-server-url", () -> keycloak.getRealmUrl(SELECTED_REALM))
             .withProperty("quarkus.oidc.client-id", CLIENT_ID_DEFAULT)
             .withProperty("quarkus.oidc.credentials.secret", CLIENT_SECRET_DEFAULT);
 
@@ -26,5 +32,10 @@ public class SecurityResourceIT extends BaseSecurityResourceIT {
     @Override
     protected KeycloakService getKeycloak() {
         return keycloak;
+    }
+
+    @Override
+    protected void initAuthzClient() {
+        authzClient = getKeycloak().createAuthzClient(SELECTED_REALM, CLIENT_ID_DEFAULT, CLIENT_SECRET_DEFAULT);
     }
 }

--- a/examples/keycloak/src/test/java/io/quarkus/qe/OpenShiftUsingBuildMultiRealmResourceIT.java
+++ b/examples/keycloak/src/test/java/io/quarkus/qe/OpenShiftUsingBuildMultiRealmResourceIT.java
@@ -1,0 +1,8 @@
+package io.quarkus.qe;
+
+import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
+import io.quarkus.test.scenarios.OpenShiftScenario;
+
+@OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.Build)
+public class OpenShiftUsingBuildMultiRealmResourceIT extends MultiRealmResourceIT {
+}

--- a/examples/keycloak/src/test/java/io/quarkus/qe/OpenShiftUsingCustomTemplateResourceIT.java
+++ b/examples/keycloak/src/test/java/io/quarkus/qe/OpenShiftUsingCustomTemplateResourceIT.java
@@ -20,7 +20,7 @@ public class OpenShiftUsingCustomTemplateResourceIT {
 
     @QuarkusApplication
     static final RestService app = new RestService()
-            .withProperty("quarkus.oidc.auth-server-url", customkeycloak::getRealmUrl)
+            .withProperty("quarkus.oidc.auth-server-url", () -> customkeycloak.getRealmUrl(REALM_DEFAULT))
             .withProperty("quarkus.oidc.client-id", CLIENT_ID_DEFAULT)
             .withProperty("quarkus.oidc.credentials.secret", CLIENT_SECRET_DEFAULT);
 

--- a/examples/keycloak/src/test/resources/realms/keycloak-test-realm.json
+++ b/examples/keycloak/src/test/resources/realms/keycloak-test-realm.json
@@ -1,0 +1,57 @@
+{
+  "realm": "test-realm",
+  "enabled": true,
+  "sslRequired": "none",
+  "accessTokenLifespan": 5,
+  "roles": {
+    "realm": [
+      {
+        "name": "test-user-role"
+      },
+      {
+        "name": "test-admin-role"
+      }
+    ]
+  },
+  "users": [
+    {
+      "username": "test-normal-user",
+      "enabled": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "test-normal-user"
+        }
+      ],
+      "realmRoles": [
+        "test-user-role"
+      ]
+    },
+    {
+      "username": "test-admin-user",
+      "enabled": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "test-admin-user"
+        }
+      ],
+      "realmRoles": [
+        "test-admin-role",
+        "test-user-role"
+      ]
+    }
+  ],
+  "clients": [
+    {
+      "clientId": "test-application-client",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "test-application-client-secret"
+    }
+  ]
+}

--- a/examples/keycloak/src/test/resources/realms/keycloak-test-two-realm.json
+++ b/examples/keycloak/src/test/resources/realms/keycloak-test-two-realm.json
@@ -1,0 +1,57 @@
+{
+  "realm": "test-two-realm",
+  "enabled": true,
+  "sslRequired": "none",
+  "accessTokenLifespan": 5,
+  "roles": {
+    "realm": [
+      {
+        "name": "test-user-role"
+      },
+      {
+        "name": "test-admin-role"
+      }
+    ]
+  },
+  "users": [
+    {
+      "username": "test-normal-user",
+      "enabled": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "test-normal-user"
+        }
+      ],
+      "realmRoles": [
+        "test-user-role"
+      ]
+    },
+    {
+      "username": "test-admin-user",
+      "enabled": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "test-admin-user"
+        }
+      ],
+      "realmRoles": [
+        "test-admin-role",
+        "test-user-role"
+      ]
+    }
+  ],
+  "clients": [
+    {
+      "clientId": "test-application-client",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "test-application-client-secret"
+    }
+  ]
+}

--- a/quarkus-test-service-keycloak/src/main/java/io/quarkus/test/bootstrap/KeycloakService.java
+++ b/quarkus-test-service-keycloak/src/main/java/io/quarkus/test/bootstrap/KeycloakService.java
@@ -1,6 +1,12 @@
 package io.quarkus.test.bootstrap;
 
+import static io.quarkus.test.utils.PropertiesUtils.SLASH;
+
+import java.io.File;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.impl.client.HttpClients;
@@ -13,20 +19,39 @@ public class KeycloakService extends BaseService<KeycloakService> {
     private static final String PASSWORD = "admin";
     private static final int HTTP_80 = 80;
 
-    private final String realm;
+    private final List<String> realms = new ArrayList<>();
 
     public KeycloakService(String file, String realm) {
         this(realm);
         withProperty("KEYCLOAK_IMPORT", "resource::" + file);
     }
 
-    public KeycloakService(String realm) {
-        this.realm = realm;
+    public KeycloakService(List<String> realms, String realmsFolderPath) {
+        this.realms.addAll(realms);
+        if (realmsFolderPath.startsWith(SLASH)) {
+            realmsFolderPath = realmsFolderPath.replaceFirst(SLASH, StringUtils.EMPTY);
+        }
+
+        if (!isValidRealmFolder(realmsFolderPath)) {
+            throw new RuntimeException(String.format("Unexpected realms folder %s ", realmsFolderPath));
+        }
+
+        withProperty("KEYCLOAK_OCP_FOLDER", "resource:://" + realmsFolderPath);
+        withProperty("JAVA_OPTS_APPEND", "-Dkeycloak.migration.action=import "
+                + "-Dkeycloak.migration.provider=dir "
+                + "-Dkeycloak.migration.dir=/" + realmsFolderPath + " "
+                + "-Dkeycloak.migration.strategy=OVERWRITE_EXISTING ");
         withProperty("KEYCLOAK_USER", USER);
         withProperty("KEYCLOAK_PASSWORD", PASSWORD);
     }
 
-    public String getRealmUrl() {
+    public KeycloakService(String realm) {
+        this.realms.add(realm);
+        withProperty("KEYCLOAK_USER", USER);
+        withProperty("KEYCLOAK_PASSWORD", PASSWORD);
+    }
+
+    public String getRealmUrl(String realm) {
         String url = getHost();
         // SMELL: Keycloak does not validate Token Issuers when URL contains the port 80.
         if (getPort() != HTTP_80) {
@@ -37,11 +62,41 @@ public class KeycloakService extends BaseService<KeycloakService> {
     }
 
     public AuthzClient createAuthzClient(String clientId, String clientSecret) {
+        String realm = getMainRealm();
+        return authzClientInstance(realm, clientId, clientSecret);
+    }
+
+    public AuthzClient createAuthzClient(String realm, String clientId, String clientSecret) {
+        if (!realms.contains(realm)) {
+            throw new RuntimeException(String.format("Realm %s not found", realm));
+        }
+
+        return authzClientInstance(realm, clientId, clientSecret);
+    }
+
+    private AuthzClient authzClientInstance(String realm, String clientId, String clientSecret) {
         return AuthzClient.create(new Configuration(
-                StringUtils.substringBefore(getRealmUrl(), "/realms"),
+                StringUtils.substringBefore(getRealmUrl(realm), "/realms"),
                 realm,
                 clientId,
                 Collections.singletonMap("secret", clientSecret),
                 HttpClients.createDefault()));
+    }
+
+    private String getMainRealm() {
+        return realms.stream()
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("Unexpected empty realms"));
+    }
+
+    private boolean isValidRealmFolder(String realmsFolderPath) {
+        ClassLoader classLoader = getClass().getClassLoader();
+        File realmsFolder = new File(classLoader.getResource(realmsFolderPath).getFile());
+        String[] realmConfigFiles = filterRealmConfigFiles(realmsFolder);
+        return realmsFolder.isDirectory() && realmConfigFiles.length > 0;
+    }
+
+    private String[] filterRealmConfigFiles(File realmsFolderPath) {
+        return Objects.requireNonNull(realmsFolderPath.list((dir, name) -> name.contains(".json")));
     }
 }


### PR DESCRIPTION
Ideally, when we want to have a multi-tenant scenario we should have one realm per tenant in order to have different user databases and pub/private keys per tenant. This PR amend these changes in order to support this kind of scenario. 
Changes: 
- Add a new `KeycloakService` constructor in order to support multiple realms
- New `createAuthzClient` in order to create a client for a given realm
- Ammend keycloak test in order to reuse the most of test cases and code 

Depends on: https://github.com/quarkus-qe/quarkus-test-framework/pull/315