### PR TITLE
Upgrade apicurio to 2.2.5.Final

### DIFF
--- a/examples/kafka-registry/src/test/java/io/quarkus/qe/StrimziKafkaWithRegistryMessagingIT.java
+++ b/examples/kafka-registry/src/test/java/io/quarkus/qe/StrimziKafkaWithRegistryMessagingIT.java
@@ -16,14 +16,11 @@ import org.junit.jupiter.api.Test;
 import io.quarkus.test.bootstrap.KafkaService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusSnapshot;
 import io.quarkus.test.services.KafkaContainer;
 import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.test.services.containers.model.KafkaVendor;
 
 @QuarkusScenario
-// TODO https://github.com/quarkusio/quarkus/issues/25814
-@DisabledOnQuarkusSnapshot(reason = "Apicurio 2.2.3.Final used in upstream is not compatible with Quarkus 2.9.2.Final")
 public class StrimziKafkaWithRegistryMessagingIT {
 
     @KafkaContainer(vendor = KafkaVendor.STRIMZI, withRegistry = true, registryPath = "/apis/registry/v2")

--- a/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/model/KafkaRegistry.java
+++ b/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/model/KafkaRegistry.java
@@ -2,7 +2,7 @@ package io.quarkus.test.services.containers.model;
 
 public enum KafkaRegistry {
     CONFLUENT("confluentinc/cp-schema-registry", "6.1.1", "/", 8081),
-    APICURIO("quay.io/apicurio/apicurio-registry-mem", "2.2.3.Final", "/apis", 8080);
+    APICURIO("quay.io/apicurio/apicurio-registry-mem", "2.2.5.Final", "/apis", 8080);
 
     private final String image;
     private final String defaultVersion;


### PR DESCRIPTION
### Summary

Upgrade apicurio to 2.2.5.Final in order to be aligned to Quarkus upstream

Please check the relevant options
- [X] Dependency update

### Checklist:
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)