### PR TITLE
Bugfix on ocp / k8s volume setup

### DIFF
--- a/quarkus-test-kubernetes/src/main/java/io/quarkus/test/bootstrap/inject/KubectlClient.java
+++ b/quarkus-test-kubernetes/src/main/java/io/quarkus/test/bootstrap/inject/KubectlClient.java
@@ -416,7 +416,7 @@ public final class KubectlClient {
 
                 // Push secret file
                 doCreateSecretFromFile(secretName, getFilePath(path));
-                volumes.put(mountPath, volumes.put(mountPath, new CustomVolume(secretName, "", SECRET)));
+                volumes.put(mountPath, new CustomVolume(secretName, "", SECRET));
                 propertyValue = mountPath + SLASH + filename;
             }
 

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
@@ -685,7 +685,7 @@ public final class OpenShiftClient {
 
                 // Push secret file
                 doCreateSecretFromFile(secretName, getFilePath(path));
-                volumes.put(mountPath, volumes.put(mountPath, new CustomVolume(secretName, "", SECRET)));
+                volumes.put(mountPath, new CustomVolume(secretName, "", SECRET));
 
                 propertyValue = mountPath + SLASH + filename;
             }


### PR DESCRIPTION
### Summary

Fix an issue on secret volumes. A null pointer exception is thrown on `Quarkus test suite / security/oidc-client-mutual-tls`

Please check the relevant options

- [X] Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)