### PR TITLE
[1.0.z] Make sure all the sub-processes are destroyed

### DIFF
--- a/quarkus-test-core/src/main/java/io/quarkus/test/utils/ProcessUtils.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/utils/ProcessUtils.java
@@ -17,7 +17,7 @@ public final class ProcessUtils {
     public static void destroy(Process process) {
         try {
             if (process != null) {
-                process.children().forEach(child -> {
+                process.descendants().forEach(child -> {
                     if (child.supportsNormalTermination()) {
                         child.destroyForcibly();
                     }


### PR DESCRIPTION
Make sure all the sub-processes are destroyed

Dev mode in CLI introduces one additional level in children processes

Backport of https://github.com/quarkus-qe/quarkus-test-framework/pull/383