### PR TITLE
Update mandrel image to 22.1

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -293,7 +293,7 @@ jobs:
       matrix:
         java: [ 11 ]
         quarkus-version: ["999-SNAPSHOT"]
-        graalvm-version: [ "21.3.0.java11"]
+        graalvm-version: [ "22.1.0.java11"]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/cache@v1

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftS2iGitRepositoryQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftS2iGitRepositoryQuarkusApplicationManagedResource.java
@@ -24,7 +24,7 @@ public class OpenShiftS2iGitRepositoryQuarkusApplicationManagedResource
     private static final String INTERNAL_MAVEN_REPOSITORY_PROPERTY = "${internal.s2i.maven.remote.repository}";
     private static final PropertyLookup MAVEN_REMOTE_REPOSITORY = new PropertyLookup("s2i.maven.remote.repository");
     private static final PropertyLookup QUARKUS_NATIVE_S2I_FROM_SRC = new PropertyLookup("s2i.openshift.base-native-image",
-            "quay.io/quarkus/ubi-quarkus-native-s2i:21.2-java11");
+            "quay.io/quarkus/ubi-quarkus-native-s2i:22.1-java11");
 
     private final GitRepositoryQuarkusApplicationManagedResourceBuilder model;
 


### PR DESCRIPTION
### Summary

Quarkus mandrel image ref: https://github.com/quarkusio/quarkus/blob/2.10/bom/application/pom.xml#L83

Please check the relevant options
- [X] Dependency update


### Checklist:
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)