### PR TITLE
Support upstream and product release drafter

### DIFF
--- a/.github/upstream-release-drafter.yml
+++ b/.github/upstream-release-drafter.yml
@@ -1,4 +1,4 @@
-name-template: '1.0.z 🌈'
+name-template: '1.1.x 🌈'
 tag-template: 'v$NEXT_PATCH_VERSION'
 exclude-labels:
   - 'skip-changelog'
@@ -22,6 +22,6 @@ categories:
     label: 'chore'
 change-template: '- #$NUMBER: $TITLE (@$AUTHOR)'
 template: |
-  ## 1.0.z Changes
+  ## 1.1.x Changes
   $CHANGES
   All contributors: $CONTRIBUTORS

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -11,5 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@v5
+        with:
+          config-name: upstream-release-drafter.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Publish on GH release [page](https://github.com/quarkus-qe/quarkus-test-framework/releases) an upstream / product release note draft, based on pre-released changes.

Note: at the moment I could not publish Ustream(1.1.x) and product(1.0.x) changes at the same time. Only show up the latest "branch" changes. So, if the latest commit is on main branch then GH release page will publish a 1.1.x release-note draft, called `Next 1.1.x`. 

Related to: #407

Main Doc: https://github.com/release-drafter/release-drafter