### PR TITLE
Use separate log files for CLI commands and CLI dev mode, and clean the files at the end

### DIFF
--- a/quarkus-test-cli/src/main/java/io/quarkus/test/services/quarkus/CliDevModeLocalhostQuarkusApplicationManagedResource.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/services/quarkus/CliDevModeLocalhostQuarkusApplicationManagedResource.java
@@ -17,6 +17,7 @@ import io.quarkus.test.logging.LoggingHandler;
 import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusSnapshotCondition;
 import io.quarkus.test.services.quarkus.model.LaunchMode;
 import io.quarkus.test.services.quarkus.model.QuarkusProperties;
+import io.quarkus.test.utils.FileUtils;
 import io.quarkus.test.utils.ProcessUtils;
 import io.quarkus.test.utils.SocketUtils;
 
@@ -50,9 +51,8 @@ public class CliDevModeLocalhostQuarkusApplicationManagedResource extends Quarku
 
         try {
             assignPorts();
-            process = client.runOnDev(serviceContext.getServiceFolder(), getPropertiesForCommand());
-
-            File logFile = serviceContext.getServiceFolder().resolve(QuarkusCliClient.LOG_FILE).toFile();
+            File logFile = serviceContext.getServiceFolder().resolve(QuarkusCliClient.DEV_MODE_LOG_FILE).toFile();
+            process = client.runOnDev(serviceContext.getServiceFolder(), logFile, getPropertiesForCommand());
             loggingHandler = new FileServiceLoggingHandler(serviceContext.getOwner(), logFile);
             loggingHandler.startWatching();
         } catch (Exception e) {
@@ -64,6 +64,8 @@ public class CliDevModeLocalhostQuarkusApplicationManagedResource extends Quarku
     public void stop() {
         if (loggingHandler != null) {
             loggingHandler.stopWatching();
+            File logFile = serviceContext.getServiceFolder().resolve(QuarkusCliClient.DEV_MODE_LOG_FILE).toFile();
+            FileUtils.deleteFileContent(logFile);
         }
 
         ProcessUtils.destroy(process);

--- a/quarkus-test-core/src/main/java/io/quarkus/test/utils/FileUtils.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/utils/FileUtils.java
@@ -117,6 +117,16 @@ public final class FileUtils {
         }
     }
 
+    public static void deleteFileContent(File file) {
+        if (file.exists()) {
+            try {
+                org.apache.commons.io.FileUtils.write(file, "", StandardCharsets.UTF_8);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
     public static Optional<String> findTargetFile(Path basePath, String endsWith) {
         try (Stream<Path> binariesFound = Files
                 .find(basePath, NO_RECURSIVE,


### PR DESCRIPTION
Use separate log files for CLI commands and CLI dev mode, and clean the files at the end

Fixes https://github.com/quarkus-qe/quarkus-test-framework/issues/477

Run `QuarkusCliClientIT` from examples to see the difference before the fix and with the fix.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### Checklist:
- [ ] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)