### PR TITLE
Disable consul ocp sceanrio OpenShiftGreetingResourceIT

### DIFF
--- a/examples/consul/src/test/java/io/quarkus/qe/OpenShiftGreetingResourceIT.java
+++ b/examples/consul/src/test/java/io/quarkus/qe/OpenShiftGreetingResourceIT.java
@@ -1,7 +1,11 @@
 package io.quarkus.qe;
 
+import org.junit.jupiter.api.Disabled;
+
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
 @OpenShiftScenario
+@Disabled
+//TODO https://github.com/quarkusio/quarkus/issues/24277
 public class OpenShiftGreetingResourceIT extends GreetingResourceIT {
 }


### PR DESCRIPTION
Quarkus application can't reach the consul server, because of a Quarkus DNS resolver issue.