### PR TITLE
Revert "Fix `QuarkusCliClientIT#shouldCreateExtension` "

### DIFF
--- a/examples/quarkus-cli/src/test/java/io/quarkus/qe/QuarkusCliClientIT.java
+++ b/examples/quarkus-cli/src/test/java/io/quarkus/qe/QuarkusCliClientIT.java
@@ -1,7 +1,6 @@
 package io.quarkus.qe;
 
 import static io.quarkus.test.utils.AwaitilityUtils.untilAsserted;
-import static io.quarkus.test.utils.PropertiesUtils.resolveProperty;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
@@ -52,11 +51,8 @@ public class QuarkusCliClientIT {
         // Create extension
         QuarkusCliDefaultService app = cliClient.createExtension("extension-abc");
 
-        // TODO: remove when https://github.com/quarkusio/quarkus/issues/26014 is resolved
-        var setQuarkusVersion = String.format("-Dquarkus.version=%s", resolveProperty("${quarkus.platform.version}"));
-
         // Should build on Jvm
-        QuarkusCliClient.Result result = app.buildOnJvm(setQuarkusVersion);
+        QuarkusCliClient.Result result = app.buildOnJvm();
         assertTrue(result.isSuccessful(), "The extension build failed. Output: " + result.getOutput());
     }
 


### PR DESCRIPTION
### Summary

This reverts commit d03cddd51641f9ac49c6eac793bedd82575865d6. [Quarkus Issue 26014](https://github.com/quarkusio/quarkus/issues/26014) has been fixed, thus changes made in [PR 483](https://github.com/quarkus-qe/quarkus-test-framework/pull/483) should be reverted.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)