### PR TITLE
Trace test results via OTLP HTTP protocol instead of gRPC

### DIFF
--- a/extensions/tracing/src/test/java/io/quarkus/qe/resources/JaegerContainer.java
+++ b/extensions/tracing/src/test/java/io/quarkus/qe/resources/JaegerContainer.java
@@ -7,11 +7,11 @@ import org.testcontainers.containers.wait.strategy.Wait;
 
 public class JaegerContainer extends GenericContainer<JaegerContainer> {
     public static final int REST_PORT = 16686;
-    private static final int TRACE_PORT = 4317;
+    private static final int TRACE_PORT = 4318;
     private static final int STARTUP_TIMEOUT_SECONDS = 30;
 
     public JaegerContainer() {
-        super("quay.io/jaegertracing/all-in-one:1.36");
+        super("quay.io/jaegertracing/all-in-one:1.37");
         addEnv("COLLECTOR_OTLP_ENABLED", "true");
         waitingFor(Wait.forLogMessage(".*server started.*", 1));
         withStartupTimeout(Duration.ofSeconds(STARTUP_TIMEOUT_SECONDS));

--- a/extensions/tracing/src/test/resources/test.properties
+++ b/extensions/tracing/src/test/resources/test.properties
@@ -1,1 +1,1 @@
-ts.global.tracing.jaeger.endpoint=http://localhost:4317
+ts.global.tracing.jaeger.endpoint=http://localhost:4318/v1/traces

--- a/misc/Tracing.md
+++ b/misc/Tracing.md
@@ -10,8 +10,8 @@ All errors are going to be tagged as `error` and the error message is going to b
 
 In order to push your tracing events to your Jaeger you must provide the following system properties:
 - ts.global.tracing.jaeger.endpoint:
-        Default Value: `http://localhost:4317` 
-        Example, `https://myjaeger.apps.ocp47.dynamic.quarkus:4317`
+        Default Value: `http://localhost:4318/v1/traces`
+        Example, `https://myjaeger.apps.ocp47.dynamic.quarkus:4318/v1/traces`
         
 All the metrics will be tagging [the test execution properties](Execution.md).
 
@@ -20,10 +20,10 @@ All the metrics will be tagging [the test execution properties](Execution.md).
 - On bare metal:
 
 ```
-docker run --name jaeger -e COLLECTOR_OTLP_ENABLED=true -p 16686:16686 -p 4317:4317 quay.io/jaegertracing/all-in-one:1.36
+docker run --name jaeger -e COLLECTOR_OTLP_ENABLED=true -p 16686:16686 -p 4318:4318 quay.io/jaegertracing/all-in-one:1.37
 ```
 
-The JAEGER API URL will be available at `http://localhost:4317`.
+The JAEGER API URL will be available at `http://localhost:4318/v1/traces`.
 The JAEGER UI URL is `http://localhost:16686`.
 
 - On OpenShift:

--- a/misc/jaeger-for-tracing.yaml
+++ b/misc/jaeger-for-tracing.yaml
@@ -75,7 +75,7 @@ items:
             app: 'jaeger'
         spec:
           containers:
-            - image: 'quay.io/jaegertracing/all-in-one:1.36'
+            - image: 'quay.io/jaegertracing/all-in-one:1.37'
               name: 'jaeger'
               env:
                 - name: COLLECTOR_OTLP_ENABLED
@@ -93,7 +93,7 @@ items:
                   protocol: UDP
                 - containerPort: 5778
                   protocol: TCP
-                - containerPort: 4317
+                - containerPort: 4318
                   protocol: TCP
                 - containerPort: 16686
                   protocol: TCP
@@ -110,9 +110,9 @@ items:
     spec:
       ports:
         - name: jaeger-api
-          port: 4317
+          port: 4318
           protocol: TCP
-          targetPort: 4317
+          targetPort: 4318
       selector:
         app: 'jaeger'
   - apiVersion: v1

--- a/quarkus-test-core/src/main/java/io/quarkus/test/tracing/QuarkusScenarioTracer.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/tracing/QuarkusScenarioTracer.java
@@ -4,7 +4,7 @@ import static io.quarkus.test.tracing.QuarkusScenarioAttributes.SUCCESS;
 
 import java.util.Map;
 
-import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
+import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
@@ -25,8 +25,7 @@ public class QuarkusScenarioTracer {
                 .builder()
                 .setResource(Resource.getDefault().toBuilder().put(SERVICE_NAME, serviceName).build())
                 .addSpanProcessor(BatchSpanProcessor
-                        .builder(OtlpGrpcSpanExporter.builder().setEndpoint(jaegerHttpEndpoint).build())
-                        .build())
+                        .builder(OtlpHttpSpanExporter.builder().setEndpoint(jaegerHttpEndpoint).build()).build())
                 .setSampler(Sampler.alwaysOn())
                 .build();
         quarkusScenarioSpan = new QuarkusScenarioSpan(tracerProvider.get(serviceName), new QuarkusScenarioAttributes());


### PR DESCRIPTION
### Summary

I didn't manage to make OTLP gRPC work with OCP 4.9. OT gRPC exporter supports limited customization and I can't work around hostname verification. OTLP HTTP is fully supported and we can avoid self-signed certificates. Changes need to be done on Jenkins (path `/api/traces` to `/v1/traces`) jobs and TFW must be released and the release backported to the TS 2.7.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)