### PR TITLE
Quarkus QE Test Framework 1.1.0.Beta2 release

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 name: Quarkus QE Test Framework
 release:
-  current-version: 1.1.0.Beta.1
+  current-version: 1.1.0.Beta2
   next-version: 1.1.0-SNAPSHOT


### PR DESCRIPTION
Release note
-------------------

## 1.1.0.Beta2 Changes 
- #415: Bump nexus-staging-maven-plugin from 1.6.8 to 1.6.12 (@dependabot)
- #418: Bump log4j.version from 2.17.1 to 2.17.2 (@dependabot)
- #417: Support platform group ID parametrization (@pjgg)
- #416: Updated platform version (@fedinskiy)
- #406: Support upstream and product release drafter (@pjgg)
- #409: Bump maven-compiler-plugin from 3.9.0 to 3.10.0 (@dependabot)
- #408: Bump maven-javadoc-plugin from 3.3.1 to 3.3.2 (@dependabot)
- #412: Move to Quarkus 2.7 including CI (@rsvoboda)
- #402: Set Quarkus_maven_plugin based on -Dquarkus-plugin.version parameter (@pjgg)
- #401: Disable Kafka related examples due to changes Quarkus main (@rsvoboda)
- #396: Vulnerable Log4J version exclusions (@mjurc)
- #399: Bump simpleclient_pushgateway from 0.14.1 to 0.15.0 (@dependabot)
- #395: Bump htmlunit from 2.57.0 to 2.58.0 (@dependabot)
- #393: Quarkus plugin should have his own version (@pjgg)
- #387: Add Quarkus TF release strategy doc (@pjgg)
- #392: [fix] Disable also ColorPatternFormatter when property is used (@llowinge)
All contributors: @QuarkusQE, @dependabot, @dependabot[bot], @fedinskiy, @llowinge, @mjurc, @pjgg and @rsvoboda