### PR TITLE
Activate maven profile by property for compatibility with Windows env…

### DIFF
--- a/examples/blocking-reactive-model/pom.xml
+++ b/examples/blocking-reactive-model/pom.xml
@@ -53,6 +53,11 @@
     <profiles>
         <profile>
             <id>deploy-to-openshift-using-extension</id>
+            <activation>
+                <property>
+                    <name>deploy-to-openshift-using-extension</name>
+                </property>
+            </activation>
             <dependencies>
                 <dependency>
                     <groupId>io.quarkus</groupId>

--- a/examples/consul/pom.xml
+++ b/examples/consul/pom.xml
@@ -59,6 +59,11 @@
     <profiles>
         <profile>
             <id>deploy-to-openshift-using-extension</id>
+            <activation>
+                <property>
+                    <name>deploy-to-openshift-using-extension</name>
+                </property>
+            </activation>
             <dependencies>
                 <dependency>
                     <groupId>io.quarkus</groupId>

--- a/examples/grpc/pom.xml
+++ b/examples/grpc/pom.xml
@@ -52,6 +52,11 @@
     <profiles>
         <profile>
             <id>deploy-to-openshift-using-extension</id>
+            <activation>
+                <property>
+                    <name>deploy-to-openshift-using-extension</name>
+                </property>
+            </activation>
             <dependencies>
                 <dependency>
                     <groupId>io.quarkus</groupId>

--- a/examples/infinispan/pom.xml
+++ b/examples/infinispan/pom.xml
@@ -58,6 +58,11 @@
     <profiles>
         <profile>
             <id>deploy-to-openshift-using-extension</id>
+            <activation>
+                <property>
+                    <name>deploy-to-openshift-using-extension</name>
+                </property>
+            </activation>
             <dependencies>
                 <dependency>
                     <groupId>io.quarkus</groupId>

--- a/examples/kafka-streams/pom.xml
+++ b/examples/kafka-streams/pom.xml
@@ -57,6 +57,11 @@
     <profiles>
         <profile>
             <id>deploy-to-openshift-using-extension</id>
+            <activation>
+                <property>
+                    <name>deploy-to-openshift-using-extension</name>
+                </property>
+            </activation>
             <dependencies>
                 <dependency>
                     <groupId>io.quarkus</groupId>

--- a/examples/keycloak/pom.xml
+++ b/examples/keycloak/pom.xml
@@ -58,6 +58,11 @@
     <profiles>
         <profile>
             <id>deploy-to-openshift-using-extension</id>
+            <activation>
+                <property>
+                    <name>deploy-to-openshift-using-extension</name>
+                </property>
+            </activation>
             <dependencies>
                 <dependency>
                     <groupId>io.quarkus</groupId>

--- a/examples/pingpong/pom.xml
+++ b/examples/pingpong/pom.xml
@@ -49,6 +49,11 @@
     <profiles>
         <profile>
             <id>deploy-to-openshift-using-extension</id>
+            <activation>
+                <property>
+                    <name>deploy-to-openshift-using-extension</name>
+                </property>
+            </activation>
             <dependencies>
                 <dependency>
                     <groupId>io.quarkus</groupId>

--- a/examples/restclient/pom.xml
+++ b/examples/restclient/pom.xml
@@ -53,6 +53,11 @@
     <profiles>
         <profile>
             <id>deploy-to-openshift-using-extension</id>
+            <activation>
+                <property>
+                    <name>deploy-to-openshift-using-extension</name>
+                </property>
+            </activation>
             <dependencies>
                 <dependency>
                     <groupId>io.quarkus</groupId>

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/ExtensionOpenShiftQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/ExtensionOpenShiftQuarkusApplicationManagedResource.java
@@ -31,7 +31,7 @@ import io.quarkus.test.utils.PropertiesUtils;
 public class ExtensionOpenShiftQuarkusApplicationManagedResource
         extends OpenShiftQuarkusApplicationManagedResource<ProdQuarkusApplicationManagedResourceBuilder> {
 
-    private static final String USING_EXTENSION_PROFILE = "-Pdeploy-to-openshift-using-extension";
+    private static final String USING_EXTENSION_PROFILE = "-Ddeploy-to-openshift-using-extension";
     private static final String QUARKUS_PLUGIN_DEPLOY = "-Dquarkus.kubernetes.deploy=true";
     private static final String QUARKUS_PLUGIN_EXPOSE = "-Dquarkus.openshift.expose=true";
     private static final String QUARKUS_PLUGIN_ROUTE_EXPOSE = "-Dquarkus.openshift.route.expose=true";


### PR DESCRIPTION
### Summary

I engaged scenario when Maven profile is not activated by `-PprofileName` on system with following configuration

`Apache Maven 3.8.5 (3599d3414f046de2324203b78ddcf9b5e4388aa0)
Java version: 11.0.15, vendor: GraalVM Community, Default locale: en_US, platform encoding: Cp1252
OS name: "windows server 2019" (CYGWIN_NT-10.0), version: "10.0", arch: "amd64", family: "windows"`

I could not find an explanation in [reference guide](https://maven.apache.org/guides/introduction/introduction-to-profiles.html), however Maven profile activation by property (`-DprofileName`), is compatible across Windows/Unix-like operating systems (heuristic conclusion).

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)

### Reproducer
```
 mvn io.quarkus.platform:quarkus-maven-plugin:2.8.3.Final:create -DprojectGroupId=org.acme -DprojectArtifactId=oc
 cd oc/
 cat << EOF > pom.xml
 $(head -n -2 pom.xml)
 <profile>
            <id>deploy-to-openshift-using-extension</id>
            <activation>
                <property>
                    <name>deploy-to-openshift-using-extension</name>
                </property>
            </activation>
            <dependencies>
                <dependency>
                    <groupId>io.quarkus</groupId>
                    <artifactId>quarkus-openshift</artifactId>
                </dependency>
            </dependencies>
        </profile>
    </profiles>
 </project>
 EOF
```
#### Profile activation by property
```
mvn clean install -Ddeploy-to-openshift-using-extension -Dquarkus.openshift.expose=true -Dquarkus.openshift.route.expose=true -DskipTests=true -DskipITs=true
```
When run on Linux/Windows, log will contain
```
[INFO] [io.quarkus.kubernetes.deployment.KubernetesDeployer] Selecting target 'openshift' since it has the highest priority among the implicitly enabled deployment targets
```
#### Profile activation by name
```
mvn clean install -Pdeploy-to-openshift-using-extension -Dquarkus.openshift.expose=true -Dquarkus.openshift.route.expose=true -DskipTests=true -DskipITs=true
```
When run on Linux, log will contain information logged by `KubernetesDeployer` (same as above), however when run on Windows, log will contain
```
[WARNING] [io.quarkus.config] Unrecognized configuration key "quarkus.openshift.route.expose" was provided; it will be ignored; verify
 that the dependency extension for this configuration is set or that you did not make a typo
```