### PR TITLE
Release 1.2.0.Beta3

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 name: Quarkus QE Test Framework
 release:
-  current-version: 1.2.0.Beta2
-  next-version: 1.2.0-Beta3
+  current-version: 1.2.0.Beta3
+  next-version: 1.2.0.Beta4


### PR DESCRIPTION
### Summary

https://github.com/quarkus-qe/quarkus-test-framework/pull/523: Bugfix on ocp / k8s volume setup (@pjgg)
https://github.com/quarkus-qe/quarkus-test-framework/pull/520: Update mandrel image to 22.1 (@pjgg)
https://github.com/quarkus-qe/quarkus-test-framework/pull/522: Upgrade ocp exec command to the latest version (@pjgg)
https://github.com/quarkus-qe/quarkus-test-framework/pull/521: Bump formatter-maven-plugin from 2.19.0 to 2.20.0 (https://github.com/dependabot)

