### PR TITLE
Make sure all the sub-processes are destroyed

### DIFF
--- a/quarkus-test-core/src/main/java/io/quarkus/test/utils/ProcessUtils.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/utils/ProcessUtils.java
@@ -17,7 +17,7 @@ public final class ProcessUtils {
     public static void destroy(Process process) {
         try {
             if (process != null) {
-                process.children().forEach(child -> {
+                process.descendants().forEach(child -> {
                     if (child.supportsNormalTermination()) {
                         child.destroyForcibly();
                     }


### PR DESCRIPTION
Make sure all the sub-processes are destroyed

Dev mode in CLI introduces one additional level in children processes

Before this change there were leftover processes after the TS execution

For example after running `QuarkusCliCreateJvmApplicationIT` I have seen these processes:
```
51345 /Users/rsvoboda/git/quarkus-test-suite/quarkus-cli/target/QuarkusCliCreateJvmApplicationIT/app/target/app-dev.jar
51879 /Users/rsvoboda/git/quarkus-test-suite/quarkus-cli/target/QuarkusCliCreateJvmApplicationIT/app/target/app-dev.jar
51528 /Users/rsvoboda/git/quarkus-test-suite/quarkus-cli/target/QuarkusCliCreateJvmApplicationIT/app/target/app-dev.jar
51822 /Users/rsvoboda/git/quarkus-test-suite/quarkus-cli/target/QuarkusCliCreateJvmApplicationIT/app/target/app-dev.jar
```