### PR TITLE
Bump Keycloak version to 16.1.0

### DIFF
--- a/examples/keycloak/src/test/java/io/quarkus/qe/BaseSecurityResourceIT.java
+++ b/examples/keycloak/src/test/java/io/quarkus/qe/BaseSecurityResourceIT.java
@@ -17,7 +17,7 @@ public abstract class BaseSecurityResourceIT {
     static final String CLIENT_SECRET_DEFAULT = "test-application-client-secret";
     static final String NORMAL_USER = "test-normal-user";
 
-    @Container(image = "quay.io/keycloak/keycloak:14.0.0", expectedLog = "Admin console listening", port = 8080)
+    @Container(image = "quay.io/keycloak/keycloak:16.1.0", expectedLog = "Admin console listening", port = 8080)
     static final KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT);
 
     private AuthzClient authzClient;

--- a/examples/keycloak/src/test/java/io/quarkus/qe/OpenShiftUsingCustomTemplateResourceIT.java
+++ b/examples/keycloak/src/test/java/io/quarkus/qe/OpenShiftUsingCustomTemplateResourceIT.java
@@ -15,7 +15,7 @@ public class OpenShiftUsingCustomTemplateResourceIT {
     private static final String CLIENT_ID_DEFAULT = "test-application-client";
     private static final String CLIENT_SECRET_DEFAULT = "test-application-client-secret";
 
-    @Container(image = "quay.io/keycloak/keycloak:14.0.0", expectedLog = "Admin console listening", port = 8080)
+    @Container(image = "quay.io/keycloak/keycloak:16.1.0", expectedLog = "Admin console listening", port = 8080)
     static final KeycloakService customkeycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT);
 
     @QuarkusApplication

--- a/examples/keycloak/src/test/resources/keycloak-custom-template.yaml
+++ b/examples/keycloak/src/test/resources/keycloak-custom-template.yaml
@@ -12,7 +12,7 @@ items:
       - name: latest
         from:
           kind: DockerImage
-          name: quay.io/keycloak/keycloak:14.0.0
+          name: quay.io/keycloak/keycloak:16.1.0
 - apiVersion: apps.openshift.io/v1
   kind: DeploymentConfig
   metadata:


### PR DESCRIPTION
### Summary

Quarkus 2.7.x has moved to [Keycloak 16.1.0](https://github.com/quarkusio/quarkus/blob/2733bae7cb7ded76d324b41a3a9f4e81b89ee122/bom/application/pom.xml#L186) as a default supported Keykloak.

This PR bump keycloak version according to these changes. 
Upgrade Keycloak container: 15.0.1 -> 16.1.0

Please check the relevant options
- [X] Dependency update

### Checklist:
- [X] Example scenarios has been updated / added
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)