### PR TITLE
Upgrade quarkus version to 2.9.1.Final

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -5,7 +5,7 @@ on:
     - cron: '0 23 * * *'
 jobs:
   quarkus-main-build:
-    name: Quarkus 2.7 build
+    name: Quarkus main build
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -28,7 +28,7 @@ jobs:
           check-latest: true
       - name: Build Quarkus main
         run: |
-          git clone https://github.com/quarkusio/quarkus.git && cd quarkus && git checkout 2.7 && ./mvnw -B -s .github/mvn-settings.xml clean install -Dquickly -Prelocations
+          git clone https://github.com/quarkusio/quarkus.git && cd quarkus && ./mvnw -B -s .github/mvn-settings.xml clean install -Dquickly -Prelocations
       - name: Tar Maven Repo
         shell: bash
         run: tar -I 'pigz -9' -cf maven-repo.tgz -C ~ .m2/repository
@@ -128,7 +128,7 @@ jobs:
 #          password: ${{ secrets.CI_REGISTRY_PASSWORD }}
       - name: Build Quarkus CLI
         run: |
-          git clone https://github.com/quarkusio/quarkus.git && cd quarkus/devtools/cli && git checkout 2.7 && mvn -B -s ../../../.github/mvn-settings.xml clean install -Dquickly -Prelocations
+          git clone https://github.com/quarkusio/quarkus.git && cd quarkus/devtools/cli && mvn -B -s ../../../.github/mvn-settings.xml clean install -Dquickly -Prelocations
       - name: Install Quarkus CLI
         run: |
           cat <<EOF > ./quarkus-dev-cli

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -26,7 +26,7 @@ jobs:
         run: |
           mvn -V -B -s .github/mvn-settings.xml verify -Pframework,examples -Dvalidate-format -DskipTests -DskipITs
   quarkus-main-build:
-    name: Quarkus 2.7 build
+    name: Quarkus main build
     runs-on: ubuntu-latest
     needs: validate-format
     strategy:
@@ -50,7 +50,7 @@ jobs:
           check-latest: true
       - name: Build Quarkus main
         run: |
-          git clone https://github.com/quarkusio/quarkus.git && cd quarkus && git checkout 2.7 && ./mvnw -B -s .github/mvn-settings.xml clean install -Dquickly -Prelocations
+          git clone https://github.com/quarkusio/quarkus.git && cd quarkus && ./mvnw -B -s .github/mvn-settings.xml clean install -Dquickly -Prelocations
       - name: Tar Maven Repo
         shell: bash
         run: tar -I 'pigz -9' -cf maven-repo.tgz -C ~ .m2/repository
@@ -136,7 +136,7 @@ jobs:
         run: tar -xzf maven-repo.tgz -C ~
       - name: Build Quarkus CLI
         run: |
-          git clone https://github.com/quarkusio/quarkus.git && cd quarkus/devtools/cli && git checkout 2.7 && mvn -B -s ../../../.github/mvn-settings.xml clean install -Dquickly -Prelocations
+          git clone https://github.com/quarkusio/quarkus.git && cd quarkus/devtools/cli && mvn -B -s ../../../.github/mvn-settings.xml clean install -Dquickly -Prelocations
       - name: Install Quarkus CLI
         run: |
           cat <<EOF > ./quarkus-dev-cli

--- a/examples/kafka-registry/pom.xml
+++ b/examples/kafka-registry/pom.xml
@@ -30,7 +30,7 @@
         <!-- with this, you don't have to use avro-maven-plugin -->
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-avro</artifactId>
+            <artifactId>quarkus-confluent-registry-avro</artifactId>
         </dependency>
         <!-- Confluent AVRO libraries -->
         <dependency>

--- a/examples/kafka-registry/src/test/java/io/quarkus/qe/StrimziKafkaWithRegistryMessagingIT.java
+++ b/examples/kafka-registry/src/test/java/io/quarkus/qe/StrimziKafkaWithRegistryMessagingIT.java
@@ -16,11 +16,14 @@ import org.junit.jupiter.api.Test;
 import io.quarkus.test.bootstrap.KafkaService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusSnapshot;
 import io.quarkus.test.services.KafkaContainer;
 import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.test.services.containers.model.KafkaVendor;
 
 @QuarkusScenario
+// TODO https://github.com/quarkusio/quarkus/issues/25814
+@DisabledOnQuarkusSnapshot(reason = "Apicurio 2.2.3.Final used in upstream is not compatible with Quarkus 2.9.2.Final")
 public class StrimziKafkaWithRegistryMessagingIT {
 
     @KafkaContainer(vendor = KafkaVendor.STRIMZI, withRegistry = true, registryPath = "/apis/registry/v2")

--- a/examples/quarkus-cli/src/test/java/io/quarkus/qe/QuarkusCliClientIT.java
+++ b/examples/quarkus-cli/src/test/java/io/quarkus/qe/QuarkusCliClientIT.java
@@ -26,7 +26,7 @@ import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
 @DisabledOnQuarkusVersion(version = "1\\..*", reason = "Quarkus CLI has been reworked in 2.x")
 public class QuarkusCliClientIT {
 
-    static final String RESTEASY_EXTENSION = "quarkus-resteasy";
+    static final String RESTEASY_REACTIVE_EXTENSION = "quarkus-resteasy-reactive";
     static final String SMALLRYE_HEALTH_EXTENSION = "quarkus-smallrye-health";
     static final int CMD_DELAY_SEC = 3;
 
@@ -64,15 +64,15 @@ public class QuarkusCliClientIT {
         // Create application
         QuarkusCliRestService app = cliClient.createApplication("app");
 
-        // By default, it installs only "quarkus-resteasy"
-        assertInstalledExtensions(app, RESTEASY_EXTENSION);
+        // By default, it installs only "quarkus-resteasy-reactive"
+        assertInstalledExtensions(app, RESTEASY_REACTIVE_EXTENSION);
 
         // Let's install Quarkus Smallrye Health
         QuarkusCliClient.Result result = app.installExtension(SMALLRYE_HEALTH_EXTENSION);
         assertTrue(result.isSuccessful(), SMALLRYE_HEALTH_EXTENSION + " was not installed. Output: " + result.getOutput());
 
         // Verify both extensions now
-        assertInstalledExtensions(app, RESTEASY_EXTENSION, SMALLRYE_HEALTH_EXTENSION);
+        assertInstalledExtensions(app, RESTEASY_REACTIVE_EXTENSION, SMALLRYE_HEALTH_EXTENSION);
 
         // The health endpoint should be now available
         app.start();

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <htmlunit.version>2.61.0</htmlunit.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.5.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.9.2.Final</quarkus.platform.version>
         <exclude.tests.with.tags>quarkus-cli</exclude.tests.with.tags>
         <include.tests>**/*IT.java</include.tests>
         <exclude.openshift.tests>**/OpenShift*IT.java</exclude.openshift.tests>

--- a/quarkus-test-cli/src/test/java/io/quarkus/test/QuarkusCliClientIT.java
+++ b/quarkus-test-cli/src/test/java/io/quarkus/test/QuarkusCliClientIT.java
@@ -32,8 +32,8 @@ import io.quarkus.test.services.quarkus.model.QuarkusProperties;
 public class QuarkusCliClientIT {
 
     static final String RESTEASY_SPRING_WEB_EXTENSION = "quarkus-spring-web";
-    static final String RESTEASY_EXTENSION = "quarkus-resteasy";
-    static final String RESTEASY_JACKSON_EXTENSION = "quarkus-resteasy-jackson";
+    static final String RESTEASY_REACTIVE_EXTENSION = "quarkus-resteasy-reactive";
+    static final String RESTEASY_REACTIVE_JACKSON_EXTENSION = "quarkus-resteasy-reactive-jackson";
     static final String SMALLRYE_HEALTH_EXTENSION = "quarkus-smallrye-health";
     static final int CMD_DELAY_SEC = 3;
 
@@ -80,10 +80,10 @@ public class QuarkusCliClientIT {
         // Create application with Resteasy Jackson
         QuarkusCliRestService app = cliClient.createApplication("app",
                 QuarkusCliClient.CreateApplicationRequest.defaults().withExtensions(RESTEASY_SPRING_WEB_EXTENSION,
-                        RESTEASY_JACKSON_EXTENSION));
+                        RESTEASY_REACTIVE_JACKSON_EXTENSION));
 
         // Verify By default, it installs only "quarkus-resteasy"
-        assertInstalledExtensions(app, RESTEASY_SPRING_WEB_EXTENSION, RESTEASY_JACKSON_EXTENSION);
+        assertInstalledExtensions(app, RESTEASY_SPRING_WEB_EXTENSION, RESTEASY_REACTIVE_JACKSON_EXTENSION);
 
         // Start using DEV mode
         app.start();
@@ -97,15 +97,15 @@ public class QuarkusCliClientIT {
         // Create application
         QuarkusCliRestService app = cliClient.createApplication("app");
 
-        // By default, it installs only "quarkus-resteasy"
-        assertInstalledExtensions(app, RESTEASY_EXTENSION);
+        // By default, it installs only "quarkus-resteasy-reactive"
+        assertInstalledExtensions(app, RESTEASY_REACTIVE_EXTENSION);
 
         // Let's install Quarkus Smallrye Health
         QuarkusCliClient.Result result = app.installExtension(SMALLRYE_HEALTH_EXTENSION);
         assertTrue(result.isSuccessful(), SMALLRYE_HEALTH_EXTENSION + " was not installed. Output: " + result.getOutput());
 
         // Verify both extensions now
-        assertInstalledExtensions(app, RESTEASY_EXTENSION, SMALLRYE_HEALTH_EXTENSION);
+        assertInstalledExtensions(app, RESTEASY_REACTIVE_EXTENSION, SMALLRYE_HEALTH_EXTENSION);
 
         // The health endpoint should be now available
         app.start();

--- a/quarkus-test-service-kafka/pom.xml
+++ b/quarkus-test-service-kafka/pom.xml
@@ -9,7 +9,7 @@
     <artifactId>quarkus-test-service-kafka</artifactId>
     <name>Quarkus - Test Framework - Service - Kafka</name>
     <properties>
-        <strimzi.testcontainers.version>0.25.0</strimzi.testcontainers.version>
+        <strimzi.testcontainers.version>0.100.0</strimzi.testcontainers.version>
         <log4j.version>2.17.2</log4j.version>
     </properties>
     <dependencies>

--- a/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/BaseKafkaContainerManagedResource.java
+++ b/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/BaseKafkaContainerManagedResource.java
@@ -51,6 +51,10 @@ public abstract class BaseKafkaContainerManagedResource extends DockerContainerM
         return StringUtils.defaultIfBlank(model.getVersion(), model.getVendor().getDefaultVersion());
     }
 
+    protected String getKafkaImageName() {
+        return StringUtils.defaultIfBlank(model.getImage(), model.getVendor().getImage());
+    }
+
     protected String getKafkaRegistryImage() {
         return model.getRegistryImageVersion();
     }

--- a/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/StrimziKafkaContainerManagedResource.java
+++ b/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/StrimziKafkaContainerManagedResource.java
@@ -42,7 +42,7 @@ public class StrimziKafkaContainerManagedResource extends BaseKafkaContainerMana
 
     @Override
     protected GenericContainer<?> initKafkaContainer() {
-        ExtendedStrimziKafkaContainer container = new ExtendedStrimziKafkaContainer(getKafkaVersion());
+        ExtendedStrimziKafkaContainer container = new ExtendedStrimziKafkaContainer(getKafkaImageName(), getKafkaVersion());
         if (StringUtils.isNotEmpty(getServerProperties())) {
             container.useCustomServerProperties();
         }

--- a/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/model/KafkaRegistry.java
+++ b/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/model/KafkaRegistry.java
@@ -2,7 +2,7 @@ package io.quarkus.test.services.containers.model;
 
 public enum KafkaRegistry {
     CONFLUENT("confluentinc/cp-schema-registry", "6.1.1", "/", 8081),
-    APICURIO("quay.io/apicurio/apicurio-registry-mem", "2.0.1.Final", "/api", 8080);
+    APICURIO("quay.io/apicurio/apicurio-registry-mem", "2.1.5.Final", "/apis", 8080);
 
     private final String image;
     private final String defaultVersion;

--- a/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/strimzi/ExtendedStrimziKafkaContainer.java
+++ b/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/strimzi/ExtendedStrimziKafkaContainer.java
@@ -7,7 +7,7 @@ import org.testcontainers.images.builder.Transferable;
 import com.github.dockerjava.api.command.InspectContainerResponse;
 
 import io.quarkus.test.services.containers.model.KafkaVendor;
-import io.strimzi.StrimziKafkaContainer;
+import io.strimzi.test.container.StrimziKafkaContainer;
 
 /**
  * Extend the functionality of io.strimzi.StrimziKafkaContainer with:
@@ -21,8 +21,8 @@ public class ExtendedStrimziKafkaContainer extends StrimziKafkaContainer {
 
     private boolean useCustomServerProperties = false;
 
-    public ExtendedStrimziKafkaContainer(String version) {
-        super(version);
+    public ExtendedStrimziKafkaContainer(String name, String version) {
+        super(String.format("%s:%s", name, version));
     }
 
     public void useCustomServerProperties() {


### PR DESCRIPTION
### Summary

- Move on to Quarkus 2.9.1.Final
- Upgrade Strimzi Kafka TestContainers and amend strimzi scenario
- amend quarkus-cli examples

Please check the relevant options

- [X] Dependency update


### Checklist:
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)