### PR TITLE
Ignore quarkus-cli shouldAddAndRemoveExtensions on upstream

### DIFF
--- a/examples/quarkus-cli/src/test/java/io/quarkus/qe/QuarkusCliClientIT.java
+++ b/examples/quarkus-cli/src/test/java/io/quarkus/qe/QuarkusCliClientIT.java
@@ -13,6 +13,7 @@ import javax.inject.Inject;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import io.quarkus.test.bootstrap.QuarkusCliClient;
 import io.quarkus.test.bootstrap.QuarkusCliDefaultService;
@@ -57,6 +58,8 @@ public class QuarkusCliClientIT {
     }
 
     @Test
+    @DisabledIfSystemProperty(named = "quarkus.platform.version", matches = "999-SNAPSHOT", disabledReason = "Default upstream version is quarkus-resteasy-reactive")
+    // TODO https://github.com/quarkusio/quarkus/issues/25142
     public void shouldAddAndRemoveExtensions() throws InterruptedException {
         // Create application
         QuarkusCliRestService app = cliClient.createApplication("app");


### PR DESCRIPTION
### Summary

Looks like Quarkus-cli upstream has changed the defaults extension when an application is created. 
This PR ignore scenario `QuarkusCliClientIT#shouldAddAndRemoveExtensions` until is clarified which is giong to be the default behavior

Linked to: https://github.com/quarkusio/quarkus/issues/25142

Please check the relevant options

- [X] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [X] Example scenarios has been updated / added
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)