### PR TITLE
Set Quarkus_maven_plugin based on -Dquarkus-plugin.version parameter

### DIFF
--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/GitRepositoryQuarkusApplication.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/GitRepositoryQuarkusApplication.java
@@ -14,7 +14,9 @@ public @interface GitRepositoryQuarkusApplication {
 
     String contextDir() default "";
 
-    String mavenArgs() default "-DskipTests=true -DskipITs=true -Dquarkus.platform.version=${QUARKUS_VERSION}";
+    String mavenArgs() default "-DskipTests=true -DskipITs=true "
+            + "-Dquarkus.platform.version=${QUARKUS_VERSION} "
+            + "-Dquarkus-plugin.version=${QUARKUS-PLUGIN_VERSION}";
 
     boolean devMode() default false;
 

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/GitRepositoryLocalhostQuarkusApplicationManagedResource.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/GitRepositoryLocalhostQuarkusApplicationManagedResource.java
@@ -1,5 +1,7 @@
 package io.quarkus.test.services.quarkus;
 
+import static io.quarkus.test.services.quarkus.model.QuarkusProperties.PLUGIN_VERSION;
+
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.LinkedList;
@@ -15,9 +17,8 @@ public class GitRepositoryLocalhostQuarkusApplicationManagedResource
         extends ProdLocalhostQuarkusApplicationManagedResource {
 
     private static final String QUARKUS_VERSION = "quarkus.version";
-    private static final String QUARKUS_PLUGIN_VERSION = "quarkus.plugin.version";
+    private static final String QUARKUS_PLUGIN_VERSION = "quarkus-plugin.version";
     private static final String QUARKUS_VERSION_VALUE = "${quarkus.platform.version}";
-    private static final String QUARKUS_PLUGIN_VERSION_VALUE = "${quarkus-plugin.version}";
 
     private final GitRepositoryQuarkusApplicationManagedResourceBuilder model;
 
@@ -78,9 +79,11 @@ public class GitRepositoryLocalhostQuarkusApplicationManagedResource
 
     private List<String> getEffectivePropertiesForGitRepository(List<String> properties) {
         List<String> effectiveProperties = new LinkedList<>(properties);
-        // Override quarkus plugin version.
         effectiveProperties.add(MavenUtils.withProperty(QUARKUS_VERSION, QUARKUS_VERSION_VALUE));
-        effectiveProperties.add(MavenUtils.withProperty(QUARKUS_PLUGIN_VERSION, QUARKUS_PLUGIN_VERSION_VALUE));
+
+        if (StringUtils.isEmpty(PLUGIN_VERSION.get())) {
+            effectiveProperties.add(MavenUtils.withProperty(QUARKUS_PLUGIN_VERSION, QUARKUS_VERSION_VALUE));
+        }
 
         return effectiveProperties;
     }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/GitRepositoryQuarkusApplicationManagedResourceBuilder.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/GitRepositoryQuarkusApplicationManagedResourceBuilder.java
@@ -14,6 +14,7 @@ import io.quarkus.test.services.quarkus.model.QuarkusProperties;
 public class GitRepositoryQuarkusApplicationManagedResourceBuilder extends ProdQuarkusApplicationManagedResourceBuilder {
 
     protected static final String QUARKUS_VERSION_PROPERTY = "${QUARKUS_VERSION}";
+    protected static final String QUARKUS_PLUGIN_VERSION_PROPERTY = "${QUARKUS-PLUGIN_VERSION}";
 
     private final ServiceLoader<GitRepositoryQuarkusApplicationManagedResourceBinding> bindings = ServiceLoader
             .load(GitRepositoryQuarkusApplicationManagedResourceBinding.class);
@@ -45,7 +46,9 @@ public class GitRepositoryQuarkusApplicationManagedResourceBuilder extends ProdQ
     }
 
     protected String getMavenArgsWithVersion() {
-        return mavenArgs.replaceAll(quote(QUARKUS_VERSION_PROPERTY), QuarkusProperties.getVersion());
+        return mavenArgs
+                .replaceAll(quote(QUARKUS_PLUGIN_VERSION_PROPERTY), QuarkusProperties.getPluginVersion())
+                .replaceAll(quote(QUARKUS_VERSION_PROPERTY), QuarkusProperties.getVersion());
     }
 
     @Override

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/model/QuarkusProperties.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/model/QuarkusProperties.java
@@ -13,6 +13,7 @@ public final class QuarkusProperties {
 
     public static final PropertyLookup PLATFORM_GROUP_ID = new PropertyLookup("quarkus.platform.group-id", "io.quarkus");
     public static final PropertyLookup PLATFORM_VERSION = new PropertyLookup("quarkus.platform.version");
+    public static final PropertyLookup PLUGIN_VERSION = new PropertyLookup("quarkus-plugin.version");
     public static final String PACKAGE_TYPE_NAME = "quarkus.package.type";
     public static final String MUTABLE_JAR = "mutable-jar";
     public static final PropertyLookup PACKAGE_TYPE = new PropertyLookup(PACKAGE_TYPE_NAME);
@@ -29,12 +30,11 @@ public final class QuarkusProperties {
     }
 
     public static String getVersion() {
-        String version = PLATFORM_VERSION.get();
-        if (StringUtils.isEmpty(version)) {
-            version = Version.getVersion();
-        }
+        return defaultVersionIfEmpty(PLATFORM_VERSION.get());
+    }
 
-        return version;
+    public static String getPluginVersion() {
+        return defaultVersionIfEmpty(PLUGIN_VERSION.get());
     }
 
     public static boolean isNativePackageType() {
@@ -51,5 +51,13 @@ public final class QuarkusProperties {
 
     public static boolean isJvmPackageType(ServiceContext context) {
         return PACKAGE_TYPE_JVM_VALUES.contains(PACKAGE_TYPE.get(context));
+    }
+
+    private static String defaultVersionIfEmpty(String version) {
+        if (StringUtils.isEmpty(version)) {
+            version = Version.getVersion();
+        }
+
+        return version;
     }
 }


### PR DESCRIPTION
If no quarkus plugin version is provided, by mvn command system property `-Dquarkus-plugin.version` then quarkus plugin version will have the same value as quarkus platform version. Otherwise  `-Dquarkus-plugin.version` value will be taken in place.

Examples:

`mvn clean verify`

quarkus.platform.version -> 2.2.5.Final
quarkus-plugin.version -> 2.2.5.Final

`mvn clean verify  -Dquarkus.platform.group-id=com.redhat.quarkus.platform -Dquarkus.platform.artifact-id=quarkus-bom -Dquarkus.platform.version=2.2.5.Final-redhat-00006 -Dquarkus-plugin.version=2.2.5.Final-redhat-00009`

quarkus.platform.version -> 2.2.5.Final-redhat-00006
quarkus-plugin.version -> 2.2.5.Final-redhat-00009