### PR TITLE
Create extension fix - the service folder parent needs to exist for cli log file

### DIFF
--- a/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/QuarkusCliClient.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/QuarkusCliClient.java
@@ -114,6 +114,9 @@ public class QuarkusCliClient {
         QuarkusCliDefaultService service = new QuarkusCliDefaultService(this);
         ServiceContext serviceContext = service.register("quarkus-" + name, context);
 
+        // We need the service folder parent to exist for cli log file
+        FileUtils.createDirectory(serviceContext.getServiceFolder().getParent());
+
         // Generate project
         List<String> args = new ArrayList<>();
         args.addAll(Arrays.asList("create", "extension", name));


### PR DESCRIPTION
Create extension fix - the service folder parent needs to exist for cli log file

Create extension works fine if included in TestCase with other CLI tests, but once used in dedicated TestCase there is no parent directory available and tests fail.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### Checklist:
- [ ] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)