### PR TITLE
Upgrade keycloak to version 18.0.0

### DIFF
--- a/examples/keycloak/src/test/java/io/quarkus/qe/LegacyKeycloakIT.java
+++ b/examples/keycloak/src/test/java/io/quarkus/qe/LegacyKeycloakIT.java
@@ -8,40 +8,42 @@ import org.keycloak.authorization.client.AuthzClient;
 
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.RestService;
-import io.quarkus.test.services.KeycloakContainer;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.Container;
+import io.quarkus.test.services.QuarkusApplication;
 
-public abstract class BaseSecurityResourceIT {
+@QuarkusScenario
+public class LegacyKeycloakIT {
 
-    static final String REALM_BASE_PATH = "realms";
     static final String REALM_DEFAULT = "test-realm";
     static final String CLIENT_ID_DEFAULT = "test-application-client";
     static final String CLIENT_SECRET_DEFAULT = "test-application-client-secret";
     static final String NORMAL_USER = "test-normal-user";
 
-    @KeycloakContainer(command = { "start-dev --import-realm" })
-    static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT, REALM_BASE_PATH);
+    @Container(image = "quay.io/keycloak/keycloak:14.0.0", expectedLog = "Admin console listening", port = 8080)
+    static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT, "/auth/realms/");
 
     private AuthzClient authzClient;
 
-    protected abstract RestService getApp();
+    @QuarkusApplication
+    static final RestService app = new RestService()
+            .withProperty("quarkus.oidc.auth-server-url", () -> keycloak.getRealmUrl())
+            .withProperty("quarkus.oidc.client-id", CLIENT_ID_DEFAULT)
+            .withProperty("quarkus.oidc.credentials.secret", CLIENT_SECRET_DEFAULT);
 
     @BeforeEach
     public void setup() {
-        initAuthzClient();
+        authzClient = keycloak.createAuthzClient(CLIENT_ID_DEFAULT, CLIENT_SECRET_DEFAULT);
     }
 
     @Test
     public void checkUserResourceByNormalUser() {
-        getApp().given()
+        app.given()
                 .auth().oauth2(getTokenByTestNormalUser())
                 .get("/user")
                 .then()
                 .statusCode(200)
                 .body(equalTo("Hello, user test-normal-user"));
-    }
-
-    private void initAuthzClient() {
-        authzClient = keycloak.createAuthzClient(CLIENT_ID_DEFAULT, CLIENT_SECRET_DEFAULT);
     }
 
     private String getTokenByTestNormalUser() {

--- a/examples/keycloak/src/test/java/io/quarkus/qe/OpenShiftUsingCustomTemplateResourceIT.java
+++ b/examples/keycloak/src/test/java/io/quarkus/qe/OpenShiftUsingCustomTemplateResourceIT.java
@@ -15,7 +15,7 @@ public class OpenShiftUsingCustomTemplateResourceIT {
     private static final String CLIENT_ID_DEFAULT = "test-application-client";
     private static final String CLIENT_SECRET_DEFAULT = "test-application-client-secret";
 
-    @Container(image = "quay.io/keycloak/keycloak:16.1.0", expectedLog = "Admin console listening", port = 8080)
+    @Container(image = "quay.io/keycloak/keycloak:18.0.0", expectedLog = "started", port = 8080)
     static final KeycloakService customkeycloak = new KeycloakService("/keycloak-realm.json", REALM_DEFAULT);
 
     @QuarkusApplication

--- a/examples/keycloak/src/test/java/io/quarkus/qe/OpenShiftUsingExtensionLegacyKeycloakIT.java
+++ b/examples/keycloak/src/test/java/io/quarkus/qe/OpenShiftUsingExtensionLegacyKeycloakIT.java
@@ -1,0 +1,8 @@
+package io.quarkus.qe;
+
+import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
+import io.quarkus.test.scenarios.OpenShiftScenario;
+
+@OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
+public class OpenShiftUsingExtensionLegacyKeycloakIT extends LegacyKeycloakIT {
+}

--- a/examples/keycloak/src/test/java/io/quarkus/qe/SecurityResourceIT.java
+++ b/examples/keycloak/src/test/java/io/quarkus/qe/SecurityResourceIT.java
@@ -6,6 +6,7 @@ import io.quarkus.test.services.QuarkusApplication;
 
 @QuarkusScenario
 public class SecurityResourceIT extends BaseSecurityResourceIT {
+
     @QuarkusApplication
     static final RestService app = new RestService()
             .withProperty("quarkus.oidc.auth-server-url", () -> keycloak.getRealmUrl())

--- a/examples/keycloak/src/test/resources/keycloak-custom-template.yaml
+++ b/examples/keycloak/src/test/resources/keycloak-custom-template.yaml
@@ -12,7 +12,7 @@ items:
       - name: latest
         from:
           kind: DockerImage
-          name: quay.io/keycloak/keycloak:16.1.0
+          name: quay.io/keycloak/keycloak:18.0.0
 - apiVersion: apps.openshift.io/v1
   kind: DeploymentConfig
   metadata:
@@ -31,6 +31,7 @@ items:
       spec:
         containers:
         - name: keycloak
+          args: [ "start-dev", "--import-realm"]
           env:
           - name: X509_CA_BUNDLE
             value: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt

--- a/examples/keycloak/src/test/resources/keycloak-realm.json
+++ b/examples/keycloak/src/test/resources/keycloak-realm.json
@@ -51,7 +51,38 @@
       "implicitFlowEnabled": false,
       "directAccessGrantsEnabled": true,
       "clientAuthenticatorType": "client-secret",
-      "secret": "test-application-client-secret"
+      "secret": "test-application-client-secret",
+      "protocolMappers": [
+        {
+          "id": "f17f8d5f-2327-4e0b-8001-48a7706be252",
+          "name": "realm roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "foo",
+            "access.token.claim": "true",
+            "claim.name": "realm_access.roles",
+            "jsonType.label": "String",
+            "multivalued": "true"
+          }
+        },
+        {
+          "id": "0e0f1e8d-60f9-4435-b753-136d70e56af8",
+          "name": "username",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "preferred_username",
+            "jsonType.label": "String"
+          }
+        }
+        ]
     }
   ]
 }

--- a/quarkus-test-containers/src/main/java/io/quarkus/test/services/containers/ContainerManagedResourceBuilder.java
+++ b/quarkus-test-containers/src/main/java/io/quarkus/test/services/containers/ContainerManagedResourceBuilder.java
@@ -1,6 +1,7 @@
 package io.quarkus.test.services.containers;
 
 import java.lang.annotation.Annotation;
+import java.util.Optional;
 import java.util.ServiceLoader;
 
 import io.quarkus.test.bootstrap.ManagedResource;
@@ -29,7 +30,7 @@ public class ContainerManagedResourceBuilder implements ManagedResourceBuilder {
     }
 
     protected String[] getCommand() {
-        return command;
+        return Optional.ofNullable(command).orElse(new String[] {});
     }
 
     protected Integer getPort() {

--- a/quarkus-test-core/src/main/java/io/quarkus/test/utils/PropertiesUtils.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/utils/PropertiesUtils.java
@@ -16,6 +16,9 @@ import org.apache.commons.lang3.StringUtils;
 public final class PropertiesUtils {
 
     public static final String RESOURCE_PREFIX = "resource::/";
+    public static final String RESOURCE_WITH_DESTINATION_PREFIX = "resource_with_destination::";
+    public static final String RESOURCE_WITH_DESTINATION_SPLIT_CHAR = "\\|";
+    public static final String RESOURCE_WITH_DESTINATION_PREFIX_MATCHER = ".*" + RESOURCE_WITH_DESTINATION_SPLIT_CHAR + ".*";
     public static final String SECRET_PREFIX = "secret::/";
     public static final Path TARGET = Path.of("target");
     public static final String SLASH = "/";

--- a/quarkus-test-kubernetes/src/main/java/io/quarkus/test/bootstrap/inject/KubectlClient.java
+++ b/quarkus-test-kubernetes/src/main/java/io/quarkus/test/bootstrap/inject/KubectlClient.java
@@ -1,6 +1,11 @@
 package io.quarkus.test.bootstrap.inject;
 
+import static io.quarkus.test.model.CustomVolume.VolumeType.CONFIG_MAP;
+import static io.quarkus.test.model.CustomVolume.VolumeType.SECRET;
 import static io.quarkus.test.utils.PropertiesUtils.RESOURCE_PREFIX;
+import static io.quarkus.test.utils.PropertiesUtils.RESOURCE_WITH_DESTINATION_PREFIX;
+import static io.quarkus.test.utils.PropertiesUtils.RESOURCE_WITH_DESTINATION_PREFIX_MATCHER;
+import static io.quarkus.test.utils.PropertiesUtils.RESOURCE_WITH_DESTINATION_SPLIT_CHAR;
 import static io.quarkus.test.utils.PropertiesUtils.SECRET_PREFIX;
 import static io.quarkus.test.utils.PropertiesUtils.SLASH;
 import static io.quarkus.test.utils.PropertiesUtils.TARGET;
@@ -26,16 +31,13 @@ import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
 
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
-import io.fabric8.kubernetes.api.model.ConfigMapVolumeSourceBuilder;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesList;
 import io.fabric8.kubernetes.api.model.Pod;
-import io.fabric8.kubernetes.api.model.SecretVolumeSourceBuilder;
 import io.fabric8.kubernetes.api.model.ServicePort;
-import io.fabric8.kubernetes.api.model.Volume;
-import io.fabric8.kubernetes.api.model.VolumeBuilder;
+import io.fabric8.kubernetes.api.model.VolumeMount;
 import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.client.utils.Serialization;
@@ -46,6 +48,7 @@ import io.fabric8.openshift.client.OpenShiftConfigBuilder;
 import io.quarkus.test.bootstrap.Service;
 import io.quarkus.test.configuration.PropertyLookup;
 import io.quarkus.test.logging.Log;
+import io.quarkus.test.model.CustomVolume;
 import io.quarkus.test.utils.Command;
 import io.quarkus.test.utils.FileUtils;
 
@@ -365,65 +368,86 @@ public final class KubectlClient {
 
     private Map<String, String> enrichProperties(Map<String, String> properties, Deployment deployment) {
         // mount path x volume
-        Map<String, Volume> volumes = new HashMap<>();
+        Map<String, CustomVolume> volumes = new HashMap<>();
 
         Map<String, String> output = new HashMap<>();
         for (Entry<String, String> entry : properties.entrySet()) {
-            String value = entry.getValue();
+            String propertyValue = entry.getValue();
             if (isResource(entry.getValue())) {
                 String path = entry.getValue().replace(RESOURCE_PREFIX, StringUtils.EMPTY);
                 String mountPath = getMountPath(path);
                 String filename = getFileName(path);
-                String configMapName = normalizeName(mountPath);
+                String configMapName = normalizeConfigMapName(mountPath);
 
                 // Update config map
                 createOrUpdateConfigMap(configMapName, filename, getFileContent(path));
 
                 // Add the volume
                 if (!volumes.containsKey(mountPath)) {
-                    Volume volume = new VolumeBuilder()
-                            .withName(configMapName)
-                            .withConfigMap(new ConfigMapVolumeSourceBuilder().withName(configMapName).build())
-                            .build();
-                    volumes.put(mountPath, volume);
+                    volumes.put(mountPath, new CustomVolume(configMapName, "", CONFIG_MAP));
                 }
 
-                value = mountPath + SLASH + filename;
+                propertyValue = mountPath + SLASH + filename;
+            } else if (isResourceWithDestinationPath(propertyValue)) {
+                String path = propertyValue.replace(RESOURCE_WITH_DESTINATION_PREFIX, StringUtils.EMPTY);
+                if (!propertyValue.matches(RESOURCE_WITH_DESTINATION_PREFIX_MATCHER)) {
+                    String errorMsg = String.format("Unexpected %s format. Expected destinationPath|fileName but found %s",
+                            RESOURCE_WITH_DESTINATION_PREFIX, propertyValue);
+                    throw new RuntimeException(errorMsg);
+                }
+
+                String mountPath = path.split(RESOURCE_WITH_DESTINATION_SPLIT_CHAR)[0];
+                String fileName = path.split(RESOURCE_WITH_DESTINATION_SPLIT_CHAR)[1];
+                String fileNameNormalized = getFileName(fileName);
+                String configMapName = normalizeConfigMapName(mountPath);
+
+                // Update config map
+                createOrUpdateConfigMap(configMapName, fileNameNormalized, getFileContent(fileName));
+                propertyValue = mountPath + SLASH + fileNameNormalized;
+                // Add the volume
+                if (!volumes.containsKey(mountPath)) {
+                    volumes.put(propertyValue, new CustomVolume(configMapName, fileNameNormalized, CONFIG_MAP));
+                }
             } else if (isSecret(entry.getValue())) {
                 String path = entry.getValue().replace(SECRET_PREFIX, StringUtils.EMPTY);
                 String mountPath = getMountPath(path);
                 String filename = getFileName(path);
-                String secretName = normalizeName(path);
+                String secretName = normalizeConfigMapName(path);
 
                 // Push secret file
                 doCreateSecretFromFile(secretName, getFilePath(path));
-
-                // Add the volume
-                Volume volume = new VolumeBuilder()
-                        .withName(secretName)
-                        .withSecret(new SecretVolumeSourceBuilder()
-                                .withSecretName(secretName)
-                                .build())
-                        .build();
-                volumes.put(mountPath, volume);
-
-                value = mountPath + SLASH + filename;
+                volumes.put(mountPath, volumes.put(mountPath, new CustomVolume(secretName, "", SECRET)));
+                propertyValue = mountPath + SLASH + filename;
             }
 
-            output.put(entry.getKey(), value);
+            output.put(entry.getKey(), propertyValue);
         }
 
-        for (Entry<String, Volume> volume : volumes.entrySet()) {
-            deployment.getSpec().getTemplate().getSpec().getVolumes().add(volume.getValue());
+        for (Entry<String, CustomVolume> volume : volumes.entrySet()) {
+            deployment.getSpec().getTemplate().getSpec().getVolumes().add(volume.getValue().getVolume());
 
             // Configure all the containers to map the volume
             deployment.getSpec().getTemplate().getSpec().getContainers()
                     .forEach(container -> container.getVolumeMounts()
-                            .add(new VolumeMountBuilder().withName(volume.getValue().getName())
-                                    .withReadOnly(true).withMountPath(volume.getKey()).build()));
+                            .add(createVolumeMount(volume)));
         }
 
         return output;
+    }
+
+    private VolumeMount createVolumeMount(Entry<String, CustomVolume> volume) {
+        VolumeMountBuilder volumeMountBuilder = new VolumeMountBuilder().withName(volume.getValue().getName())
+                .withReadOnly(true).withMountPath(volume.getKey());
+
+        if (!volume.getValue().getSubFolderRegExp().isEmpty()) {
+            volumeMountBuilder.withSubPathExpr(volume.getValue().getSubFolderRegExp());
+        }
+
+        return volumeMountBuilder.build();
+    }
+
+    private boolean isResourceWithDestinationPath(String key) {
+        return key.startsWith(RESOURCE_WITH_DESTINATION_PREFIX);
     }
 
     private void createOrUpdateConfigMap(String configMapName, String key, String value) {
@@ -498,7 +522,7 @@ public final class KubectlClient {
         return path;
     }
 
-    private String normalizeName(String name) {
+    private String normalizeConfigMapName(String name) {
         return StringUtils.removeStart(name, SLASH)
                 .replaceAll(Pattern.quote("."), "-")
                 .replaceAll(SLASH, "-");

--- a/quarkus-test-kubernetes/src/main/java/io/quarkus/test/model/CustomVolume.java
+++ b/quarkus-test-kubernetes/src/main/java/io/quarkus/test/model/CustomVolume.java
@@ -1,0 +1,68 @@
+package io.quarkus.test.model;
+
+import io.fabric8.kubernetes.api.model.ConfigMapVolumeSource;
+import io.fabric8.kubernetes.api.model.ConfigMapVolumeSourceBuilder;
+import io.fabric8.kubernetes.api.model.SecretVolumeSource;
+import io.fabric8.kubernetes.api.model.SecretVolumeSourceBuilder;
+import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.VolumeBuilder;
+
+/**
+ * CustomVolume represents a K8s volume plus some additions related to how is mounted.
+ */
+public class CustomVolume {
+    public enum VolumeType {
+        CONFIG_MAP,
+        SECRET
+    }
+
+    private final Volume volume;
+    private final String name;
+    private final String subFolderRegExp;
+    private ConfigMapVolumeSource configMap;
+    private SecretVolumeSource secret;
+
+    public CustomVolume(String name, String subFolderRegExp, VolumeType volumeType) {
+        this.subFolderRegExp = subFolderRegExp;
+        this.name = name;
+        VolumeBuilder vBuilder = new VolumeBuilder().withName(name);
+
+        if (volumeType.equals(VolumeType.CONFIG_MAP)) {
+            this.configMap = new ConfigMapVolumeSourceBuilder().withName(name).build();
+            vBuilder = vBuilder.withConfigMap(configMap);
+        } else {
+            this.secret = new SecretVolumeSourceBuilder().withSecretName(name).build();
+            vBuilder = vBuilder.withSecret(secret);
+        }
+
+        volume = vBuilder.build();
+    }
+
+    public Volume getVolume() {
+        return volume;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public ConfigMapVolumeSource getConfigMap() {
+        return configMap;
+    }
+
+    public void setConfigMap(ConfigMapVolumeSource configMap) {
+        this.configMap = configMap;
+    }
+
+    public SecretVolumeSource getSecret() {
+        return secret;
+    }
+
+    public void setSecret(SecretVolumeSource secret) {
+        this.secret = secret;
+    }
+
+    public String getSubFolderRegExp() {
+        return subFolderRegExp;
+    }
+}

--- a/quarkus-test-kubernetes/src/main/java/io/quarkus/test/services/containers/KubernetesContainerManagedResource.java
+++ b/quarkus-test-kubernetes/src/main/java/io/quarkus/test/services/containers/KubernetesContainerManagedResource.java
@@ -109,7 +109,8 @@ public class KubernetesContainerManagedResource implements ManagedResource {
 
         return content.replaceAll(quote("${IMAGE}"), model.getImage())
                 .replaceAll(quote("${SERVICE_NAME}"), model.getContext().getName())
-                .replaceAll(quote("${INTERNAL_PORT}"), "" + model.getPort());
+                .replaceAll(quote("${INTERNAL_PORT}"), "" + model.getPort())
+                .replaceAll(quote("${ARGS}"), String.join(" ", model.getCommand()));
     }
 
     private boolean useInternalServiceAsUrl() {

--- a/quarkus-test-kubernetes/src/main/resources/kubernetes-deployment-template.yml
+++ b/quarkus-test-kubernetes/src/main/resources/kubernetes-deployment-template.yml
@@ -18,6 +18,7 @@ items:
       spec:
         containers:
         - image: "${IMAGE}"
+          args: [${ARGS}]
           name: "${SERVICE_NAME}"
           ports:
           - containerPort: ${INTERNAL_PORT}

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/model/CustomVolume.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/model/CustomVolume.java
@@ -1,0 +1,68 @@
+package io.quarkus.test.model;
+
+import io.fabric8.kubernetes.api.model.ConfigMapVolumeSource;
+import io.fabric8.kubernetes.api.model.ConfigMapVolumeSourceBuilder;
+import io.fabric8.kubernetes.api.model.SecretVolumeSource;
+import io.fabric8.kubernetes.api.model.SecretVolumeSourceBuilder;
+import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.VolumeBuilder;
+
+/**
+ * CustomVolume represents a K8s volume plus some additions related to how is mounted.
+ */
+public class CustomVolume {
+    public enum VolumeType {
+        CONFIG_MAP,
+        SECRET
+    }
+
+    private final Volume volume;
+    private final String name;
+    private final String subFolderRegExp;
+    private ConfigMapVolumeSource configMap;
+    private SecretVolumeSource secret;
+
+    public CustomVolume(String name, String subFolderRegExp, VolumeType volumeType) {
+        this.subFolderRegExp = subFolderRegExp;
+        this.name = name;
+        VolumeBuilder vBuilder = new VolumeBuilder().withName(name);
+
+        if (volumeType.equals(VolumeType.CONFIG_MAP)) {
+            this.configMap = new ConfigMapVolumeSourceBuilder().withName(name).build();
+            vBuilder = vBuilder.withConfigMap(configMap);
+        } else {
+            this.secret = new SecretVolumeSourceBuilder().withSecretName(name).build();
+            vBuilder = vBuilder.withSecret(secret);
+        }
+
+        volume = vBuilder.build();
+    }
+
+    public Volume getVolume() {
+        return volume;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public ConfigMapVolumeSource getConfigMap() {
+        return configMap;
+    }
+
+    public void setConfigMap(ConfigMapVolumeSource configMap) {
+        this.configMap = configMap;
+    }
+
+    public SecretVolumeSource getSecret() {
+        return secret;
+    }
+
+    public void setSecret(SecretVolumeSource secret) {
+        this.secret = secret;
+    }
+
+    public String getSubFolderRegExp() {
+        return subFolderRegExp;
+    }
+}

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/containers/OpenShiftContainerManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/containers/OpenShiftContainerManagedResource.java
@@ -130,7 +130,8 @@ public class OpenShiftContainerManagedResource implements ManagedResource {
 
         return content.replaceAll(quote("${IMAGE}"), model.getImage())
                 .replaceAll(quote("${SERVICE_NAME}"), model.getContext().getName())
-                .replaceAll(quote("${INTERNAL_PORT}"), "" + model.getPort());
+                .replaceAll(quote("${INTERNAL_PORT}"), "" + model.getPort())
+                .replaceAll(quote("${ARGS}"), String.join(" ", model.getCommand()));
     }
 
     private void applyDeployment() {

--- a/quarkus-test-openshift/src/main/resources/openshift-deployment-template.yml
+++ b/quarkus-test-openshift/src/main/resources/openshift-deployment-template.yml
@@ -29,6 +29,7 @@ items:
       spec:
         containers:
         - image: "${IMAGE}"
+          args: [${ARGS}]
           imagePullPolicy: "IfNotPresent"
           name: "${SERVICE_NAME}"
           ports:

--- a/quarkus-test-service-keycloak/pom.xml
+++ b/quarkus-test-service-keycloak/pom.xml
@@ -17,5 +17,15 @@
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-authz-client</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus.qe</groupId>
+            <artifactId>quarkus-test-containers</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus.qe</groupId>
+            <artifactId>quarkus-test-openshift</artifactId>
+            <optional>true</optional>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/quarkus-test-service-keycloak/src/main/java/io/quarkus/test/services/KeycloakContainer.java
+++ b/quarkus-test-service-keycloak/src/main/java/io/quarkus/test/services/KeycloakContainer.java
@@ -1,0 +1,26 @@
+package io.quarkus.test.services;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import io.quarkus.test.bootstrap.ManagedResourceBuilder;
+import io.quarkus.test.services.containers.KeycloakContainerManagedResourceBuilder;
+
+/**
+ * KeycloakContainer annotation is supported since Keycloak 18.
+ */
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface KeycloakContainer {
+    String image() default "quay.io/keycloak/keycloak:18.0.0";
+
+    int port() default 8080;
+
+    String expectedLog() default "started";
+
+    String[] command() default {};
+
+    Class<? extends ManagedResourceBuilder> builder() default KeycloakContainerManagedResourceBuilder.class;
+}

--- a/quarkus-test-service-keycloak/src/main/java/io/quarkus/test/services/containers/KeycloakContainerAnnotationBinding.java
+++ b/quarkus-test-service-keycloak/src/main/java/io/quarkus/test/services/containers/KeycloakContainerAnnotationBinding.java
@@ -1,0 +1,23 @@
+package io.quarkus.test.services.containers;
+
+import java.lang.reflect.Field;
+
+import io.quarkus.test.bootstrap.AnnotationBinding;
+import io.quarkus.test.bootstrap.ManagedResourceBuilder;
+import io.quarkus.test.services.KeycloakContainer;
+
+public class KeycloakContainerAnnotationBinding implements AnnotationBinding {
+    @Override
+    public boolean isFor(Field field) {
+        return field.isAnnotationPresent(KeycloakContainer.class);
+    }
+
+    @Override
+    public ManagedResourceBuilder createBuilder(Field field) throws Exception {
+        KeycloakContainer metadata = field.getAnnotation(KeycloakContainer.class);
+
+        ManagedResourceBuilder builder = metadata.builder().getDeclaredConstructor().newInstance();
+        builder.init(metadata);
+        return builder;
+    }
+}

--- a/quarkus-test-service-keycloak/src/main/java/io/quarkus/test/services/containers/KeycloakContainerManagedResourceBinding.java
+++ b/quarkus-test-service-keycloak/src/main/java/io/quarkus/test/services/containers/KeycloakContainerManagedResourceBinding.java
@@ -1,0 +1,9 @@
+package io.quarkus.test.services.containers;
+
+import io.quarkus.test.bootstrap.ManagedResource;
+
+public interface KeycloakContainerManagedResourceBinding {
+    boolean appliesFor(KeycloakContainerManagedResourceBuilder builder);
+
+    ManagedResource init(KeycloakContainerManagedResourceBuilder builder);
+}

--- a/quarkus-test-service-keycloak/src/main/java/io/quarkus/test/services/containers/KeycloakContainerManagedResourceBuilder.java
+++ b/quarkus-test-service-keycloak/src/main/java/io/quarkus/test/services/containers/KeycloakContainerManagedResourceBuilder.java
@@ -1,0 +1,66 @@
+package io.quarkus.test.services.containers;
+
+import java.lang.annotation.Annotation;
+import java.util.ServiceLoader;
+
+import io.quarkus.test.bootstrap.ManagedResource;
+import io.quarkus.test.bootstrap.ServiceContext;
+import io.quarkus.test.services.KeycloakContainer;
+
+public class KeycloakContainerManagedResourceBuilder extends ContainerManagedResourceBuilder {
+
+    private final ServiceLoader<KeycloakContainerManagedResourceBinding> managedResourceBindingsRegistry = ServiceLoader
+            .load(KeycloakContainerManagedResourceBinding.class);
+
+    private ServiceContext context;
+    private String image;
+    private int restPort;
+    private String[] command;
+    private String expectedLog;
+
+    @Override
+    protected String getImage() {
+        return image;
+    }
+
+    @Override
+    protected Integer getPort() {
+        return restPort;
+    }
+
+    @Override
+    protected String[] getCommand() {
+        return command;
+    }
+
+    @Override
+    protected ServiceContext getContext() {
+        return context;
+    }
+
+    @Override
+    protected String getExpectedLog() {
+        return expectedLog;
+    }
+
+    @Override
+    public void init(Annotation annotation) {
+        KeycloakContainer metadata = (KeycloakContainer) annotation;
+        this.image = metadata.image();
+        this.restPort = metadata.port();
+        this.expectedLog = metadata.expectedLog();
+        this.command = metadata.command();
+    }
+
+    @Override
+    public ManagedResource build(ServiceContext context) {
+        this.context = context;
+        for (KeycloakContainerManagedResourceBinding binding : managedResourceBindingsRegistry) {
+            if (binding.appliesFor(this)) {
+                return binding.init(this);
+            }
+        }
+
+        return new KeycloakGenericDockerContainerManagedResource(this);
+    }
+}

--- a/quarkus-test-service-keycloak/src/main/java/io/quarkus/test/services/containers/KeycloakGenericDockerContainerManagedResource.java
+++ b/quarkus-test-service-keycloak/src/main/java/io/quarkus/test/services/containers/KeycloakGenericDockerContainerManagedResource.java
@@ -1,0 +1,69 @@
+package io.quarkus.test.services.containers;
+
+import org.apache.commons.lang3.StringUtils;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
+
+import io.quarkus.test.logging.Log;
+import io.quarkus.test.utils.DockerUtils;
+
+public class KeycloakGenericDockerContainerManagedResource extends GenericDockerContainerManagedResource {
+
+    private static final String PRIVILEGED_MODE = "container.privileged-mode";
+    private static final String REUSABLE_MODE = "container.reusable";
+
+    private final KeycloakContainerManagedResourceBuilder model;
+
+    protected KeycloakGenericDockerContainerManagedResource(KeycloakContainerManagedResourceBuilder model) {
+        super(model);
+
+        this.model = model;
+    }
+
+    @Override
+    protected GenericContainer<?> initContainer() {
+        GenericContainer<?> container = new GenericContainer<>(model.getImage());
+
+        if (StringUtils.isNotBlank(model.getExpectedLog())) {
+            container.waitingFor(new LogMessageWaitStrategy().withRegEx(".*" + model.getExpectedLog() + ".*\\s"));
+        }
+
+        if (model.getCommand() != null && model.getCommand().length > 0) {
+            container.withCommand(model.getCommand());
+        }
+
+        if (isPrivileged()) {
+            Log.info(model.getContext().getOwner(), "Running container on Privileged mode");
+            container.setPrivilegedMode(true);
+        }
+
+        container.withCreateContainerCmdModifier(cmd -> cmd.withName(DockerUtils.generateDockerContainerName()));
+
+        if (isReusable()) {
+            Log.info(model.getContext().getOwner(), "Running container on Reusable mode");
+            Log.warn(model.getContext().getOwner(), "Reusable mode expose testcontainers 'withReuse' method that is"
+                    + " tagged as UnstableAPI, so is a subject to change and SHOULD NOT be considered a stable API");
+
+            container.withReuse(true);
+        }
+
+        container.withExposedPorts(model.getPort());
+
+        return container;
+    }
+
+    @Override
+    public void stop() {
+        if (!isReusable()) {
+            super.stop();
+        }
+    }
+
+    protected boolean isReusable() {
+        return model.getContext().getOwner().getConfiguration().isTrue(REUSABLE_MODE);
+    }
+
+    private boolean isPrivileged() {
+        return model.getContext().getOwner().getConfiguration().isTrue(PRIVILEGED_MODE);
+    }
+}

--- a/quarkus-test-service-keycloak/src/main/java/io/quarkus/test/services/containers/OpenShiftKeycloakContainerManagedResource.java
+++ b/quarkus-test-service-keycloak/src/main/java/io/quarkus/test/services/containers/OpenShiftKeycloakContainerManagedResource.java
@@ -1,0 +1,11 @@
+package io.quarkus.test.services.containers;
+
+public class OpenShiftKeycloakContainerManagedResource extends OpenShiftContainerManagedResource {
+
+    private final KeycloakContainerManagedResourceBuilder model;
+
+    protected OpenShiftKeycloakContainerManagedResource(KeycloakContainerManagedResourceBuilder model) {
+        super(model);
+        this.model = model;
+    }
+}

--- a/quarkus-test-service-keycloak/src/main/java/io/quarkus/test/services/containers/OpenShiftKeycloakContainerManagedResourceBinding.java
+++ b/quarkus-test-service-keycloak/src/main/java/io/quarkus/test/services/containers/OpenShiftKeycloakContainerManagedResourceBinding.java
@@ -1,0 +1,16 @@
+package io.quarkus.test.services.containers;
+
+import io.quarkus.test.bootstrap.ManagedResource;
+import io.quarkus.test.scenarios.OpenShiftScenario;
+
+public class OpenShiftKeycloakContainerManagedResourceBinding implements KeycloakContainerManagedResourceBinding {
+    @Override
+    public boolean appliesFor(KeycloakContainerManagedResourceBuilder builder) {
+        return builder.getContext().getTestContext().getRequiredTestClass().isAnnotationPresent(OpenShiftScenario.class);
+    }
+
+    @Override
+    public ManagedResource init(KeycloakContainerManagedResourceBuilder builder) {
+        return new OpenShiftKeycloakContainerManagedResource(builder);
+    }
+}

--- a/quarkus-test-service-keycloak/src/main/resources/META-INF/services/io.quarkus.test.bootstrap.AnnotationBinding
+++ b/quarkus-test-service-keycloak/src/main/resources/META-INF/services/io.quarkus.test.bootstrap.AnnotationBinding
@@ -1,0 +1,1 @@
+io.quarkus.test.services.containers.KeycloakContainerAnnotationBinding

--- a/quarkus-test-service-keycloak/src/main/resources/META-INF/services/io.quarkus.test.services.containers.KeycloakContainerManagedResourceBinding
+++ b/quarkus-test-service-keycloak/src/main/resources/META-INF/services/io.quarkus.test.services.containers.KeycloakContainerManagedResourceBinding
@@ -1,0 +1,1 @@
+io.quarkus.test.services.containers.OpenShiftKeycloakContainerManagedResourceBinding


### PR DESCRIPTION
### Summary

Motivation: https://github.com/quarkusio/quarkus/wiki/Migration-Guide-2.10

 [Keycloak 18.0.0](https://www.keycloak.org/server/importExport) changes (that impact Quarkus test framework): 

- Environment variable `KEYCLOAK_IMPORT` is not supported anymore
- A [new way](https://www.keycloak.org/server/importExport#_importing_a_realm_during_startup) to import a realm at start time was created
- Environment variables `KEYCLOAK_USER` and `KEYCLOAK_PASSWORD` was replaced by `KEYCLOAK_ADMIN` and `KEYCLOAK_ADMIN_PASSWORD`

This PR is trying to integrate all of these required changes into QuarkusTestFramework. 

### PR Design decision 

1. New container annotation was created in order to handle Keycloak scenarios: Currently keycloak component doesn't have its own annotation instead we are using a generic approach, through `@Container` where the developers could set any keycloak version image. The proposal is to use a new annotation called  `KeycloakContainer` where the default values are already set

KeycloakContainer default values:
     - image: `quay.io/keycloak/keycloak:18.0.0`
     - port: `8080`
     - expected started log: `started`
     - `io.quarkus.test.bootstrap.KeycloakService` has new constructors: 

Keycloak 18.0 requires that the imported realms are located into one specific folder: `/opt/keycloak/data/import`
The new KeycloakService has two constructors: 

`public KeycloakService(String realmFile, String realm)` // by default realmDestPath is set to `/opt/keycloak/data/import`
`public KeycloakService(String realm)` // could be useful if you want to setup a keycloak without realm

2. A new way to attach resources to a container has been created: 

Nowadays if you want to attach some file to your container you should add a property with the following value:

```
myContainer.withProperty("KEYCLOAK_IMPORT", "resource::/tmp/myRealm.json")
```

The value "prefix", `resource::` will trigger a  background command in order to create a configMap or to push the above file into the container. However, this "prefix" assume that the file destination path was the same as the original location. Unfortunately on Keycloak this is not valid, the `realm.json` must be under the folder `/opt/keycloak/data/import` in order to be imported at the start time. To accomplish this task, we have developed a new "prefix" action:

`resource_with_destination::<DEST_PATH> | <ORIGIN_PATH>`

For example: `withProperty("KEYCLOAK_IMPORT", "resource_with_destination::/opt/keycloak/data/import | /keycloak-realm.json")`

3. Add container "arguments"(`${ARGS}`) to default `openshift-deployment-template.yml` (required in order to launch keycloak 18.0.0)
4. Add sub-paths to openshiftClient Volumes (required in order to read a configMap from keycloak import command)

### How to use it

Keycloak 18
```
 @KeycloakContainer(command = { "start-dev --import-realm --hostname-strict=false" })
    static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", "test-realm", "/realms");
```

Note: Previous versions of keycloak as Keycloak 16 or 14 could still use the old way
```
@Container(image = "${keycloak.image}", expectedLog = "Admin console listening", port = KEYCLOAK_PORT)
    static KeycloakService keycloak = new KeycloakService("/keycloak-realm.json", "test-realm");
```

Please check the relevant options

- [X] New feature (non-breaking change which adds functionality)
- [X] Refactoring
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [X] This change requires a documentation update

### Checklist:
- [X] Example scenarios has been updated / added
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)