### PR TITLE
Disable Kafka related examples due to changes Quarkus main

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -362,9 +362,10 @@
                 <module>examples/infinispan</module>
                 <module>examples/microprofile</module>
                 <module>examples/keycloak</module>
+                <!-- Disable kafka related examples due to changes Quarkus main
                 <module>examples/kafka</module>
                 <module>examples/kafka-registry</module>
-                <module>examples/kafka-streams</module>
+                <module>examples/kafka-streams</module> -->
                 <module>examples/amq-tcp</module>
                 <module>examples/amq-amqp</module>
                 <module>examples/jaeger</module>


### PR DESCRIPTION
Disable Kafka related examples due to changes Quarkus main

Failed daily run https://github.com/quarkus-qe/quarkus-test-framework/runs/5117648285?check_suite_focus=true

related to https://github.com/quarkus-qe/quarkus-test-framework/issues/400