### PR TITLE
Make containers reusable

### DIFF
--- a/quarkus-test-containers/src/main/java/io/quarkus/test/services/Container.java
+++ b/quarkus-test-containers/src/main/java/io/quarkus/test/services/Container.java
@@ -20,4 +20,6 @@ public @interface Container {
     String[] command() default {};
 
     Class<? extends ManagedResourceBuilder> builder() default ContainerManagedResourceBuilder.class;
+
+    boolean reusable() default false;
 }

--- a/quarkus-test-containers/src/main/java/io/quarkus/test/services/containers/ContainerManagedResourceBuilder.java
+++ b/quarkus-test-containers/src/main/java/io/quarkus/test/services/containers/ContainerManagedResourceBuilder.java
@@ -19,6 +19,7 @@ public class ContainerManagedResourceBuilder implements ManagedResourceBuilder {
     private String expectedLog;
     private String[] command;
     private Integer port;
+    private boolean reusable;
 
     protected String getImage() {
         return image;
@@ -40,6 +41,10 @@ public class ContainerManagedResourceBuilder implements ManagedResourceBuilder {
         return context;
     }
 
+    public boolean isReusable() {
+        return reusable;
+    }
+
     @Override
     public void init(Annotation annotation) {
         Container metadata = (Container) annotation;
@@ -47,6 +52,7 @@ public class ContainerManagedResourceBuilder implements ManagedResourceBuilder {
         this.command = metadata.command();
         this.expectedLog = PropertiesUtils.resolveProperty(metadata.expectedLog());
         this.port = metadata.port();
+        this.reusable = metadata.reusable();
     }
 
     @Override

--- a/quarkus-test-containers/src/main/java/io/quarkus/test/services/containers/GenericDockerContainerManagedResource.java
+++ b/quarkus-test-containers/src/main/java/io/quarkus/test/services/containers/GenericDockerContainerManagedResource.java
@@ -45,6 +45,7 @@ public class GenericDockerContainerManagedResource extends DockerContainerManage
 
         container.withExposedPorts(model.getPort());
 
+        container.withReuse(model.isReusable());
         return container;
     }
 


### PR DESCRIPTION
Close https://github.com/quarkus-qe/quarkus-test-framework/issues/347

This is a POC of what I had in mind when I mentioned that it should be possible to make containers reusable.
But, ideally, instead of the annotation, it would be more powerful to set this with a `DatabaseService.withReuse(true)` but I couldn't figure out how to do it