### PR TITLE
Fix `QuarkusCliClientIT#shouldCreateExtension`

### DIFF
--- a/examples/quarkus-cli/src/test/java/io/quarkus/qe/QuarkusCliClientIT.java
+++ b/examples/quarkus-cli/src/test/java/io/quarkus/qe/QuarkusCliClientIT.java
@@ -1,6 +1,7 @@
 package io.quarkus.qe;
 
 import static io.quarkus.test.utils.AwaitilityUtils.untilAsserted;
+import static io.quarkus.test.utils.PropertiesUtils.resolveProperty;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
@@ -51,8 +52,11 @@ public class QuarkusCliClientIT {
         // Create extension
         QuarkusCliDefaultService app = cliClient.createExtension("extension-abc");
 
+        // TODO: remove when https://github.com/quarkusio/quarkus/issues/26014 is resolved
+        var setQuarkusVersion = String.format("-Dquarkus.version=%s", resolveProperty("${quarkus.platform.version}"));
+
         // Should build on Jvm
-        QuarkusCliClient.Result result = app.buildOnJvm();
+        QuarkusCliClient.Result result = app.buildOnJvm(setQuarkusVersion);
         assertTrue(result.isSuccessful(), "The extension build failed. Output: " + result.getOutput());
     }
 


### PR DESCRIPTION
### Summary

Test `QuarkusCliClientIT#shouldCreateExtension` is failing in the Daily Build of Quarkus Test Framework as it can't resolve `quarkus-extension-maven-plugin:JAR:2.9.2.Final`. I created issue for that [here](https://github.com/quarkusio/quarkus/issues/26014), but before it's resolved we could simply set `quarkus.version` accordingly to `quarkus.platform.version`, which fixes the problem for the SNAPSHOT version, problem was introduced 2 days ago, thus previous versions are not affected by this.

### Steps to reproduce

Prerequisites are quarkus-cli in version 999-SNAPSHOT and the latest Quarkus 999-SNAPSHOT, please see linked issue for detail steps.

``` bash
[mvavrik@fedora quarkus-test-framework]$ pwd
/home/mvavrik/sources/quarkus-test-framework
[mvavrik@fedora quarkus-test-framework]$ mvn -fae clean install -Pframework,examples,extensions,coverage -Drun-cli-tests -Dquarkus.platform.version=999-SNAPSHOT -Dts.quarkus.cli.cmd="${PWD}/examples/quarkus-cli/quarkus-dev-cli" -f examples/quarkus-cli/
```

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)