### PR TITLE
Bump simpleclient_pushgateway & quarkus.platform

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <surefire-plugin.version>2.22.2</surefire-plugin.version>
         <jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
         <jaeger.version>1.6.0</jaeger.version>
-        <prometheus.simpleclient_pushgateway.version>0.13.0</prometheus.simpleclient_pushgateway.version>
+        <prometheus.simpleclient_pushgateway.version>0.14.1</prometheus.simpleclient_pushgateway.version>
         <maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>
         <formatter-maven-plugin.version>2.17.1</formatter-maven-plugin.version>
         <impsort-maven-plugin.version>1.6.2</impsort-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <htmlunit.version>2.56.0</htmlunit.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.3.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.6.0.Final</quarkus.platform.version>
         <exclude.tests.with.tags>quarkus-cli</exclude.tests.with.tags>
         <include.tests>**/*IT.java</include.tests>
         <exclude.openshift.tests>**/OpenShift*IT.java</exclude.openshift.tests>


### PR DESCRIPTION
quarkus.platform -> 2.3.0.Final to 2.6.0.Final
prometheus.simpleclient_pushgateway -> 0.13.0 to 0.14.1

This PR is required because those changes has been over written by:

https://github.com/quarkus-qe/quarkus-test-framework/pull/361
https://github.com/quarkus-qe/quarkus-test-framework/pull/362