### PR TITLE
Disable Windows/oracle native compilation

### DIFF
--- a/examples/database-oracle/pom.xml
+++ b/examples/database-oracle/pom.xml
@@ -60,6 +60,21 @@
         </plugins>
     </build>
     <profiles>
+        <!-- TODO - Disabled native build on Windows, https://github.com/quarkusio/quarkus/issues/25954 -->
+        <profile>
+            <id>native</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+                <os>
+                    <family>windows</family>
+                </os>
+            </activation>
+            <properties>
+                <quarkus.package.type>fast-jar</quarkus.package.type>
+            </properties>
+        </profile>
         <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
         <profile>
             <id>skip-tests-on-windows</id>


### PR DESCRIPTION
### Summary

Diable windows/oracle example on native mode. 
Issue: https://github.com/quarkusio/quarkus/issues/25954

Please check the relevant options

- [X] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [X] Example scenarios has been updated / added
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)