### PR TITLE
Knative runs over HTTPS protocol

### DIFF
--- a/examples/pingpong/src/test/java/io/quarkus/qe/PingPongResourceIT.java
+++ b/examples/pingpong/src/test/java/io/quarkus/qe/PingPongResourceIT.java
@@ -13,7 +13,7 @@ public class PingPongResourceIT {
 
     @Test
     public void shouldPingPongWorks() {
-        given().get("/ping").then().statusCode(HttpStatus.SC_OK).body(is("ping"));
-        given().get("/pong").then().statusCode(HttpStatus.SC_OK).body(is("pong"));
+        given().relaxedHTTPSValidation().get("/ping").then().statusCode(HttpStatus.SC_OK).body(is("ping"));
+        given().relaxedHTTPSValidation().get("/pong").then().statusCode(HttpStatus.SC_OK).body(is("pong"));
     }
 }


### PR DESCRIPTION
OCP4.9 / serverless 1.19.0 is running over `HTTPS`

This PR swapp serverless HTTP request to HTTPS

Close: https://github.com/quarkus-qe/quarkus-test-framework/issues/352