### PR TITLE
Activate Maven profile `skip-tests-on-windows-in-native` in daily runs

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -334,7 +334,7 @@ jobs:
       - name: Build in Native mode
         shell: bash
         run: |
-          mvn -B -fae -s .github/mvn-settings.xml clean install -Pframework,examples,native -Dquarkus.native.container-build=false -Dquarkus.platform.version="${{ matrix.quarkus-version }}"
+          mvn -B -fae -s .github/mvn-settings.xml clean install -Pframework,examples,native,skip-tests-on-windows-in-native -Dquarkus.native.container-build=false -Dquarkus.platform.version="${{ matrix.quarkus-version }}"
       - name: Zip Artifacts
         shell: bash
         if: failure()

--- a/examples/blocking-reactive-model/pom.xml
+++ b/examples/blocking-reactive-model/pom.xml
@@ -62,7 +62,7 @@
         </profile>
         <!-- Skipped on Windows in a native mode due to https://github.com/quarkusio/quarkus/issues/27061 -->
         <profile>
-            <id>skip-tests-on-windows</id>
+            <id>skip-tests-on-windows-in-native</id>
             <activation>
                 <os>
                     <family>windows</family>


### PR DESCRIPTION
### Summary

#525 was supposed to deactive `blocking-reactive` example on Windows in native, but today daily run failed again. I made (at least :-)) 2 mistakes - in daily runs profiles are activated by `-P` not by the property. And profile activation by property won't work properly from parent module, I tested it in 2 ways 
- `mvn clean verify -f examples/blocking-reactive-model/ -Dnative` from `quarkus-test-framework` dir did not deactive tests in `blocking-reactive-model`;
- I commented out all modules but `blocking-reactive-model` and run `mvn -B -fae clean install -Pframework,examples,native`

tests still run (even though I added profile with activation conditions to the parent pom and just `plugin` skip stuff to the submodue).

Now we active the profile in a same manner, as all other profiles in daily run are activated.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)