### PR TITLE
`delete project after all` property should not scale down services

### DIFF
--- a/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/BaseService.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/BaseService.java
@@ -210,12 +210,14 @@ public class BaseService<T extends Service> implements Service {
      */
     @Override
     public void close() {
-        stop();
-        if (getConfiguration().isTrue(DELETE_FOLDER_ON_EXIT)) {
-            try {
-                FileUtils.deletePath(getServiceFolder());
-            } catch (Exception ex) {
-                Log.warn(this, "Could not delete service folder. Caused by " + ex.getMessage());
+        if (!context.getScenarioContext().isDebug()) {
+            stop();
+            if (getConfiguration().isTrue(DELETE_FOLDER_ON_EXIT)) {
+                try {
+                    FileUtils.deletePath(getServiceFolder());
+                } catch (Exception ex) {
+                    Log.warn(this, "Could not delete service folder. Caused by " + ex.getMessage());
+                }
             }
         }
     }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/ScenarioContext.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/ScenarioContext.java
@@ -19,6 +19,7 @@ public final class ScenarioContext {
     private final ExtensionContext.Namespace testNamespace;
     private ExtensionContext methodTestContext;
     private boolean failed;
+    private boolean debug;
 
     protected ScenarioContext(ExtensionContext testContext) {
         this.testContext = testContext;
@@ -32,6 +33,14 @@ public final class ScenarioContext {
 
     public boolean isFailed() {
         return failed;
+    }
+
+    public boolean isDebug() {
+        return debug;
+    }
+
+    public void setDebug(boolean debug) {
+        this.debug = debug;
     }
 
     public String getRunningTestClassName() {

--- a/quarkus-test-kubernetes/src/main/java/io/quarkus/test/bootstrap/inject/KubectlClient.java
+++ b/quarkus-test-kubernetes/src/main/java/io/quarkus/test/bootstrap/inject/KubectlClient.java
@@ -53,8 +53,7 @@ public final class KubectlClient {
 
     public static final String LABEL_TO_WATCH_FOR_LOGS = "tsLogWatch";
     public static final String LABEL_SCENARIO_ID = "scenarioId";
-
-    private static final PropertyLookup ENABLED_EPHEMERAL_NAMESPACES = new PropertyLookup(
+    public static final PropertyLookup ENABLED_EPHEMERAL_NAMESPACES = new PropertyLookup(
             "ts.kubernetes.ephemeral.namespaces.enabled", Boolean.TRUE.toString());
 
     private static final String RESOURCE_MNT_FOLDER = "/resource";

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
@@ -70,6 +70,8 @@ public final class OpenShiftClient {
 
     public static final String LABEL_TO_WATCH_FOR_LOGS = "tsLogWatch";
     public static final String LABEL_SCENARIO_ID = "scenarioId";
+    public static final PropertyLookup ENABLED_EPHEMERAL_NAMESPACES = new PropertyLookup(
+            "ts.openshift.ephemeral.namespaces.enabled", Boolean.TRUE.toString());
 
     private static final String IMAGE_STREAM_TIMEOUT = "imagestream.install.timeout";
     private static final String OPERATOR_INSTALL_TIMEOUT = "operator.install.timeout";
@@ -83,9 +85,6 @@ public final class OpenShiftClient {
     private static final String RESOURCE_MNT_FOLDER = "/resources";
 
     private static final String OC = "oc";
-
-    private static final PropertyLookup ENABLED_EPHEMERAL_NAMESPACES = new PropertyLookup(
-            "ts.openshift.ephemeral.namespaces.enabled", Boolean.TRUE.toString());
 
     private final String currentNamespace;
     private final DefaultOpenShiftClient masterClient;


### PR DESCRIPTION
`ts.kubernetes.delete.project.after.all=false` should not scale down k8s/ocp services
Also must only works if `ts.kubernetes.ephemeral.namespaces.enabled=false`

Close #342 