### PR TITLE
Docker containers prefix feature

### DIFF
--- a/quarkus-test-containers/src/main/java/io/quarkus/test/services/containers/GenericDockerContainerManagedResource.java
+++ b/quarkus-test-containers/src/main/java/io/quarkus/test/services/containers/GenericDockerContainerManagedResource.java
@@ -5,6 +5,7 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 
 import io.quarkus.test.logging.Log;
+import io.quarkus.test.utils.DockerUtils;
 
 public class GenericDockerContainerManagedResource extends DockerContainerManagedResource {
 
@@ -43,6 +44,7 @@ public class GenericDockerContainerManagedResource extends DockerContainerManage
             container.setPrivilegedMode(true);
         }
 
+        container.withCreateContainerCmdModifier(cmd -> cmd.withName(DockerUtils.generateDockerContainerName()));
         container.withExposedPorts(model.getPort());
 
         return container;

--- a/quarkus-test-images/src/main/java/io/quarkus/test/utils/DockerUtils.java
+++ b/quarkus-test-images/src/main/java/io/quarkus/test/utils/DockerUtils.java
@@ -6,7 +6,9 @@ import static org.junit.jupiter.api.Assertions.fail;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.Random;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -24,10 +26,12 @@ public final class DockerUtils {
 
     public static final String CONTAINER_REGISTRY_URL_PROPERTY = "ts.container.registry-url";
 
+    private static final String CONTAINER_PREFIX = "ts.global.docker-container-prefix";
     private static final String DOCKERFILE = "Dockerfile";
     private static final String DOCKERFILE_TEMPLATE = "/Dockerfile.%s";
     private static final String DOCKER = "docker";
     private static final Object LOCK = new Object();
+    private static final Random RANDOM = new Random();
 
     private static DockerClient dockerClientInstance;
 
@@ -126,6 +130,16 @@ public final class DockerUtils {
             }
         }
         return result;
+    }
+
+    public static String generateDockerContainerName() {
+        String containerName = "" + (RANDOM.nextInt() & Integer.MAX_VALUE);
+        String dockerContainerPrefix = System.getProperty(CONTAINER_PREFIX);
+        if (Objects.nonNull(dockerContainerPrefix)) {
+            containerName = dockerContainerPrefix + "-" + containerName;
+        }
+
+        return containerName;
     }
 
     private static DockerClient dockerClient() {

--- a/quarkus-test-service-jaeger/src/main/java/io/quarkus/test/services/containers/JaegerGenericDockerContainerManagedResource.java
+++ b/quarkus-test-service-jaeger/src/main/java/io/quarkus/test/services/containers/JaegerGenericDockerContainerManagedResource.java
@@ -5,6 +5,7 @@ import static io.quarkus.test.bootstrap.JaegerService.JAEGER_TRACE_URL_PROPERTY;
 import org.testcontainers.containers.GenericContainer;
 
 import io.quarkus.test.bootstrap.Protocol;
+import io.quarkus.test.utils.DockerUtils;
 
 public class JaegerGenericDockerContainerManagedResource extends GenericDockerContainerManagedResource {
 
@@ -26,6 +27,8 @@ public class JaegerGenericDockerContainerManagedResource extends GenericDockerCo
     protected GenericContainer<?> initContainer() {
         GenericContainer<?> container = super.initContainer();
         container.addExposedPort(model.getTracePort());
+        container.withCreateContainerCmdModifier(cmd -> cmd.withName(DockerUtils.generateDockerContainerName()));
+
         return container;
     }
 

--- a/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/ConfluentKafkaContainerManagedResource.java
+++ b/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/ConfluentKafkaContainerManagedResource.java
@@ -5,6 +5,8 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
+import io.quarkus.test.utils.DockerUtils;
+
 public class ConfluentKafkaContainerManagedResource extends BaseKafkaContainerManagedResource {
 
     protected ConfluentKafkaContainerManagedResource(KafkaContainerManagedResourceBuilder model) {
@@ -18,7 +20,8 @@ public class ConfluentKafkaContainerManagedResource extends BaseKafkaContainerMa
 
     @Override
     protected GenericContainer<?> initKafkaContainer() {
-        return new KafkaContainer(DockerImageName.parse(getKafkaImage() + ":" + getKafkaVersion()));
+        return new KafkaContainer(DockerImageName.parse(getKafkaImage() + ":" + getKafkaVersion()))
+                .withCreateContainerCmdModifier(cmd -> cmd.withName(DockerUtils.generateDockerContainerName()));
     }
 
     @Override
@@ -29,6 +32,8 @@ public class ConfluentKafkaContainerManagedResource extends BaseKafkaContainerMa
         schemaRegistry.withEnv("SCHEMA_REGISTRY_LISTENERS", "http://0.0.0.0:" + getKafkaRegistryPort());
         schemaRegistry.withEnv("SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS",
                 "PLAINTEXT://" + kafka.getNetworkAliases().get(0) + ":9092");
+        schemaRegistry.withCreateContainerCmdModifier(cmd -> cmd.withName(DockerUtils.generateDockerContainerName()));
+
         return schemaRegistry;
     }
 

--- a/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/StrimziKafkaContainerManagedResource.java
+++ b/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/StrimziKafkaContainerManagedResource.java
@@ -11,6 +11,7 @@ import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.services.containers.model.KafkaProtocol;
 import io.quarkus.test.services.containers.model.KafkaVendor;
 import io.quarkus.test.services.containers.strimzi.ExtendedStrimziKafkaContainer;
+import io.quarkus.test.utils.DockerUtils;
 
 public class StrimziKafkaContainerManagedResource extends BaseKafkaContainerManagedResource {
 
@@ -45,6 +46,7 @@ public class StrimziKafkaContainerManagedResource extends BaseKafkaContainerMana
         if (StringUtils.isNotEmpty(getServerProperties())) {
             container.useCustomServerProperties();
         }
+        container.withCreateContainerCmdModifier(cmd -> cmd.withName(DockerUtils.generateDockerContainerName()));
 
         return container;
     }
@@ -56,6 +58,8 @@ public class StrimziKafkaContainerManagedResource extends BaseKafkaContainerMana
         schemaRegistry.withEnv("APPLICATION_ID", "registry_id");
         schemaRegistry.withEnv("APPLICATION_SERVER", "localhost:9000");
         schemaRegistry.withEnv("KAFKA_BOOTSTRAP_SERVERS", "PLAINTEXT://localhost:" + getTargetPort());
+        schemaRegistry.withCreateContainerCmdModifier(cmd -> cmd.withName(DockerUtils.generateDockerContainerName()));
+
         return schemaRegistry;
     }
 


### PR DESCRIPTION
The goal of this PR is to provide the ability to set a custom docker container process prefix name. This feature will give us the ability to share a remote docker-engine between different Jenkins workers. So, if a Jenkins worker removes or makes some change to a docker container instance, will only apply to his "domain" or prefix. Basically is a workaround, is like a namespace based on prefixes.  Other technologies as Redis are using this prefix approach and works pretty well. 

The docker container names will be generated by our `DockerUtils class` and are going to be a random number plus an optional custom prefix.             

For example:

Imagine that you have two Jenkins jobs called `2.2-baremetal-ts-jvm` and `1.7-baremetal-ts-jvm`. Lets hash and then pick the first 10 digits, in order to have a unique name without weird characters:

`2.2-baremetal-ts-jvm` -> md5 -> `4a73c71664d6629d8fd639781b8a1b54` -> `4a73c71664`
`1.7-baremetal-ts-jvm` -> md5 -> `ba40ab410ed194be244b7114e2229d15` -> `ba40ab410e`

Then both jobs could be triggered with a command like the following one: 

`2.2-baremetal-ts-jvm` -> `mvn clean verify -Dts.global.docker-container-prefix=4a73c71664`
`1.7-baremetal-ts-jvm` -> `mvn clean verify -Dts.global.docker-container-prefix=ba40ab410e`

the result would be something like this (assuming that both jobs creates a Keycloak container): 

```
CONTAINER ID   IMAGE                               PORTS                                                   NAMES
e7a2ef3a3e84   quay.io/keycloak/keycloak:14.0.0    8443/tcp, 0.0.0.0:50138->8080/tcp, :::50138->8080/tcp   4a73c71664-2074505752

a6b3bf6c3c99   quay.io/keycloak/keycloak:14.0.0    8443/tcp, 0.0.0.0:50138->8080/tcp, :::50138->8080/tcp   ba40ab410e-2074505752
```

This prefix approach could be handly because allow us to then later clean the containers by running a script, something that is very interesting when you are using a remote docker engine between several workers:

Stop&remove all `4a73c71664` (2.2-baremetal-ts-jvm) containers:

```
docker stop $(docker ps -a | grep 4a73c71664 | awk '{print $1}')
docker rm $(docker ps -a | grep 4a73c71664 | awk '{print $1}')
```

Or if you want to stop and remove all containers of all jobs except Docker-api proxy then you could do something like:

```
docker stop $(docker ps -a | grep -v "docker-remote-api" | awk 'NR>1 {print $1}')
docker rm $(docker ps -a | grep -v "docker-remote-api" | awk 'NR>1 {print $1}')
```