### PR TITLE
Support platform group ID parametrization

### DIFF
--- a/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftS2iQuickstartUsingUberJarIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftS2iQuickstartUsingUberJarIT.java
@@ -17,7 +17,7 @@ public class OpenShiftS2iQuickstartUsingUberJarIT {
     /**
      * Package type is set in the custom template.
      */
-    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", contextDir = "getting-started", branch = "1.11")
+    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", contextDir = "getting-started")
     static final RestService appuberjar = new RestService();
 
     @Test

--- a/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftTodoDemoIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftTodoDemoIT.java
@@ -1,0 +1,11 @@
+package io.quarkus.qe;
+
+import io.quarkus.test.scenarios.OpenShiftScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnNative;
+import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusSnapshot;
+
+@DisabledOnQuarkusSnapshot(reason = "999-SNAPSHOT is not available in the Maven repositories in OpenShift")
+@DisabledOnNative(reason = "Native + s2i not supported")
+@OpenShiftScenario
+public class OpenShiftTodoDemoIT extends TodoDemoIT {
+}

--- a/examples/external-applications/src/test/java/io/quarkus/qe/QuickstartUsingUsingUberJarIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/QuickstartUsingUsingUberJarIT.java
@@ -15,11 +15,11 @@ import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Windows does not support long file paths")
 public class QuickstartUsingUsingUberJarIT {
 
-    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", contextDir = "getting-started", mavenArgs = "-Dquarkus.package.type=uber-jar")
+    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", contextDir = "getting-started", mavenArgs = "-Dquarkus.package.type=uber-jar -DskipTests=true -Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus.platform.version=${QUARKUS_VERSION}")
     static final RestService app = new RestService();
 
     @Test
-    public void test() {
+    public void test() throws InterruptedException {
         app.given()
                 .get("/hello")
                 .then()

--- a/examples/external-applications/src/test/java/io/quarkus/qe/TodoDemoIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/TodoDemoIT.java
@@ -1,0 +1,24 @@
+package io.quarkus.qe;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnNative;
+import io.quarkus.test.services.GitRepositoryQuarkusApplication;
+
+@DisabledOnNative(reason = "This scenario is using uber-jar, so it's incompatible with Native")
+@QuarkusScenario
+public class TodoDemoIT {
+    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/todo-demo-app.git", mavenArgs = "-Dquarkus.package.type=uber-jar -DskipTests=true -Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus.platform.version=${QUARKUS_VERSION}")
+    static final RestService app = new RestService();
+
+    @Test
+    public void verify() {
+        app.given()
+                .get()
+                .then()
+                .statusCode(HttpStatus.SC_OK);
+    }
+}

--- a/examples/external-applications/src/test/resources/uber-jar-quarkus-s2i-source-build-template.yml
+++ b/examples/external-applications/src/test/resources/uber-jar-quarkus-s2i-source-build-template.yml
@@ -32,10 +32,8 @@ items:
         type: Source
         sourceStrategy:
           env:
-            - name: ARTIFACT_COPY_ARGS
-              value: -p -r *-runner.jar
             - name: MAVEN_ARGS
-              value: -s /configuration/settings.xml ${GIT_MAVEN_ARGS} -Dquarkus.platform.version=${QUARKUS_VERSION} -Dquarkus-plugin.version=${QUARKUS_VERSION} -Dquarkus.package.type=uber-jar
+              value: -s /configuration/settings.xml ${GIT_MAVEN_ARGS} -Dquarkus.platform.version=${QUARKUS_VERSION} -Dquarkus-plugin.version=${QUARKUS_VERSION} -Dquarkus.package.uber-jar -Dquarkus.openshift.jar-file-name=quarkus-run
           from:
             kind: DockerImage
             name: ${QUARKUS_S2I_BUILDER_IMAGE}

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/GitRepositoryQuarkusApplication.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/GitRepositoryQuarkusApplication.java
@@ -16,7 +16,8 @@ public @interface GitRepositoryQuarkusApplication {
 
     String mavenArgs() default "-DskipTests=true -DskipITs=true "
             + "-Dquarkus.platform.version=${QUARKUS_VERSION} "
-            + "-Dquarkus-plugin.version=${QUARKUS-PLUGIN_VERSION}";
+            + "-Dquarkus-plugin.version=${QUARKUS-PLUGIN_VERSION} "
+            + "-Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID}";
 
     boolean devMode() default false;
 

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/GitRepositoryQuarkusApplicationManagedResourceBuilder.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/GitRepositoryQuarkusApplicationManagedResourceBuilder.java
@@ -15,6 +15,7 @@ public class GitRepositoryQuarkusApplicationManagedResourceBuilder extends ProdQ
 
     protected static final String QUARKUS_VERSION_PROPERTY = "${QUARKUS_VERSION}";
     protected static final String QUARKUS_PLUGIN_VERSION_PROPERTY = "${QUARKUS-PLUGIN_VERSION}";
+    protected static final String QUARKUS_PLATFORM_GROUP_ID_PROPERTY = "${QUARKUS_PLATFORM_GROUP-ID}";
 
     private final ServiceLoader<GitRepositoryQuarkusApplicationManagedResourceBinding> bindings = ServiceLoader
             .load(GitRepositoryQuarkusApplicationManagedResourceBinding.class);
@@ -47,6 +48,7 @@ public class GitRepositoryQuarkusApplicationManagedResourceBuilder extends ProdQ
 
     protected String getMavenArgsWithVersion() {
         return mavenArgs
+                .replaceAll(quote(QUARKUS_PLATFORM_GROUP_ID_PROPERTY), QuarkusProperties.PLATFORM_GROUP_ID.get())
                 .replaceAll(quote(QUARKUS_PLUGIN_VERSION_PROPERTY), QuarkusProperties.getPluginVersion())
                 .replaceAll(quote(QUARKUS_VERSION_PROPERTY), QuarkusProperties.getVersion());
     }

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftS2iGitRepositoryQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftS2iGitRepositoryQuarkusApplicationManagedResource.java
@@ -1,6 +1,8 @@
 package io.quarkus.test.services.quarkus;
 
+import static io.quarkus.test.services.quarkus.GitRepositoryQuarkusApplicationManagedResourceBuilder.QUARKUS_PLATFORM_GROUP_ID_PROPERTY;
 import static io.quarkus.test.services.quarkus.GitRepositoryQuarkusApplicationManagedResourceBuilder.QUARKUS_VERSION_PROPERTY;
+import static io.quarkus.test.services.quarkus.model.QuarkusProperties.PLATFORM_GROUP_ID;
 import static io.quarkus.test.services.quarkus.model.QuarkusProperties.QUARKUS_JVM_S2I;
 import static java.util.regex.Pattern.quote;
 
@@ -84,6 +86,7 @@ public class OpenShiftS2iGitRepositoryQuarkusApplicationManagedResource
                 .replaceAll(quote("${GIT_REF}"), model.getGitBranch())
                 .replaceAll(quote("${CONTEXT_DIR}"), model.getContextDir())
                 .replaceAll(quote("${GIT_MAVEN_ARGS}"), mavenArgs)
+                .replaceAll(quote(QUARKUS_PLATFORM_GROUP_ID_PROPERTY), PLATFORM_GROUP_ID.get())
                 .replaceAll(quote(QUARKUS_VERSION_PROPERTY), quarkusVersion);
     }
 

--- a/quarkus-test-openshift/src/main/resources/quarkus-s2i-source-build-template.yml
+++ b/quarkus-test-openshift/src/main/resources/quarkus-s2i-source-build-template.yml
@@ -33,7 +33,7 @@ items:
         sourceStrategy:
           env:
             - name: MAVEN_ARGS
-              value: -s /configuration/settings.xml ${GIT_MAVEN_ARGS} -Dquarkus.version=${QUARKUS_VERSION} -Dquarkus.platform.version=${QUARKUS_VERSION} -Dquarkus.plugin.version=${QUARKUS_VERSION} -Dquarkus-plugin.version=${QUARKUS_VERSION}
+              value: -s /configuration/settings.xml ${GIT_MAVEN_ARGS} -Dquarkus.version=${QUARKUS_VERSION} -Dquarkus.platform.version=${QUARKUS_VERSION} -Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus-plugin.version=${QUARKUS_VERSION}
           from:
             kind: DockerImage
             name: ${QUARKUS_S2I_BUILDER_IMAGE}


### PR DESCRIPTION
Currently the annotation `@GitRepositoryQuarkusApplication` supports the following injections in mavenArgs annotation property:

* -Dquarkus.platform.version=${QUARKUS_VERSION} 
* -Dquarkus-plugin.version=${QUARKUS-PLUGIN_VERSION} 

Note: if `quarkus-plugin.version` and/or `quarkus.platform.version` is not provided then a default version is set

This PR add a new mavenArg injection:
* -Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID}

If `quarkus.platform.group-id` is not provided then `io.quarkus` would be used as a default group

Usage example:

```
@DisabledOnNative(reason = "This scenario is using uber-jar, so it's incompatible with Native")
@QuarkusScenario
public class TodoDemoIT {
    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/todo-demo-app.git", mavenArgs = "-Dquarkus.package.type=uber-jar -DskipTests=true -Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus.platform.version=${QUARKUS_VERSION} -Dquarkus-plugin.version=${QUARKUS-PLUGIN_VERSION}")
    static final RestService app = new RestService();

    @Test
    public void verify() {
        app.given()
                .get()
                .then()
                .statusCode(HttpStatus.SC_OK);
    }
}
```

Prompt

```
mvn -U clean verify -Dall-modules -Dopenshift -pl external-applications -Dmaven.repo.local=~/Downloads/rh-quarkus-2.2.5.CR3-maven-repository/maven-repository -Dquarkus.platform.group-id=com.redhat.quarkus.platform -Dquarkus.platform.artifact-id=quarkus-bom -Dquarkus.platform.version=2.2.5.Final-redhat-00007 -Dquarkus-plugin.version=2.2.5.Final-redhat-00007 
```

This example will use the external application `https://github.com/quarkusio/todo-demo-app.git` with the following maven args:
* quarkus.platform.version=${QUARKUS_VERSION} -> taken from promt -> 2.2.5.Final-redhat-00007
* quarkus-plugin.version=${QUARKUS-PLUGIN_VERSION} -> taken from promt -> 2.2.5.Final-redhat-00007
* quarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -> taken from promt -> com.redhat.quarkus.platform