### PR TITLE
Fix docker rates limits in Jaeger and Mysql

### DIFF
--- a/examples/database-mysql/src/test/java/io/quarkus/qe/database/mysql/DevModeMySqlDatabaseIT.java
+++ b/examples/database-mysql/src/test/java/io/quarkus/qe/database/mysql/DevModeMySqlDatabaseIT.java
@@ -19,8 +19,10 @@ public class DevModeMySqlDatabaseIT extends AbstractSqlDatabaseIT {
     static final String MYSQL_DATABASE = "mydb";
     static final int MYSQL_PORT = 3306;
 
-    @Container(image = "mysql/mysql-server:8.0", port = MYSQL_PORT, expectedLog = "port: 3306  MySQL Community Server")
+    @Container(image = "quay.io/bitnami/mysql:8.0.27", port = MYSQL_PORT, expectedLog = "ready for connections")
     static DefaultService database = new DefaultService()
+            .withProperty("MYSQL_ROOT_USER", MYSQL_USER)
+            .withProperty("MYSQL_ROOT_PASSWORD", MYSQL_PASSWORD)
             .withProperty("MYSQL_USER", MYSQL_USER)
             .withProperty("MYSQL_PASSWORD", MYSQL_PASSWORD)
             .withProperty("MYSQL_DATABASE", MYSQL_DATABASE);

--- a/examples/database-mysql/src/test/java/io/quarkus/qe/database/mysql/MySqlDatabaseIT.java
+++ b/examples/database-mysql/src/test/java/io/quarkus/qe/database/mysql/MySqlDatabaseIT.java
@@ -11,7 +11,7 @@ import io.quarkus.test.services.QuarkusApplication;
 @QuarkusScenario
 public class MySqlDatabaseIT extends AbstractSqlDatabaseIT {
 
-    @Container(image = "mysql/mysql-server:8.0", port = MYSQL_PORT, expectedLog = "port: 3306  MySQL Community Server")
+    @Container(image = "quay.io/bitnami/mysql:8.0.27", port = MYSQL_PORT, expectedLog = "ready for connections")
     static MySqlService database = new MySqlService();
 
     @QuarkusApplication

--- a/extensions/tracing/src/test/java/io/quarkus/qe/resources/JaegerContainer.java
+++ b/extensions/tracing/src/test/java/io/quarkus/qe/resources/JaegerContainer.java
@@ -11,7 +11,7 @@ public class JaegerContainer extends GenericContainer<JaegerContainer> {
     private static final int STARTUP_TIMEOUT_SECONDS = 30;
 
     public JaegerContainer() {
-        super("jaegertracing/all-in-one:1.21.0");
+        super("quay.io/jaegertracing/all-in-one:1.21.0");
         waitingFor(Wait.forLogMessage(".*server started.*", 1));
         withStartupTimeout(Duration.ofSeconds(STARTUP_TIMEOUT_SECONDS));
         addFixedExposedPort(REST_PORT, REST_PORT);

--- a/quarkus-test-service-jaeger/src/main/java/io/quarkus/test/services/JaegerContainer.java
+++ b/quarkus-test-service-jaeger/src/main/java/io/quarkus/test/services/JaegerContainer.java
@@ -11,7 +11,7 @@ import io.quarkus.test.services.containers.JaegerContainerManagedResourceBuilder
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface JaegerContainer {
-    String image() default "jaegertracing/all-in-one:1.21.0";
+    String image() default "quay.io/jaegertracing/all-in-one:1.21.0";
 
     int tracePort() default 16686;
 


### PR DESCRIPTION
We are reaching some limits in Jenkins jobs

Use Quay images instead of DockerHub images:
 
`mysql/mysql-server:8.0` -> `quay.io/quarkusqeteam/mysql-server:8.0`
`jaegertracing/all-in-one:1.21.0` -> `quay.io/jaegertracing/all-in-one:1.21.0`