### PR TITLE
Downgrade confluent kafka avro serializer version to 7.0.1

### DIFF
--- a/examples/kafka-registry/pom.xml
+++ b/examples/kafka-registry/pom.xml
@@ -10,7 +10,7 @@
     <artifactId>examples-kafka-registry</artifactId>
     <name>Quarkus - Test Framework - Examples - Kafka with Registry</name>
     <properties>
-        <confluent.kafka-avro-serializer.version>7.1.0</confluent.kafka-avro-serializer.version>
+        <confluent.kafka-avro-serializer.version>7.0.1</confluent.kafka-avro-serializer.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
### Summary

confluent kafka avro serializer 7.1.0 is throwing the following error in native mode: 

```
Caused by: com.oracle.graal.pointsto.constraints.UnsupportedFeatureException: Detected an instance of Random/SplittableRandom class in the image heap. Instances created during image generation have cached seed values and don't behave as expected.  To see how this object got instantiated use --trace-object-instantiation=java.util.Random. The object was probably created by a class initializer and is reachable from a static field. You can request class initialization at image runtime by using the option --initialize-at-run-time=<class-name>. Or you can write your own initialization methods and call them explicitly from your main entry point.
        at com.oracle.svm.hosted.image.DisallowedImageHeapObjectFeature.error(DisallowedImageHeapObjectFeature.java:173)
```

Due to an internal static inizialization: https://github.com/confluentinc/schema-registry/blob/master/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/utils/UrlList.java#L33

Please check the relevant options

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Dependency update


### Checklist:
- [X] Example scenarios has been updated / added
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)