### PR TITLE
Remove Testcontainers and DockerJava dependencies (Quarkus 1.x incomp)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,3 @@ updates:
     ignore:
       # For Quarkus Maven Plugin, updates are managed by the Quarkus Bom dependency
       - dependency-name: io.quarkus:quarkus-maven-plugin
-      # Exclude Docker Java as it might conflict with Testcontainers and Quarkus
-      - dependency-name: com.github.docker-java:docker-java-core
-      - dependency-name: com.github.docker-java:docker-java-api
-      - dependency-name: com.github.docker-java:docker-java-transport-zerodep

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        quarkus-version: ["1.13.7.Final", "current"]
+        quarkus-version: ["current"]
         java: [ 11 ]
     steps:
       - uses: actions/checkout@v1
@@ -62,15 +62,17 @@ jobs:
           check-latest: true
       - name: Build
         run: |
+          MAVEN_PROFILES="-Pframework,examples"
           if [[ "${{ matrix.quarkus-version }}" = 1.* ]]; then
              EXCLUDE_MODULES="-pl !examples/grpc"
+             MAVEN_PROFILES=$MAVEN_PROFILES
           fi
 
           if [[ "${{ matrix.quarkus-version }}" != current ]]; then
              QUARKUS_VERSION="-Dquarkus.platform.version=${{ matrix.quarkus-version }}"
           fi
 
-          mvn -fae -s .github/mvn-settings.xml clean install -Pframework,examples -Dvalidate-format $QUARKUS_VERSION $EXCLUDE_MODULES
+          mvn -fae -s .github/mvn-settings.xml clean install  -Dvalidate-format $QUARKUS_VERSION $EXCLUDE_MODULES
       - name: Zip Artifacts
         if: failure()
         run: |
@@ -190,7 +192,7 @@ jobs:
     needs: quarkus-main-build
     strategy:
       matrix:
-        quarkus-version: ["1.13.7.Final", "current", "999-SNAPSHOT"]
+        quarkus-version: ["current", "999-SNAPSHOT"]
         java: [ 11 ]
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -65,7 +65,7 @@ jobs:
     needs: validate-format
     strategy:
       matrix:
-        quarkus-version: ["1.13.7.Final", "current"]
+        quarkus-version: ["current"]
         java: [ 11 ]
     steps:
       - uses: actions/checkout@v1

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <surefire-plugin.version>2.22.2</surefire-plugin.version>
-        <testcontainers.version>1.16.0</testcontainers.version>
         <jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
         <jaeger.version>1.6.0</jaeger.version>
         <prometheus.simpleclient_pushgateway.version>0.12.0</prometheus.simpleclient_pushgateway.version>
@@ -50,7 +49,6 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>2.3.0.Final</quarkus.platform.version>
-        <com.github.docker-java.version>3.2.11</com.github.docker-java.version>
         <exclude.tests.with.tags>quarkus-cli</exclude.tests.with.tags>
         <include.tests>**/*IT.java</include.tests>
         <exclude.openshift.tests>**/OpenShift*IT.java</exclude.openshift.tests>
@@ -74,13 +72,6 @@
     </distributionManagement>
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>org.testcontainers</groupId>
-                <artifactId>testcontainers-bom</artifactId>
-                <version>${testcontainers.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
             <dependency>
                 <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>${quarkus.platform.artifact-id}</artifactId>
@@ -174,21 +165,6 @@
                 <groupId>io.prometheus</groupId>
                 <artifactId>simpleclient_pushgateway</artifactId>
                 <version>${prometheus.simpleclient_pushgateway.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.github.docker-java</groupId>
-                <artifactId>docker-java-core</artifactId>
-                <version>${com.github.docker-java.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.github.docker-java</groupId>
-                <artifactId>docker-java-api</artifactId>
-                <version>${com.github.docker-java.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.github.docker-java</groupId>
-                <artifactId>docker-java-transport-zerodep</artifactId>
-                <version>${com.github.docker-java.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Removing the testcontainers and dockerhub dependencies in quarkus test framework, and start using the ones imported in Quarkus 2.x Bom.

Note that this change makes the test framework incompatible with Quarkus 1.x. Users would need to use previous versions of the test framework to continue using it.