### PR TITLE
Downgrade confluent AVRO serializers to 6.2.1

### DIFF
--- a/examples/kafka-registry/pom.xml
+++ b/examples/kafka-registry/pom.xml
@@ -10,7 +10,7 @@
     <artifactId>examples-kafka-registry</artifactId>
     <name>Quarkus - Test Framework - Examples - Kafka with Registry</name>
     <properties>
-        <confluent.kafka-avro-serializer.version>7.0.0</confluent.kafka-avro-serializer.version>
+        <confluent.kafka-avro-serializer.version>6.2.1</confluent.kafka-avro-serializer.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Confluent AVRO serializers version 7.0 are supported in Upstream "999-SNAPSHOT" but TestFramework is pointing to Quarkus `2.3.0.Final` so we should downgrade Confluent serializer version from now. 

Confluent serializer 7.0 is also not supported in `Quarkus 2.5.0.Final` (Native mode)

Fix daily build: https://github.com/quarkus-qe/quarkus-test-framework/runs/4293313951?check_suite_focus=true
