### PR TITLE
Upgrade ocp exec command to the latest version

### DIFF
--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
@@ -487,7 +487,11 @@ public final class OpenShiftClient {
         List<String> output = new ArrayList<>();
         List<String> args = new ArrayList<>();
         args.addAll(Arrays.asList(OC, "exec", podName, "-c", containerId, "-n", namespace));
-        args.addAll(Arrays.asList(input));
+        List<String> command = Arrays.asList(input);
+        if (!command.isEmpty()) {
+            args.add("--");
+            args.addAll(command);
+        }
         new Command(args).outputToLines(output).runAndWait();
 
         return output.stream().collect(Collectors.joining(System.lineSeparator()));


### PR DESCRIPTION
### Summary

Current ocp exec command is throwing the following warning

`kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.`

This commit updates this command by the suggested way

Please check the relevant options
- [X] Refactoring


### Checklist:
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)