### PR TITLE
Use io.quarkiverse.artemis groupId for quarkus-artemis-jms extension

### DIFF
--- a/examples/amq-tcp/pom.xml
+++ b/examples/amq-tcp/pom.xml
@@ -11,8 +11,9 @@
     <name>Quarkus - Test Framework - Examples - AMQ TCP</name>
     <dependencies>
         <dependency>
-            <groupId>io.quarkus</groupId>
+            <groupId>io.quarkiverse.artemis</groupId>
             <artifactId>quarkus-artemis-jms</artifactId>
+            <version>1.0.5</version>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
Use io.quarkiverse.artemis groupId for quarkus-artemis-jms extension

See https://github.com/quarkusio/quarkus/wiki/Migration-Guide-2.6#extensions-moved-out-of-the-quarkus-platform

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Dependency update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### Checklist:
- [x] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)