### PR TITLE
Add an explicit reusable container verification example

### DIFF
--- a/examples/database-mysql/src/test/java/io/quarkus/qe/database/mysql/AbstractMysqlReusableInstance.java
+++ b/examples/database-mysql/src/test/java/io/quarkus/qe/database/mysql/AbstractMysqlReusableInstance.java
@@ -1,0 +1,37 @@
+package io.quarkus.qe.database.mysql;
+
+import java.util.Objects;
+
+import org.junit.Assert;
+
+import io.quarkus.test.bootstrap.MySqlService;
+import io.quarkus.test.services.Container;
+
+public abstract class AbstractMysqlReusableInstance extends AbstractSqlDatabaseIT {
+
+    /**
+     * This mysql instance will be shared between different @QuarkusScenarios if
+     * property `ts.database.container.reusable` is enabled on test.properties
+     **/
+
+    @Container(image = "docker.io/mysql:8.0.27", port = 3306, expectedLog = "port: 3306  MySQL Community Server")
+    public static MySqlService database = new MySqlService();
+
+    static Integer containerPort;
+
+    protected void IsContainerReused() {
+        if (isFirstInstance()) {
+            setContainerPort();
+        }
+
+        Assert.assertEquals(containerPort, database.getPort());
+    }
+
+    private boolean isFirstInstance() {
+        return Objects.isNull(containerPort);
+    }
+
+    private void setContainerPort() {
+        containerPort = database.getPort();
+    }
+}

--- a/examples/database-mysql/src/test/java/io/quarkus/qe/database/mysql/DevModeMySqlDevServicesDatabaseIT.java
+++ b/examples/database-mysql/src/test/java/io/quarkus/qe/database/mysql/DevModeMySqlDevServicesDatabaseIT.java
@@ -12,7 +12,7 @@ import io.quarkus.test.services.DevModeQuarkusApplication;
  */
 @DisabledOnNative
 @QuarkusScenario
-public class DevServicesOnDevModeMySqlDatabaseIT extends AbstractSqlDatabaseIT {
+public class DevModeMySqlDevServicesDatabaseIT extends AbstractSqlDatabaseIT {
 
     @DevModeQuarkusApplication
     static RestService app = new RestService();
@@ -24,6 +24,6 @@ public class DevServicesOnDevModeMySqlDatabaseIT extends AbstractSqlDatabaseIT {
 
     @Test
     public void verifyLogsToAssertDevMode() {
-        app.logs().assertContains("Profile DevServicesOnDevModeMySqlDatabaseIT activated. Live Coding activated");
+        app.logs().assertContains("Profile DevModeMySqlDevServicesDatabaseIT activated. Live Coding activated");
     }
 }

--- a/examples/database-mysql/src/test/java/io/quarkus/qe/database/mysql/MySqlDatabaseIT.java
+++ b/examples/database-mysql/src/test/java/io/quarkus/qe/database/mysql/MySqlDatabaseIT.java
@@ -1,18 +1,13 @@
 package io.quarkus.qe.database.mysql;
 
-import static io.quarkus.qe.database.mysql.DevModeMySqlDatabaseIT.MYSQL_PORT;
+import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.bootstrap.MySqlService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @QuarkusScenario
-public class MySqlDatabaseIT extends AbstractSqlDatabaseIT {
-
-    @Container(image = "docker.io/mysql:8.0.27", port = MYSQL_PORT, expectedLog = "port: 3306  MySQL Community Server")
-    static MySqlService database = new MySqlService();
+public class MySqlDatabaseIT extends AbstractMysqlReusableInstance {
 
     @QuarkusApplication
     static RestService app = new RestService()
@@ -23,5 +18,12 @@ public class MySqlDatabaseIT extends AbstractSqlDatabaseIT {
     @Override
     protected RestService getApp() {
         return app;
+    }
+
+    @Test
+    public void verifyContainerIsReused() {
+        // Ignored if is the first Mysql instance
+        // This test works in conjunction with MySqlReusableDatabaseIT.verifyContainerIsReused
+        IsContainerReused();
     }
 }

--- a/examples/database-mysql/src/test/java/io/quarkus/qe/database/mysql/MySqlReusableDatabaseIT.java
+++ b/examples/database-mysql/src/test/java/io/quarkus/qe/database/mysql/MySqlReusableDatabaseIT.java
@@ -1,18 +1,13 @@
 package io.quarkus.qe.database.mysql;
 
-import static io.quarkus.qe.database.mysql.DevModeMySqlDatabaseIT.MYSQL_PORT;
+import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.bootstrap.MySqlService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @QuarkusScenario
-public class MySqlReusableDatabaseIT extends AbstractSqlDatabaseIT {
-
-    @Container(image = "docker.io/mysql:8.0.27", port = MYSQL_PORT, expectedLog = "port: 3306  MySQL Community Server")
-    static MySqlService database = new MySqlService();
+public class MySqlReusableDatabaseIT extends AbstractMysqlReusableInstance {
 
     @QuarkusApplication
     static RestService app = new RestService()
@@ -23,5 +18,12 @@ public class MySqlReusableDatabaseIT extends AbstractSqlDatabaseIT {
     @Override
     protected RestService getApp() {
         return app;
+    }
+
+    @Test
+    public void verifyContainerIsReused() {
+        // Ignored if is the first Mysql instance
+        // This test works in conjunction with MySqlDatabaseIT.verifyContainerIsReused
+        IsContainerReused();
     }
 }

--- a/quarkus-test-containers/src/main/java/io/quarkus/test/services/containers/GenericDockerContainerManagedResource.java
+++ b/quarkus-test-containers/src/main/java/io/quarkus/test/services/containers/GenericDockerContainerManagedResource.java
@@ -60,6 +60,13 @@ public class GenericDockerContainerManagedResource extends DockerContainerManage
         return container;
     }
 
+    @Override
+    public void stop() {
+        if (!isReusable()) {
+            super.stop();
+        }
+    }
+
     protected boolean isReusable() {
         return model.getContext().getOwner().getConfiguration().isTrue(REUSABLE_MODE);
     }


### PR DESCRIPTION
### Summary

- Rename `DevServicesOnDevModeMySqlDatabaseIT` -> `DevModeMySqlDevServicesDatabaseIT`
- Reusable container should not force a close event on docker container service.
- Add a explicit verification of reusable containers. 

Please check the relevant options

- [X] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [X] Example scenarios has been updated / added
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)