### PR TITLE
Update Quarkus version to 2.10.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <htmlunit.version>2.62.0</htmlunit.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.9.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.10.2.Final</quarkus.platform.version>
         <exclude.tests.with.tags>quarkus-cli</exclude.tests.with.tags>
         <include.tests>**/*IT.java</include.tests>
         <exclude.openshift.tests>**/OpenShift*IT.java</exclude.openshift.tests>

--- a/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/model/KafkaRegistry.java
+++ b/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/model/KafkaRegistry.java
@@ -2,7 +2,7 @@ package io.quarkus.test.services.containers.model;
 
 public enum KafkaRegistry {
     CONFLUENT("confluentinc/cp-schema-registry", "6.1.1", "/", 8081),
-    APICURIO("quay.io/apicurio/apicurio-registry-mem", "2.1.5.Final", "/apis", 8080);
+    APICURIO("quay.io/apicurio/apicurio-registry-mem", "2.2.3.Final", "/apis", 8080);
 
     private final String image;
     private final String defaultVersion;


### PR DESCRIPTION
### Summary

QuarkusVersion: `2.9.2.Final` -> `2.10.2.Final`
Upgrade apicurio to `2.2.3.Final` (required by Quarkus 2.10.2.Final)

Please check the relevant options
- [X] Dependency update

### Checklist:
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)