### PR TITLE
Release 1.2.0.Beta5

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 name: Quarkus QE Test Framework
 release:
-  current-version: 1.2.0.Beta4
-  next-version: 1.2.0.Beta5
+  current-version: 1.2.0.Beta5
+  next-version: 1.2.0.Beta6


### PR DESCRIPTION
### Summary

[Swapp default consul docker image by a bitnami image](https://github.com/quarkus-qe/quarkus-test-framework/commit/0607a426ad09beb8a908c0c1f5356987447ebb84)
[Update native image builders - use version 22.0](https://github.com/quarkus-qe/quarkus-test-framework/commit/be940cfef05f98bfa68ee41a09845b132eae73b2)
[Wait for thread to finish consumption of lines](https://github.com/quarkus-qe/quarkus-test-framework/commit/cc67ce2129997e4a49db83797fbb3798ce83040e)
[Bump maven-javadoc-plugin from 3.4.0 to 3.4.1](https://github.com/quarkus-qe/quarkus-test-framework/commit/37c308d30f7ea8f0db6d07d35f474e85d8fe04bf)
[Upgrade apicurio to 2.2.5.Final](https://github.com/quarkus-qe/quarkus-test-framework/commit/a0ba64e49f103e14cd3b7411623d4c3ed4f046fc)
[Template hint for OCP run](https://github.com/quarkus-qe/quarkus-test-framework/commit/425ab3ec94d7b9956b1b1bffb1d7cbc26d892f02)
[Updated jvm and native Dockerfiles](https://github.com/quarkus-qe/quarkus-test-framework/commit/0b446b8d5d21592ded6563c21849093e6a49242f)
[Bump htmlunit from 2.63.0 to 2.64.0](https://github.com/quarkus-qe/quarkus-test-framework/commit/7f6eaf9120c6c9529cde6fb80ebf2728ce0a9469)
[Bump Keycloak to 19.0.1 version](https://github.com/quarkus-qe/quarkus-test-framework/commit/d5f5102b17d5a5564b876ac8fe2aadc6a20a4b58)
[Bump checkstyle from 10.3.2 to 10.3.3](https://github.com/quarkus-qe/quarkus-test-framework/commit/0aba180223ff56f89bb96dff0597e6ecf7fdca73)


