### PR TITLE
Kafka 2.7.0 is not supported by ocp49 strimzi operator anymore

### DIFF
--- a/quarkus-test-service-kafka/src/main/resources/strimzi-operator-kafka-instance.yaml
+++ b/quarkus-test-service-kafka/src/main/resources/strimzi-operator-kafka-instance.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kafka-instance
 spec:
   kafka:
-    version: 2.7.0
+    version: 2.8.0
     replicas: 1
     listeners:
       - name: plain
@@ -19,7 +19,7 @@ spec:
       offsets.topic.replication.factor: 1
       transaction.state.log.replication.factor: 1
       transaction.state.log.min.isr: 1
-      log.message.format.version: "2.7"
+      log.message.format.version: "2.8"
     storage:
       type: jbod
       volumes:


### PR DESCRIPTION
Required by: https://github.com/quarkus-qe/quarkus-test-framework/pull/327

OCP49 warning message:
```
2021-11-04 12:39:58 WARN  AbstractOperator:481 - Reconciliation #5(timer) Kafka(ts-tdrxyaqefb/kafka-instance): Failed to reconcile
io.strimzi.operator.cluster.model.InvalidResourceException: Version 2.7.0 is not supported. Supported versions are: 2.8.0, 2.8.1, 3.0.0.
```