### PR TITLE
Quarkus-cli --version only returns version value

### DIFF
--- a/quarkus-test-cli/src/test/java/io/quarkus/test/QuarkusCliClientIT.java
+++ b/quarkus-test-cli/src/test/java/io/quarkus/test/QuarkusCliClientIT.java
@@ -41,10 +41,10 @@ public class QuarkusCliClientIT {
     @Test
     public void shouldVersionMatchQuarkusVersion() {
         // Using option
-        assertEquals("Client Version " + QuarkusProperties.getVersion(), cliClient.run("version").getOutput());
+        assertEquals(QuarkusProperties.getVersion(), cliClient.run("version").getOutput());
 
         // Using shortcut
-        assertEquals("Client Version " + QuarkusProperties.getVersion(), cliClient.run("-v").getOutput());
+        assertEquals(QuarkusProperties.getVersion(), cliClient.run("-v").getOutput());
     }
 
     @Test


### PR DESCRIPTION
Amend test in order to fit this commit:

quarkusio/quarkus@47c2d94#diff-ffe15562f1c91992754190c19745597d15b171f0868bd7970990b8d08a4c33a1

quarkus-cli --version only return version value instead of client Version {{ version value }}