### PR TITLE
Swapp default consul docker image by a bitnami image

### DIFF
--- a/examples/consul/src/test/java/io/quarkus/qe/GreetingResourceIT.java
+++ b/examples/consul/src/test/java/io/quarkus/qe/GreetingResourceIT.java
@@ -11,6 +11,7 @@ public class GreetingResourceIT extends BaseGreetingResourceIT {
      * The framework will try to resolve the property `property.do.not.exist`
      * and as it does not exist, it will use the default image.
      */
-    @Container(image = "${property.do.not.exist:docker.io/consul:1.9.17}", expectedLog = "Synced node info", port = 8500)
+    // TODO use official image when/if this fixed https://github.com/hashicorp/docker-consul/issues/184
+    @Container(image = "${property.do.not.exist:docker.io/bitnami/consul:1.12.0}", expectedLog = "Synced node info", port = 8500)
     static ConsulService consul = new ConsulService().onPostStart(BaseGreetingResourceIT::onLoadConfigureConsul);
 }


### PR DESCRIPTION
### Summary

Openshift CI stability PR. 

Default consul docker image is not working on OCP/k8s. The issue is already reported. 

Please check the relevant options

- [X] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [X] Example scenarios has been updated / added
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)