### PR TITLE
Update kafka version to be on par with operator

### DIFF
--- a/examples/kafka/pom.xml
+++ b/examples/kafka/pom.xml
@@ -48,7 +48,7 @@
                         <configuration>
                             <systemProperties>
                                 <custom.kafka.image>quay.io/strimzi/kafka</custom.kafka.image>
-                                <custom.kafka.version>0.23.0-kafka-2.8.0</custom.kafka.version>
+                                <custom.kafka.version>0.28.0-kafka-3.1.0</custom.kafka.version>
                             </systemProperties>
                         </configuration>
                     </execution>

--- a/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/model/KafkaVendor.java
+++ b/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/model/KafkaVendor.java
@@ -2,7 +2,7 @@ package io.quarkus.test.services.containers.model;
 
 public enum KafkaVendor {
     CONFLUENT("confluentinc/cp-kafka", "6.1.1", 9093, KafkaRegistry.CONFLUENT),
-    STRIMZI("quay.io/strimzi/kafka", "0.25.0-kafka-2.8.0", 9092, KafkaRegistry.APICURIO);
+    STRIMZI("quay.io/strimzi/kafka", "0.28.0-kafka-3.1.0", 9092, KafkaRegistry.APICURIO);
 
     private final String image;
     private final String defaultVersion;

--- a/quarkus-test-service-kafka/src/main/resources/strimzi-operator-kafka-instance.yaml
+++ b/quarkus-test-service-kafka/src/main/resources/strimzi-operator-kafka-instance.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kafka-instance
 spec:
   kafka:
-    version: 2.8.0
+    version: 3.1.0
     replicas: 1
     listeners:
       - name: plain
@@ -19,7 +19,7 @@ spec:
       offsets.topic.replication.factor: 1
       transaction.state.log.replication.factor: 1
       transaction.state.log.min.isr: 1
-      log.message.format.version: "2.8"
+      log.message.format.version: "3.1-IV0"
     storage:
       type: jbod
       volumes:


### PR DESCRIPTION
### Summary
Current version of Kafka in yaml is incompatible with strimzi operator on our OCP cluster

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)