### PR TITLE
Update jaegertracing/all-in-one image for multi-arch support

### DIFF
--- a/extensions/tracing/src/test/java/io/quarkus/qe/resources/JaegerContainer.java
+++ b/extensions/tracing/src/test/java/io/quarkus/qe/resources/JaegerContainer.java
@@ -11,7 +11,7 @@ public class JaegerContainer extends GenericContainer<JaegerContainer> {
     private static final int STARTUP_TIMEOUT_SECONDS = 30;
 
     public JaegerContainer() {
-        super("quay.io/jaegertracing/all-in-one:1.21.0");
+        super("quay.io/jaegertracing/all-in-one:1.30.0");
         waitingFor(Wait.forLogMessage(".*server started.*", 1));
         withStartupTimeout(Duration.ofSeconds(STARTUP_TIMEOUT_SECONDS));
         addFixedExposedPort(REST_PORT, REST_PORT);

--- a/misc/Tracing.md
+++ b/misc/Tracing.md
@@ -20,7 +20,7 @@ All the metrics will be tagging [the test execution properties](Execution.md).
 - On bare metal:
 
 ```
-docker run -p 16686:16686 -p 14268:14268 quay.io/jaegertracing/all-in-one:1.21.0
+docker run -p 16686:16686 -p 14268:14268 quay.io/jaegertracing/all-in-one:1.30.0
 ```
 
 The JAEGER API URL will be available at `http://localhost:14268`.

--- a/misc/jaeger-for-tracing.yaml
+++ b/misc/jaeger-for-tracing.yaml
@@ -75,7 +75,7 @@ items:
             app: 'jaeger'
         spec:
           containers:
-            - image: 'quay.io/jaegertracing/all-in-one:1.21.0'
+            - image: 'quay.io/jaegertracing/all-in-one:1.30.0'
               name: 'jaeger'
 #              env:
 #                - name: SPAN_STORAGE_TYPE

--- a/quarkus-test-service-jaeger/src/main/java/io/quarkus/test/services/JaegerContainer.java
+++ b/quarkus-test-service-jaeger/src/main/java/io/quarkus/test/services/JaegerContainer.java
@@ -11,7 +11,7 @@ import io.quarkus.test.services.containers.JaegerContainerManagedResourceBuilder
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface JaegerContainer {
-    String image() default "quay.io/jaegertracing/all-in-one:1.21.0";
+    String image() default "quay.io/jaegertracing/all-in-one:1.30.0";
 
     int tracePort() default 16686;
 


### PR DESCRIPTION
Not specifically sure which branch to merge into so I just set it to main. Bump version of jaegertracing/all-in-one to 1.30.0 for multi-arch support on s390x/ppc64le. 

Related issue: https://github.com/quarkus-qe/quarkus-test-suite/pull/500