### PR TITLE
Fix `blocking-reactive` assertion and disable it on Windows in native

### DIFF
--- a/examples/blocking-reactive-model/pom.xml
+++ b/examples/blocking-reactive-model/pom.xml
@@ -60,5 +60,33 @@
                 </dependency>
             </dependencies>
         </profile>
+        <!-- Skipped on Windows in a native mode due to https://github.com/quarkusio/quarkus/issues/27061 -->
+        <profile>
+            <id>skip-tests-on-windows</id>
+            <activation>
+                <os>
+                    <family>windows</family>
+                </os>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>

--- a/examples/blocking-reactive-model/src/test/java/io/quarkus/qe/GreetingResourceIT.java
+++ b/examples/blocking-reactive-model/src/test/java/io/quarkus/qe/GreetingResourceIT.java
@@ -1,6 +1,8 @@
 package io.quarkus.qe;
 
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
@@ -27,10 +29,12 @@ public class GreetingResourceIT {
     public void shouldPickTheForcedDependencies() {
         // classic
         blocking.given().get(HELLO_PATH).then().body(is(HELLO));
-        blocking.logs().forQuarkus().installedFeatures().contains(RESTEASY_CLASSIC);
+        assertTrue(blocking.logs().forQuarkus().installedFeatures().contains(RESTEASY_CLASSIC));
+        // necessary 'resteasy' is also prefix of the 'resteasy-reactive'
+        assertFalse(blocking.logs().forQuarkus().installedFeatures().contains(RESTEASY_REACTIVE));
 
         // reactive
         reactive.given().get(HELLO_PATH).then().body(is(HELLO));
-        blocking.logs().forQuarkus().installedFeatures().contains(RESTEASY_REACTIVE);
+        assertTrue(reactive.logs().forQuarkus().installedFeatures().contains(RESTEASY_REACTIVE));
     }
 }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/utils/QuarkusLogsVerifier.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/utils/QuarkusLogsVerifier.java
@@ -25,6 +25,7 @@ public class QuarkusLogsVerifier {
         return service.getLogs().stream()
                 .filter(log -> log.contains(INSTALLED_FEATURES))
                 .flatMap(log -> Stream.of(StringUtils.substringBetween(log, OPEN_TAG, CLOSE_TAG).split(COMMA)))
+                .map(String::trim)
                 .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
### Summary

Our daily CI runs fails sometimes on Windows in native mode over `blocking-reactive` test, all explained here https://github.com/quarkusio/quarkus/issues/27061. I tracked the issue down to the switch from uber jar to the thin jar. I'd suggest to disable the test till the problem is solved.

This PR also fixes the condition assertion of the test as previously result of the `contains` was ignored and assertion was missing.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)