### PR TITLE
Example/microprofile required grpc-api lib on their classpath

### DIFF
--- a/examples/microprofile/src/main/resources/application.properties
+++ b/examples/microprofile/src/main/resources/application.properties
@@ -1,1 +1,6 @@
+# GRPC metrics are enabled by default if you bring "grpc-api" as a dependency and "quarkus-micrometer".
+# In our case "quarkus-test-core" brings it.
+# //TODO https://github.com/quarkus-qe/quarkus-test-framework/issues/359
 
+quarkus.micrometer.binder.grpc-client.enabled=false
+quarkus.micrometer.binder.grpc-server.enabled=false


### PR DESCRIPTION
gRPC metrics are now handled by the quarkus-micrometer extension. gRPC server and clients metrics are automatically enabled when your application depends on the quarkus-micrometer extension. In the case you do not want to collect these metrics, you can disable them using:
```
quarkus.micrometer.binder.grpc-client.enabled=false
quarkus.micrometer.binder.grpc-server.enabled=false
```

Doc Ref: https://github.com/quarkusio/quarkus/wiki/Migration-Guide-2.6#grpc-metrics-changes