### PR TITLE
Using a special class for passing service URIs

### DIFF
--- a/examples/database-mysql/src/test/java/io/quarkus/qe/database/mysql/AbstractMysqlReusableInstance.java
+++ b/examples/database-mysql/src/test/java/io/quarkus/qe/database/mysql/AbstractMysqlReusableInstance.java
@@ -2,7 +2,7 @@ package io.quarkus.qe.database.mysql;
 
 import java.util.Objects;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import io.quarkus.test.bootstrap.MySqlService;
 import io.quarkus.test.services.Container;
@@ -24,7 +24,7 @@ public abstract class AbstractMysqlReusableInstance extends AbstractSqlDatabaseI
             setContainerPort();
         }
 
-        Assert.assertEquals(containerPort, database.getPort());
+        Assertions.assertEquals(containerPort.intValue(), database.getURI().getPort());
     }
 
     private boolean isFirstInstance() {
@@ -32,6 +32,7 @@ public abstract class AbstractMysqlReusableInstance extends AbstractSqlDatabaseI
     }
 
     private void setContainerPort() {
-        containerPort = database.getPort();
+        containerPort = database.getURI().getPort();
+        ;
     }
 }

--- a/examples/database-mysql/src/test/java/io/quarkus/qe/database/mysql/DevModeMySqlDatabaseIT.java
+++ b/examples/database-mysql/src/test/java/io/quarkus/qe/database/mysql/DevModeMySqlDatabaseIT.java
@@ -33,7 +33,10 @@ public class DevModeMySqlDatabaseIT extends AbstractSqlDatabaseIT {
             .withProperty("quarkus.datasource.username", MYSQL_USER)
             .withProperty("quarkus.datasource.password", MYSQL_PASSWORD)
             .withProperty("quarkus.datasource.jdbc.url",
-                    () -> database.getHost().replace("http", "jdbc:mysql") + ":" + database.getPort() + "/" + MYSQL_DATABASE);
+                    () -> database.getURI()
+                            .withScheme("jdbc:mysql")
+                            .withPath("/" + MYSQL_DATABASE)
+                            .toString());
 
     @Override
     protected RestService getApp() {

--- a/examples/database-oracle/src/test/java/io/quarkus/qe/database/oracle/DevModeOracleDatabaseIT.java
+++ b/examples/database-oracle/src/test/java/io/quarkus/qe/database/oracle/DevModeOracleDatabaseIT.java
@@ -32,7 +32,7 @@ public class DevModeOracleDatabaseIT extends AbstractSqlDatabaseIT {
             .withProperty("quarkus.datasource.username", ORACLE_USER)
             .withProperty("quarkus.datasource.password", ORACLE_PASSWORD)
             .withProperty("quarkus.datasource.jdbc.url",
-                    () -> "jdbc:oracle:thin:@:" + database.getPort() + "/" + ORACLE_DATABASE);
+                    () -> "jdbc:oracle:thin:@:" + database.getURI().getPort() + "/" + ORACLE_DATABASE);
 
     @Override
     protected RestService getApp() {

--- a/examples/kafka-registry/src/test/java/io/quarkus/qe/ConfluentKafkaWithRegistryMessagingIT.java
+++ b/examples/kafka-registry/src/test/java/io/quarkus/qe/ConfluentKafkaWithRegistryMessagingIT.java
@@ -13,6 +13,7 @@ import javax.ws.rs.sse.SseEventSource;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.KafkaService;
+import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.KafkaContainer;
@@ -34,7 +35,7 @@ public class ConfluentKafkaWithRegistryMessagingIT {
     @Test
     public void producerConsumesTest() throws InterruptedException {
         Client client = ClientBuilder.newClient();
-        WebTarget target = client.target(app.getHost() + ":" + app.getPort() + "/stock/stream");
+        WebTarget target = client.target(app.getURI(Protocol.HTTP) + "/stock/stream");
 
         CountDownLatch latch = new CountDownLatch(1);
 

--- a/examples/kafka-registry/src/test/java/io/quarkus/qe/StrimziKafkaWithRegistryMessagingIT.java
+++ b/examples/kafka-registry/src/test/java/io/quarkus/qe/StrimziKafkaWithRegistryMessagingIT.java
@@ -14,6 +14,7 @@ import javax.ws.rs.sse.SseEventSource;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.KafkaService;
+import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.KafkaContainer;
@@ -35,7 +36,7 @@ public class StrimziKafkaWithRegistryMessagingIT {
     @Test
     public void producerConsumesTest() throws InterruptedException {
         Client client = ClientBuilder.newClient();
-        WebTarget target = client.target(app.getHost() + ":" + app.getPort() + "/stock/stream");
+        WebTarget target = client.target(app.getURI(Protocol.HTTP) + "/stock/stream");
 
         final CountDownLatch latch = new CountDownLatch(1);
 

--- a/examples/kafka-streams/src/test/java/io/quarkus/qe/AlertMonitorIT.java
+++ b/examples/kafka-streams/src/test/java/io/quarkus/qe/AlertMonitorIT.java
@@ -13,6 +13,7 @@ import javax.ws.rs.sse.SseEventSource;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.KafkaService;
+import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.KafkaContainer;
@@ -33,7 +34,7 @@ public class AlertMonitorIT {
     @Test
     void testAlertMonitorEventStream() throws InterruptedException {
         Client client = ClientBuilder.newClient();
-        WebTarget target = client.target(app.getHost() + ":" + app.getPort() + "/monitor/stream");
+        WebTarget target = client.target(app.getURI(Protocol.HTTP) + "/monitor/stream");
 
         final CountDownLatch latch = new CountDownLatch(1);
 

--- a/quarkus-test-cli/src/main/java/io/quarkus/test/services/quarkus/CliDevModeLocalhostQuarkusApplicationManagedResource.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/services/quarkus/CliDevModeLocalhostQuarkusApplicationManagedResource.java
@@ -15,6 +15,7 @@ import io.quarkus.test.bootstrap.ServiceContext;
 import io.quarkus.test.logging.FileServiceLoggingHandler;
 import io.quarkus.test.logging.LoggingHandler;
 import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusSnapshotCondition;
+import io.quarkus.test.services.URILike;
 import io.quarkus.test.services.quarkus.model.LaunchMode;
 import io.quarkus.test.services.quarkus.model.QuarkusProperties;
 import io.quarkus.test.utils.FileUtils;
@@ -72,13 +73,8 @@ public class CliDevModeLocalhostQuarkusApplicationManagedResource extends Quarku
     }
 
     @Override
-    public String getHost(Protocol protocol) {
-        return "http://localhost";
-    }
-
-    @Override
-    public int getPort(Protocol protocol) {
-        return assignedHttpPort;
+    public URILike getURI(Protocol protocol) {
+        return createURI(protocol.getValue(), "localhost", assignedHttpPort);
     }
 
     @Override

--- a/quarkus-test-containers/src/main/java/io/quarkus/test/services/containers/DockerContainerManagedResource.java
+++ b/quarkus-test-containers/src/main/java/io/quarkus/test/services/containers/DockerContainerManagedResource.java
@@ -25,6 +25,7 @@ import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.ServiceContext;
 import io.quarkus.test.logging.LoggingHandler;
 import io.quarkus.test.logging.TestContainersLoggingHandler;
+import io.quarkus.test.services.URILike;
 import io.quarkus.test.utils.DockerUtils;
 
 public abstract class DockerContainerManagedResource implements ManagedResource {
@@ -81,13 +82,8 @@ public abstract class DockerContainerManagedResource implements ManagedResource 
     }
 
     @Override
-    public int getPort(Protocol protocol) {
-        return getMappedPort(getTargetPort());
-    }
-
-    @Override
-    public String getHost(Protocol protocol) {
-        return protocol.getValue() + "://" + innerContainer.getHost();
+    public URILike getURI(Protocol protocol) {
+        return createURI(protocol.getValue(), innerContainer.getHost(), getMappedPort(getTargetPort()));
     }
 
     @Override
@@ -112,7 +108,6 @@ public abstract class DockerContainerManagedResource implements ManagedResource 
 
             throw ex;
         }
-
     }
 
     private Map<String, String> resolveProperties() {
@@ -169,5 +164,4 @@ public abstract class DockerContainerManagedResource implements ManagedResource 
     private boolean isSecret(String key) {
         return key.startsWith(SECRET_PREFIX);
     }
-
 }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/BaseService.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/BaseService.java
@@ -20,6 +20,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import io.quarkus.test.configuration.Configuration;
 import io.quarkus.test.logging.Log;
+import io.quarkus.test.services.URILike;
 import io.quarkus.test.utils.FileUtils;
 import io.quarkus.test.utils.LogsVerifier;
 import io.quarkus.test.utils.PropertiesUtils;
@@ -128,20 +129,32 @@ public class BaseService<T extends Service> implements Service {
         return managedResource.isRunning();
     }
 
+    public URILike getURI(Protocol protocol) {
+        return managedResource.getURI(protocol);
+    }
+
+    public URILike getURI() {
+        return managedResource.getURI(Protocol.NONE);
+    }
+
+    @Deprecated
     public String getHost() {
         return getHost(Protocol.HTTP);
     }
 
+    @Deprecated
     public String getHost(Protocol protocol) {
-        return managedResource.getHost(protocol);
+        return getURI(protocol).getRestAssuredStyleUri();
     }
 
+    @Deprecated
     public Integer getPort() {
         return getPort(Protocol.HTTP);
     }
 
+    @Deprecated
     public Integer getPort(Protocol protocol) {
-        return managedResource.getPort(protocol);
+        return getURI(protocol).getPort();
     }
 
     @Override

--- a/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/DevModeQuarkusService.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/DevModeQuarkusService.java
@@ -105,7 +105,8 @@ public class DevModeQuarkusService extends RestService {
 
     public HtmlPage webPage(String path) {
         try {
-            return webClient().getPage(getHost() + ":" + getPort() + path);
+            var uri = getURI(Protocol.HTTP).withPath(path);
+            return webClient().getPage(uri.toString());
         } catch (IOException e) {
             Assertions.fail("Page with path " + path + " does not exist");
         }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/ManagedResource.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/ManagedResource.java
@@ -2,6 +2,8 @@ package io.quarkus.test.bootstrap;
 
 import java.util.List;
 
+import io.quarkus.test.services.URILike;
+
 public interface ManagedResource {
 
     /**
@@ -24,12 +26,7 @@ public interface ManagedResource {
     /**
      * Get the Host of the running resource.
      */
-    String getHost(Protocol protocol);
-
-    /**
-     * Get the Port of the running resource.
-     */
-    int getPort(Protocol protocol);
+    URILike getURI(Protocol protocol);
 
     /**
      * @return if the resource is running.
@@ -57,6 +54,9 @@ public interface ManagedResource {
     }
 
     default void validate() {
+    }
 
+    default URILike createURI(String scheme, String host, int port) {
+        return new URILike(scheme, host, port, null);
     }
 }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/Protocol.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/Protocol.java
@@ -3,7 +3,8 @@ package io.quarkus.test.bootstrap;
 public enum Protocol {
     HTTP("http", 8080),
     HTTPS("https", 8443),
-    GRPC("grpc", 9000);
+    GRPC("grpc", 9000),
+    NONE(null, -1);
 
     private String value;
     private int port;

--- a/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/RestService.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/RestService.java
@@ -1,7 +1,5 @@
 package io.quarkus.test.bootstrap;
 
-import org.apache.commons.lang3.StringUtils;
-
 import io.restassured.RestAssured;
 import io.restassured.specification.RequestSpecification;
 import io.vertx.ext.web.client.WebClientOptions;
@@ -15,11 +13,20 @@ public class RestService extends BaseService<RestService> {
     private WebClient webClient;
 
     public RequestSpecification given() {
-        return RestAssured.given().baseUri(getHost()).basePath(BASE_PATH).port(getPort());
+        var host = getURI(Protocol.HTTP);
+        return RestAssured.given()
+                .baseUri(host.getRestAssuredStyleUri())
+                .basePath(BASE_PATH)
+                .port(host.getPort());
     }
 
     public RequestSpecification https() {
-        return RestAssured.given().baseUri(getHost(Protocol.HTTPS)).basePath("/").port(getPort(Protocol.HTTPS));
+        Protocol protocol = Protocol.HTTPS;
+        var host = getURI(protocol);
+        return RestAssured.given()
+                .baseUri(host.getRestAssuredStyleUri())
+                .basePath(BASE_PATH)
+                .port(host.getPort());
     }
 
     public WebClient mutiny() {
@@ -28,9 +35,10 @@ public class RestService extends BaseService<RestService> {
 
     public WebClient mutiny(WebClientOptions options) {
         if (webClient == null) {
+            var uri = getURI(Protocol.HTTP);
             webClient = WebClient.create(Vertx.vertx(), options
-                    .setDefaultHost(getHost().replace("http://", StringUtils.EMPTY))
-                    .setDefaultPort(getPort()));
+                    .setDefaultHost(uri.getHost())
+                    .setDefaultPort(uri.getPort()));
         }
 
         return webClient;
@@ -39,9 +47,9 @@ public class RestService extends BaseService<RestService> {
     @Override
     public void start() {
         super.start();
-
-        RestAssured.baseURI = getHost();
+        var host = getURI(Protocol.HTTP);
+        RestAssured.baseURI = host.getRestAssuredStyleUri();
         RestAssured.basePath = BASE_PATH;
-        RestAssured.port = getPort();
+        RestAssured.port = host.getPort();
     }
 }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/URILike.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/URILike.java
@@ -1,0 +1,159 @@
+package io.quarkus.test.services;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public class URILike {
+
+    private static final String SCHEME_SEPARATOR = ":";
+    private static final String HOST_PREFIX = "//";
+    /*
+     * Things like "SASL_PLAINTEXT" are not valid schemes from the URI point of view,
+     * but we need to process them anyway
+     */
+    private final String scheme;
+    private final URI wrapped;
+
+    public URILike(String scheme, String userinfo, String host, int port, String path) {
+        this.scheme = scheme;
+        this.wrapped = createURI(
+                null, //we process scheme separately
+                userinfo,
+                host,
+                port,
+                path,
+                null, // query is not used at the time of writing
+                null // fragment is not used at the time of writing
+        );
+    }
+
+    public URILike(String scheme, String host, int port, String path) {
+        this(scheme, null, host, port, path);
+    }
+
+    private URILike(String scheme, URI uri) {
+        this.scheme = scheme;
+        this.wrapped = uri;
+    }
+
+    /**
+     * Fluently creates new object, but replaces "scheme" part.
+     *
+     * @param scheme — String, will be used as a "scheme" part in the resulting string.
+     *        May not be conforming to https://datatracker.ietf.org/doc/html/rfc3986/#section-3.1
+     * @return new object with changed value of "scheme"
+     */
+    public URILike withScheme(String scheme) {
+        return new URILike(scheme, this.wrapped);
+    }
+
+    public URILike withPath(String path) {
+        URI wrapped = this.wrapped;
+        var withPath = createURI(wrapped.getScheme(),
+                wrapped.getUserInfo(),
+                wrapped.getHost(),
+                wrapped.getPort(),
+                path,
+                wrapped.getQuery(),
+                wrapped.getFragment());
+        return new URILike(this.scheme, withPath);
+    }
+
+    public URILike withPort(int port) {
+        URI wrapped = this.wrapped;
+        var withPath = createURI(wrapped.getScheme(),
+                wrapped.getUserInfo(),
+                wrapped.getHost(),
+                port,
+                wrapped.getPath(),
+                wrapped.getQuery(),
+                wrapped.getFragment());
+        return new URILike(this.scheme, withPath);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        if (scheme != null) {
+            sb.append(scheme);
+            sb.append(SCHEME_SEPARATOR);
+        }
+        sb.append(wrapped);
+        String result = sb.toString();
+        if (result.startsWith("//")) {
+            return result.substring(2);
+        } else {
+            return result;
+        }
+    }
+
+    public String getScheme() {
+        return this.scheme;
+    }
+
+    public String getHost() {
+        return wrapped.getHost();
+    }
+
+    public int getPort() {
+        return wrapped.getPort();
+    }
+
+    /**
+     * @return "URI" formatted in style, preferred by RestAssured library(e.g. "http://localhost")
+     */
+    public String getRestAssuredStyleUri() {
+        return scheme + SCHEME_SEPARATOR + HOST_PREFIX + wrapped.getHost();
+    }
+
+    public String getUserInfo() {
+        return wrapped.getUserInfo();
+    }
+
+    public static URILike parse(String uri) {
+        final String[] schemeAndTheRest = uri.split("://");
+        final boolean hasScheme = schemeAndTheRest.length == 2; //  [0]: scheme + :// + [1]: rest\
+
+        //java.net.URI expects a scheme and requires it to not contain underscores. This is a workaround
+        final URI parsed;
+        final String realScheme;
+        final String fakeScheme = "kludge://";
+        if (!hasScheme) {
+            parsed = URI.create(fakeScheme + uri);
+            realScheme = null;
+        } else if (schemeAndTheRest[0].contains("_")) {
+            parsed = URI.create(fakeScheme + schemeAndTheRest[1]);
+            realScheme = schemeAndTheRest[0];
+        } else {
+            parsed = URI.create(uri);
+            realScheme = parsed.getScheme();
+        }
+
+        return new URILike(realScheme,
+                parsed.getUserInfo(),
+                parsed.getHost(),
+                parsed.getPort(),
+                parsed.getPath());
+    }
+
+    private static URI createURI(String scheme,
+            String userInfo,
+            String host,
+            int port,
+            String path,
+            String query,
+            String fragment) {
+        try {
+            return new URI(
+                    scheme,
+                    userInfo,
+                    host,
+                    port,
+                    path,
+                    query,
+                    fragment);
+        } catch (URISyntaxException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/RemoteDevModeQuarkusApplicationManagedResourceBuilder.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/RemoteDevModeQuarkusApplicationManagedResourceBuilder.java
@@ -120,7 +120,7 @@ public class RemoteDevModeQuarkusApplicationManagedResourceBuilder extends Artif
         command.add(withProperty(QuarkusProperties.PACKAGE_TYPE_NAME, QuarkusProperties.MUTABLE_JAR));
         command.add(withProperty(QUARKUS_LIVE_RELOAD_PASSWORD, liveReloadPassword));
         command.add(withProperty(QUARKUS_LIVE_RELOAD_URL,
-                managedResource.getHost(Protocol.HTTP) + ":" + managedResource.getPort(Protocol.HTTP)));
+                managedResource.getURI(Protocol.HTTP).toString()));
         command.add("quarkus:remote-dev");
 
         Log.info("Running command: %s", String.join(" ", command));

--- a/quarkus-test-core/src/test/java/io/quarkus/test/services/URILikeTest.java
+++ b/quarkus-test-core/src/test/java/io/quarkus/test/services/URILikeTest.java
@@ -1,0 +1,82 @@
+package io.quarkus.test.services;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class URILikeTest {
+
+    @Test
+    void serialization() {
+        URILike uri = new URILike("http", "localhost", 1102, null);
+        Assertions.assertEquals("http://localhost:1102", uri.toString());
+    }
+
+    @Test
+    void emptyPort() {
+        URILike uri = new URILike("http", "localhost", -1, null);
+        Assertions.assertEquals("http://localhost", uri.toString());
+    }
+
+    @Test
+    void emptyScheme() throws URISyntaxException {
+        URILike ours = new URILike(null, "localhost", 8080, null);
+        Assertions.assertEquals("localhost:8080", ours.toString());
+
+        URI uri = new URI(null, "localhost", "/api", "bar");
+        Assertions.assertEquals("//localhost/api#bar", uri.toString());
+    }
+
+    @Test
+    void badScheme() {
+        URILike uri = new URILike("SASL_PLAINTEXT", "0.0.0.0", 9092, null);
+        Assertions.assertEquals("SASL_PLAINTEXT://0.0.0.0:9092", uri.toString());
+        URILike updated = uri.withPort(9093);
+        Assertions.assertEquals("SASL_PLAINTEXT://0.0.0.0:9093", updated.toString());
+    }
+
+    @Test
+    void badSchemeParse() {
+        URILike uriLike = URILike.parse("SASL_PLAINTEXT://0.0.0.0:9092");
+        Assertions.assertEquals("SASL_PLAINTEXT", uriLike.getScheme());
+
+        Exception thrown = null;
+        try {
+            new URI("SASL_PLAINTEXT://0.0.0.0:9092");
+            Assertions.fail("java.net.URI can not parse SASL_PLAINTEXT");
+        } catch (Exception e) {
+            thrown = e;
+        }
+        Assertions.assertNotNull(thrown);
+        Assertions.assertInstanceOf(URISyntaxException.class, thrown);
+    }
+
+    @Test
+    void debugParse() {
+        URILike web = URILike.parse("https://quarkus.io/guides/mutiny-primer");
+        Assertions.assertEquals("https", web.getScheme());
+        Assertions.assertEquals("quarkus.io", web.getHost());
+        Assertions.assertEquals(-1, web.getPort());
+        Assertions.assertEquals("https://quarkus.io/guides/mutiny-primer", web.toString());
+
+        URILike full = URILike.parse("http://localhost:8087/auth/admin/master/console/");
+        Assertions.assertEquals("http", full.getScheme());
+        Assertions.assertEquals("localhost", full.getHost());
+        Assertions.assertEquals(8087, full.getPort());
+        Assertions.assertEquals("http://localhost:8087/auth/admin/master/console/", full.toString());
+
+        URILike deploy = URILike.parse("localhost:5000");
+        Assertions.assertNull(deploy.getScheme());
+        Assertions.assertEquals("localhost", deploy.getHost());
+        Assertions.assertEquals(5000, deploy.getPort());
+        Assertions.assertEquals("localhost:5000", deploy.toString());
+
+        URILike bad = URILike.parse("SASL_PLAINTEXT://0.0.0.0:9092");
+        Assertions.assertEquals("SASL_PLAINTEXT", bad.getScheme());
+        Assertions.assertEquals("0.0.0.0", bad.getHost());
+        Assertions.assertEquals(9092, bad.getPort());
+        Assertions.assertEquals("SASL_PLAINTEXT://0.0.0.0:9092", bad.toString());
+    }
+}

--- a/quarkus-test-kubernetes/src/main/java/io/quarkus/test/bootstrap/inject/KubectlClient.java
+++ b/quarkus-test-kubernetes/src/main/java/io/quarkus/test/bootstrap/inject/KubectlClient.java
@@ -218,7 +218,7 @@ public final class KubectlClient {
      * @param service
      * @return
      */
-    public String url(Service service) {
+    public String host(Service service) {
         String serviceName = service.getName();
         io.fabric8.kubernetes.api.model.Service serviceModel = client.services().withName(serviceName).get();
         if (serviceModel == null
@@ -242,7 +242,7 @@ public final class KubectlClient {
             fail("Service " + serviceName + " host not found");
         }
 
-        return "http://" + ip.get();
+        return ip.get();
     }
 
     /**

--- a/quarkus-test-kubernetes/src/main/java/io/quarkus/test/services/containers/KubernetesContainerManagedResource.java
+++ b/quarkus-test-kubernetes/src/main/java/io/quarkus/test/services/containers/KubernetesContainerManagedResource.java
@@ -12,6 +12,7 @@ import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.inject.KubectlClient;
 import io.quarkus.test.logging.KubernetesLoggingHandler;
 import io.quarkus.test.logging.LoggingHandler;
+import io.quarkus.test.services.URILike;
 
 public class KubernetesContainerManagedResource implements ManagedResource {
 
@@ -66,21 +67,14 @@ public class KubernetesContainerManagedResource implements ManagedResource {
     }
 
     @Override
-    public String getHost(Protocol protocol) {
+    public URILike getURI(Protocol protocol) {
         if (useInternalServiceAsUrl()) {
-            return protocol.getValue() + "://" + model.getContext().getName();
+            return createURI(protocol.getValue(), model.getContext().getName(), model.getPort());
         }
 
-        return client.url(model.getContext().getOwner());
-    }
-
-    @Override
-    public int getPort(Protocol protocol) {
-        if (useInternalServiceAsUrl()) {
-            return model.getPort();
-        }
-
-        return client.port(model.getContext().getOwner());
+        return createURI("http",
+                client.host(model.getContext().getOwner()),
+                client.port(model.getContext().getOwner()));
     }
 
     @Override
@@ -117,5 +111,4 @@ public class KubernetesContainerManagedResource implements ManagedResource {
         return Boolean.TRUE.toString()
                 .equals(model.getContext().getOwner().getConfiguration().get(USE_INTERNAL_SERVICE_AS_URL_PROPERTY));
     }
-
 }

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
@@ -65,6 +65,7 @@ import io.quarkus.test.bootstrap.Service;
 import io.quarkus.test.configuration.PropertyLookup;
 import io.quarkus.test.logging.Log;
 import io.quarkus.test.model.CustomVolume;
+import io.quarkus.test.services.URILike;
 import io.quarkus.test.services.operator.model.CustomResourceStatus;
 import io.quarkus.test.utils.AwaitilityUtils;
 import io.quarkus.test.utils.Command;
@@ -365,7 +366,7 @@ public final class OpenShiftClient {
      * @param service
      * @return
      */
-    public String url(Service service) {
+    public URILike url(Service service) {
         return url(service.getName());
     }
 
@@ -375,10 +376,10 @@ public final class OpenShiftClient {
      * @param serviceName
      * @return
      */
-    public String url(String serviceName) {
+    public URILike url(String serviceName) {
         if (isServerlessService(serviceName)) {
             io.fabric8.knative.serving.v1.Route knRoute = kn.routes().withName(serviceName).get();
-            return knRoute.getStatus().getUrl();
+            return URILike.parse(knRoute.getStatus().getUrl());
         }
 
         Route route = client.routes().withName(serviceName).get();
@@ -388,7 +389,10 @@ public final class OpenShiftClient {
 
         String protocol = route.getSpec().getTls() == null ? "http" : "https";
         String path = route.getSpec().getPath() == null ? "" : route.getSpec().getPath();
-        return String.format("%s://%s%s", protocol, route.getSpec().getHost(), path);
+        return new URILike(protocol,
+                route.getSpec().getHost(),
+                -1,
+                path);
     }
 
     /**

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/containers/OpenShiftContainerManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/containers/OpenShiftContainerManagedResource.java
@@ -12,6 +12,7 @@ import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.inject.OpenShiftClient;
 import io.quarkus.test.logging.LoggingHandler;
 import io.quarkus.test.logging.OpenShiftLoggingHandler;
+import io.quarkus.test.services.URILike;
 
 public class OpenShiftContainerManagedResource implements ManagedResource {
 
@@ -66,21 +67,11 @@ public class OpenShiftContainerManagedResource implements ManagedResource {
     }
 
     @Override
-    public String getHost(Protocol protocol) {
+    public URILike getURI(Protocol protocol) {
         if (useInternalServiceAsUrl()) {
-            return protocol.getValue() + "://" + getInternalServiceName();
+            return createURI("http", getInternalServiceName(), model.getPort());
         }
-
-        return client.url(model.getContext().getOwner());
-    }
-
-    @Override
-    public int getPort(Protocol protocol) {
-        if (useInternalServiceAsUrl()) {
-            return model.getPort();
-        }
-
-        return HTTP_PORT;
+        return client.url(model.getContext().getOwner()).withPort(HTTP_PORT);
     }
 
     @Override

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/operator/OperatorManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/operator/OperatorManagedResource.java
@@ -11,6 +11,7 @@ import io.quarkus.test.bootstrap.OperatorService;
 import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.ServiceContext;
 import io.quarkus.test.bootstrap.inject.OpenShiftClient;
+import io.quarkus.test.services.URILike;
 import io.quarkus.test.services.operator.model.CustomResourceDefinition;
 import io.quarkus.test.utils.FileUtils;
 
@@ -53,15 +54,8 @@ public class OperatorManagedResource implements ManagedResource {
     }
 
     @Override
-    public String getHost(Protocol protocol) {
-        // Operator does not expose services.
-        return null;
-    }
-
-    @Override
-    public int getPort(Protocol protocol) {
-        // Operator does not expose services.
-        return 0;
+    public URILike getURI(Protocol protocol) {
+        throw new UnsupportedOperationException("Operator does not expose services.");
     }
 
     @Override

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftQuarkusApplicationManagedResource.java
@@ -14,6 +14,7 @@ import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.inject.OpenShiftClient;
 import io.quarkus.test.logging.LoggingHandler;
 import io.quarkus.test.logging.OpenShiftLoggingHandler;
+import io.quarkus.test.services.URILike;
 
 public abstract class OpenShiftQuarkusApplicationManagedResource<T extends QuarkusApplicationManagedResourceBuilder>
         extends QuarkusManagedResource {
@@ -74,20 +75,19 @@ public abstract class OpenShiftQuarkusApplicationManagedResource<T extends Quark
     }
 
     @Override
-    public String getHost(Protocol protocol) {
-        validateProtocol(protocol);
-        return untilIsNotNull(() -> client.url(model.getContext().getOwner()),
+    public URILike getURI(Protocol protocol) {
+        if (protocol == Protocol.HTTPS && !client.isServerlessService(model.getContext().getName())) {
+            fail("SSL is not supported for OpenShift tests yet");
+        } else if (protocol == Protocol.GRPC) {
+            fail("gRPC is not supported for OpenShift tests yet");
+        }
+        int port = client.isServerlessService(model.getContext().getName()) ? EXTERNAL_SSL_PORT : EXTERNAL_PORT;
+        return untilIsNotNull(() -> {
+            return client.url(model.getContext().getOwner()).withPort(port);
+        },
                 AwaitilitySettings.defaults().withService(getContext().getOwner()));
     }
 
-    @Override
-    public int getPort(Protocol protocol) {
-        int port = client.isServerlessService(model.getContext().getName()) ? EXTERNAL_SSL_PORT : EXTERNAL_PORT;
-        validateProtocol(protocol);
-        return port;
-    }
-
-    @Override
     public boolean isRunning() {
         if (!running) {
             return false;
@@ -121,16 +121,9 @@ public abstract class OpenShiftQuarkusApplicationManagedResource<T extends Quark
         return loggingHandler;
     }
 
-    private void validateProtocol(Protocol protocol) {
-        if (protocol == Protocol.HTTPS && !client.isServerlessService(model.getContext().getName())) {
-            fail("SSL is not supported for OpenShift tests yet");
-        } else if (protocol == Protocol.GRPC) {
-            fail("gRPC is not supported for OpenShift tests yet");
-        }
-    }
-
     private boolean routeIsReachable(Protocol protocol) {
-        return given().relaxedHTTPSValidation().baseUri(getHost(protocol)).basePath("/").port(getPort(protocol))
-                .get().getStatusCode() != HttpStatus.SC_SERVICE_UNAVAILABLE;
+        var url = getURI(protocol);
+        return given().relaxedHTTPSValidation().baseUri(url.getRestAssuredStyleUri()).basePath("/").port(url.getPort()).get()
+                .getStatusCode() != HttpStatus.SC_SERVICE_UNAVAILABLE;
     }
 }

--- a/quarkus-test-service-amq/src/main/java/io/quarkus/test/bootstrap/AmqService.java
+++ b/quarkus-test-service-amq/src/main/java/io/quarkus/test/bootstrap/AmqService.java
@@ -1,7 +1,5 @@
 package io.quarkus.test.bootstrap;
 
-import org.apache.commons.lang3.StringUtils;
-
 import io.quarkus.test.utils.FileUtils;
 
 public class AmqService extends BaseService<AmqService> {
@@ -23,14 +21,18 @@ public class AmqService extends BaseService<AmqService> {
     }
 
     public String getTcpUrl() {
-        return String.format("%s:%s", getHost().replace("http", "tcp"), getPort());
+        return getURI().withScheme("tcp").toString();
     }
 
     public String getAmqpUrl() {
-        return String.format("%s:%s", getHost().replace("http", "amqp"), getPort());
+        return getURI().withScheme("amqp").toString();
     }
 
     public String getAmqpHost() {
-        return getHost().replace("http://", StringUtils.EMPTY);
+        return getURI().getHost();
+    }
+
+    public Integer getPort() {
+        return getURI().getPort();
     }
 }

--- a/quarkus-test-service-consul/src/main/java/io/quarkus/test/bootstrap/ConsulService.java
+++ b/quarkus-test-service-consul/src/main/java/io/quarkus/test/bootstrap/ConsulService.java
@@ -38,6 +38,7 @@ public class ConsulService extends BaseService<ConsulService> {
     }
 
     public String getConsulEndpoint() {
-        return getHost().replace("http://", "") + ":" + getPort();
+        var host = getURI();
+        return host.getHost() + ":" + host.getPort();
     }
 }

--- a/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/DatabaseService.java
+++ b/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/DatabaseService.java
@@ -23,11 +23,17 @@ public abstract class DatabaseService<T extends Service> extends BaseService<T> 
     }
 
     public String getJdbcUrl() {
-        return getHost().replace("http", "jdbc:" + getJdbcName()) + ":" + getPort() + "/" + getDatabase();
+        return getURI()
+                .withScheme("jdbc:" + getJdbcName())
+                .withPath("/" + getDatabase())
+                .toString();
     }
 
     public String getReactiveUrl() {
-        return getHost().replace("http", getJdbcName()) + ":" + getPort() + "/" + getDatabase();
+        return getURI()
+                .withScheme(getJdbcName())
+                .withPath("/" + getDatabase())
+                .toString();
     }
 
     public T with(String user, String password, String database) {

--- a/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/MongoDbService.java
+++ b/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/MongoDbService.java
@@ -10,7 +10,9 @@ public class MongoDbService extends DatabaseService<MongoDbService> {
 
     @Override
     public String getJdbcUrl() {
-        return getHost().replace("http", getJdbcName()) + ":" + getPort();
+        return getURI()
+                .withScheme(JDBC_NAME)
+                .toString();
     }
 
     @Override

--- a/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/OracleService.java
+++ b/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/OracleService.java
@@ -21,12 +21,14 @@ public class OracleService extends DatabaseService<OracleService> {
 
     @Override
     public String getJdbcUrl() {
-        return getHost().replace("http://", "jdbc:" + getJdbcName() + ":thin:@") + ":" + getPort() + "/" + getDatabase();
+        var host = getURI();
+        return "jdbc:" + getJdbcName() + ":thin:@" + host.getHost() + ":" + host.getPort() + "/" + getDatabase();
     }
 
     @Override
     public String getReactiveUrl() {
-        return getHost().replace("http://", getJdbcName() + ":thin:@") + ":" + getPort() + ":" + getDatabase();
+        var host = getURI();
+        return getJdbcName() + ":thin:@" + host.getHost() + ":" + host.getPort() + "/" + getDatabase();
     }
 
     @Override

--- a/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/SqlServerService.java
+++ b/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/SqlServerService.java
@@ -24,7 +24,8 @@ public class SqlServerService extends DatabaseService<SqlServerService> {
 
     @Override
     public String getJdbcUrl() {
-        return getHost().replace("http", "jdbc:" + getJdbcName()) + ":" + getPort() + ";databaseName=" + getDatabase();
+        var host = getURI();
+        return "jdbc:" + getJdbcName() + "://" + host.getHost() + ":" + host.getPort() + ";databaseName=" + getDatabase();
     }
 
     @Override

--- a/quarkus-test-service-grpc/src/main/java/io/quarkus/test/bootstrap/GrpcService.java
+++ b/quarkus-test-service-grpc/src/main/java/io/quarkus/test/bootstrap/GrpcService.java
@@ -1,21 +1,16 @@
 package io.quarkus.test.bootstrap;
 
-import org.apache.commons.lang3.StringUtils;
-
 import io.grpc.Channel;
 import io.grpc.ManagedChannelBuilder;
+import io.quarkus.test.services.URILike;
 
 public class GrpcService extends RestService {
 
     public Channel grpcChannel() {
-        return ManagedChannelBuilder.forAddress(getGrpcHost(), getGrpcPort()).usePlaintext().build();
+        return ManagedChannelBuilder.forAddress(getGrpcHost().getHost(), getGrpcHost().getPort()).usePlaintext().build();
     }
 
-    public String getGrpcHost() {
-        return getHost(Protocol.GRPC).replace("grpc://", StringUtils.EMPTY).replace("http://", StringUtils.EMPTY);
-    }
-
-    public int getGrpcPort() {
-        return getPort(Protocol.GRPC);
+    public URILike getGrpcHost() {
+        return getURI(Protocol.GRPC);
     }
 }

--- a/quarkus-test-service-infinispan/src/main/java/io/quarkus/test/bootstrap/InfinispanService.java
+++ b/quarkus-test-service-infinispan/src/main/java/io/quarkus/test/bootstrap/InfinispanService.java
@@ -29,7 +29,8 @@ public class InfinispanService extends BaseService<InfinispanService> {
     }
 
     public String getInfinispanServerAddress() {
-        return getHost().replace("http://", "") + ":" + getPort();
+        var uri = getURI(Protocol.HTTP);
+        return uri.getHost() + ":" + uri.getPort();
     }
 
     public InfinispanService withConfigFile(String configFile) {

--- a/quarkus-test-service-jaeger/src/main/java/io/quarkus/test/bootstrap/JaegerService.java
+++ b/quarkus-test-service-jaeger/src/main/java/io/quarkus/test/bootstrap/JaegerService.java
@@ -6,7 +6,7 @@ public class JaegerService extends BaseService<JaegerService> {
     public static final String JAEGER_API_PATH = "/api/traces";
 
     public String getRestUrl() {
-        return getHost() + ":" + getPort() + JAEGER_API_PATH;
+        return getURI(Protocol.HTTP).withPath(JAEGER_API_PATH).toString();
     }
 
     public String getTraceUrl() {

--- a/quarkus-test-service-jaeger/src/main/java/io/quarkus/test/services/containers/JaegerGenericDockerContainerManagedResource.java
+++ b/quarkus-test-service-jaeger/src/main/java/io/quarkus/test/services/containers/JaegerGenericDockerContainerManagedResource.java
@@ -33,7 +33,8 @@ public class JaegerGenericDockerContainerManagedResource extends GenericDockerCo
     }
 
     private String getJaegerTraceUrl() {
-        return getHost(Protocol.HTTP) + ":" + getMappedPort(model.getTracePort());
+        return getURI(Protocol.HTTP)
+                .withPort(getMappedPort(model.getTracePort()))
+                .toString();
     }
-
 }

--- a/quarkus-test-service-jaeger/src/main/java/io/quarkus/test/services/containers/OpenShiftJaegerContainerManagedResource.java
+++ b/quarkus-test-service-jaeger/src/main/java/io/quarkus/test/services/containers/OpenShiftJaegerContainerManagedResource.java
@@ -38,7 +38,7 @@ public class OpenShiftJaegerContainerManagedResource extends OpenShiftContainerM
         // We need to expose an additional endpoint for trace
         String traceServiceName = model.getContext().getName() + TRACE_SUFFIX;
         getClient().expose(traceServiceName, model.getTracePort());
-        model.getContext().put(JAEGER_TRACE_URL_PROPERTY, getClient().url(traceServiceName));
+        model.getContext().put(JAEGER_TRACE_URL_PROPERTY, getClient().url(traceServiceName).toString());
     }
 
     @Override

--- a/quarkus-test-service-kafka/src/main/java/io/quarkus/test/bootstrap/KafkaService.java
+++ b/quarkus-test-service-kafka/src/main/java/io/quarkus/test/bootstrap/KafkaService.java
@@ -5,7 +5,8 @@ public class KafkaService extends BaseService<KafkaService> {
     public static final String KAFKA_REGISTRY_URL_PROPERTY = "ts.kafka.registry.url";
 
     public String getBootstrapUrl() {
-        return getHost().replace("http://", "") + ":" + getPort();
+        var host = getURI();
+        return host.getHost() + ":" + host.getPort();
     }
 
     public String getRegistryUrl() {

--- a/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/OpenShiftStrimziKafkaContainerManagedResource.java
+++ b/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/OpenShiftStrimziKafkaContainerManagedResource.java
@@ -15,6 +15,7 @@ import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.inject.OpenShiftClient;
 import io.quarkus.test.logging.LoggingHandler;
 import io.quarkus.test.logging.OpenShiftLoggingHandler;
+import io.quarkus.test.services.URILike;
 import io.quarkus.test.services.containers.model.KafkaProtocol;
 
 public class OpenShiftStrimziKafkaContainerManagedResource implements ManagedResource {
@@ -79,16 +80,11 @@ public class OpenShiftStrimziKafkaContainerManagedResource implements ManagedRes
     }
 
     @Override
-    public String getHost(Protocol protocol) {
+    public URILike getURI(Protocol protocol) {
         // Strimzi Kafka only allows to expose Routes using SSL, therefore we'll use internal service routing.
         // TODO: Make it public using the Strimzi Operator:
         // https://developers.redhat.com/blog/2019/06/10/accessing-apache-kafka-in-strimzi-part-3-red-hat-openshift-routes/
-        return model.getContext().getOwner().getName();
-    }
-
-    @Override
-    public int getPort(Protocol protocol) {
-        return HTTP_PORT;
+        return createURI("http", model.getContext().getOwner().getName(), HTTP_PORT);
     }
 
     @Override
@@ -156,7 +152,8 @@ public class OpenShiftStrimziKafkaContainerManagedResource implements ManagedRes
     }
 
     private String getKafkaBootstrapUrl() {
-        return getHost(Protocol.HTTP).replace("http://", "") + ":" + getPort(Protocol.HTTP);
+        var host = getURI(Protocol.HTTP);
+        return host.getHost() + ":" + host.getPort();
     }
 
     private String replaceDeploymentContent(String content) {

--- a/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/StrimziKafkaContainerManagedResource.java
+++ b/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/StrimziKafkaContainerManagedResource.java
@@ -8,6 +8,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.testcontainers.containers.GenericContainer;
 
 import io.quarkus.test.bootstrap.Protocol;
+import io.quarkus.test.services.URILike;
 import io.quarkus.test.services.containers.model.KafkaProtocol;
 import io.quarkus.test.services.containers.model.KafkaVendor;
 import io.quarkus.test.services.containers.strimzi.ExtendedStrimziKafkaContainer;
@@ -29,15 +30,14 @@ public class StrimziKafkaContainerManagedResource extends BaseKafkaContainerMana
     }
 
     @Override
-    public String getHost(Protocol protocol) {
-        String host = super.getHost(protocol);
+    public URILike getURI(Protocol protocol) {
+        var uri = super.getURI(protocol);
         if (model.getProtocol() == KafkaProtocol.SSL) {
-            host = host.replaceAll("http://", "SSL://");
+            uri = uri.withScheme("SSL");
         } else if (model.getProtocol() == KafkaProtocol.SASL) {
-            host = host.replaceAll("http://", "SASL_PLAINTEXT://");
+            uri = uri.withScheme("SASL_PLAINTEXT");
         }
-
-        return host;
+        return uri;
     }
 
     @Override

--- a/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/operator/KafkaInstance.java
+++ b/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/operator/KafkaInstance.java
@@ -1,6 +1,8 @@
 package io.quarkus.test.services.operator;
 
 import io.quarkus.test.bootstrap.OperatorService;
+import io.quarkus.test.bootstrap.Protocol;
+import io.quarkus.test.services.URILike;
 import io.quarkus.test.services.operator.model.KafkaInstanceCustomResource;
 
 public class KafkaInstance extends OperatorService<KafkaInstance> {
@@ -22,16 +24,12 @@ public class KafkaInstance extends OperatorService<KafkaInstance> {
     }
 
     @Override
-    public String getHost() {
-        return String.format(HOST, name);
-    }
-
-    @Override
-    public Integer getPort() {
-        return PORT;
+    public URILike getURI(Protocol protocol) {
+        return new URILike(null, String.format(HOST, name), PORT, null);
     }
 
     public String getBootstrapUrl() {
-        return getHost() + ":" + getPort();
+        var host = getURI(Protocol.NONE);
+        return host.getHost() + ":" + host.getPort();
     }
 }

--- a/quarkus-test-service-keycloak/src/main/java/io/quarkus/test/bootstrap/KeycloakService.java
+++ b/quarkus-test-service-keycloak/src/main/java/io/quarkus/test/bootstrap/KeycloakService.java
@@ -1,5 +1,7 @@
 package io.quarkus.test.bootstrap;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Collections;
 
 import org.apache.commons.lang3.StringUtils;
@@ -50,13 +52,25 @@ public class KeycloakService extends BaseService<KeycloakService> {
     }
 
     public String getRealmUrl() {
-        String url = getHost();
-        // SMELL: Keycloak does not validate Token Issuers when URL contains the port 80.
-        if (getPort() != HTTP_80) {
-            url += ":" + getPort();
-        }
+        var host = getURI(Protocol.HTTP);
 
-        return String.format("%s/%s/%s", url, realmBasePath, realm);
+        // SMELL: Keycloak does not validate Token Issuers when URL contains the port 80.
+        int port = host.getPort();
+        if (port == HTTP_80) {
+            port = -1;
+        }
+        try {
+            URI url = new URI(host.getScheme(),
+                    host.getUserInfo(),
+                    host.getHost(),
+                    port,
+                    "/" + realmBasePath + "/" + realm,
+                    null,
+                    null);
+            return url.toString();
+        } catch (URISyntaxException e) {
+            throw new IllegalStateException(e);
+        }
     }
 
     public AuthzClient createAuthzClient(String clientId, String clientSecret) {


### PR DESCRIPTION
### Summary

### The problem:
All classes, which we use for deploying services in our TS have two methods:
	getHost(returns something like "http://localhost")
	getPort(returns port as integer)
In most places, we call both these methods and then manually glue their output together, sometimes replacing http with other scheme.
In some cases, we have to parse output of getHost() string, since we need only real host name, without a scheme

### The solution:
Replace getHost and getPort with single method getURI, which will return an object of special class, with scheme(e.g. "http"), host(e.g. "localhost") and port(e.g. 8080) at the same time.
We will be able to pick parts of it manually, and glue them with single method.

Initially, I planned to use java.net.URI, but it turns out, that kafka use schemes, which are incompatible with URI standard from IETF and, therefore with java implementation

Closes https://github.com/quarkus-qe/quarkus-test-framework/issues/263

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)