### PR TITLE
Bump Quarkus to 2.11.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <htmlunit.version>2.63.0</htmlunit.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.10.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.11.1.Final</quarkus.platform.version>
         <exclude.tests.with.tags>quarkus-cli</exclude.tests.with.tags>
         <include.tests>**/*IT.java</include.tests>
         <exclude.openshift.tests>**/OpenShift*IT.java</exclude.openshift.tests>


### PR DESCRIPTION
### Summary

Bumps Quarkus version to 2.11.1.Final. This will help with OpenTelemetry dependency issue as `opentelemetry-exporter-otlp-http-trace` [has been moved](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.15.0) and we need to use same dependency with both released Quarkus and 999-SNAPSHOT.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)