### PR TITLE
Enable usage of a OTLP Exporter

### DIFF
--- a/examples/jaeger/pom.xml
+++ b/examples/jaeger/pom.xml
@@ -16,7 +16,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-smallrye-opentracing</artifactId>
+            <artifactId>quarkus-opentelemetry-exporter-otlp</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus.qe</groupId>

--- a/examples/jaeger/src/main/java/io/quarkus/qe/ClientResource.java
+++ b/examples/jaeger/src/main/java/io/quarkus/qe/ClientResource.java
@@ -1,23 +1,19 @@
 package io.quarkus.qe;
 
-import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
-import io.opentracing.Tracer;
+import io.opentelemetry.api.trace.Span;
 
 @Path("/client")
 public class ClientResource {
 
-    @Inject
-    Tracer tracer;
-
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     public String get() {
-        tracer.activeSpan().log("ClientResource called");
+        Span.current().addEvent("ClientResource called");
         return "I'm a client";
     }
 }

--- a/examples/jaeger/src/main/resources/application.properties
+++ b/examples/jaeger/src/main/resources/application.properties
@@ -1,2 +1,4 @@
 quarkus.jaeger.sampler-type=const
 quarkus.jaeger.sampler-param=1
+quarkus.opentelemetry.enabled=true
+quarkus.application.name=test-traced-service

--- a/quarkus-test-service-jaeger/src/main/java/io/quarkus/test/bootstrap/JaegerService.java
+++ b/quarkus-test-service-jaeger/src/main/java/io/quarkus/test/bootstrap/JaegerService.java
@@ -5,7 +5,15 @@ public class JaegerService extends BaseService<JaegerService> {
     public static final String JAEGER_TRACE_URL_PROPERTY = "ts.jaeger.trace.url";
     public static final String JAEGER_API_PATH = "/api/traces";
 
+    /**
+     * Deprecated, call {@link #getCollectorUrl()} directly.
+     */
+    @Deprecated
     public String getRestUrl() {
+        return getCollectorUrl();
+    }
+
+    public String getCollectorUrl() {
         return getURI(Protocol.HTTP).withPath(JAEGER_API_PATH).toString();
     }
 

--- a/quarkus-test-service-jaeger/src/main/java/io/quarkus/test/services/JaegerContainer.java
+++ b/quarkus-test-service-jaeger/src/main/java/io/quarkus/test/services/JaegerContainer.java
@@ -11,11 +11,25 @@ import io.quarkus.test.services.containers.JaegerContainerManagedResourceBuilder
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface JaegerContainer {
-    String image() default "quay.io/jaegertracing/all-in-one:1.30.0";
+    String image() default "quay.io/jaegertracing/all-in-one:1.37.0";
 
     int tracePort() default 16686;
 
+    /**
+     * Rest port of a Jaeger collector. Default port 14268 is used by a collector that accepts jaeger.thrift directly from
+     * clients.
+     */
     int restPort() default 14268;
+
+    /**
+     * OTLP port of a Jaeger collector. Default port 4317 is used for the OpenTelemetry Protocol (OTLP) over gRPC.
+     */
+    int otlpPort() default 4317;
+
+    /**
+     * Switches between {@link #restPort()} and {@link #otlpPort()}. If set to true, the OTLP collector is used.
+     */
+    boolean useOtlpCollector() default false;
 
     String expectedLog() default "server started";
 

--- a/quarkus-test-service-jaeger/src/main/java/io/quarkus/test/services/containers/JaegerContainerManagedResourceBuilder.java
+++ b/quarkus-test-service-jaeger/src/main/java/io/quarkus/test/services/containers/JaegerContainerManagedResourceBuilder.java
@@ -14,9 +14,14 @@ public class JaegerContainerManagedResourceBuilder extends ContainerManagedResou
 
     private ServiceContext context;
     private String image;
-    private int restPort;
+    /**
+     * Port used to collect traces. Depending on the {@link JaegerContainer#useOtlpCollector()}, value is either
+     * {@link JaegerContainer#otlpPort()} or {@link JaegerContainer#restPort()}.
+     */
+    private int port;
     private int tracePort;
     private String expectedLog;
+    private boolean useOtlpCollector;
 
     @Override
     protected String getImage() {
@@ -25,7 +30,7 @@ public class JaegerContainerManagedResourceBuilder extends ContainerManagedResou
 
     @Override
     protected Integer getPort() {
-        return restPort;
+        return port;
     }
 
     @Override
@@ -42,13 +47,18 @@ public class JaegerContainerManagedResourceBuilder extends ContainerManagedResou
         return tracePort;
     }
 
+    protected boolean shouldUseOtlpCollector() {
+        return useOtlpCollector;
+    }
+
     @Override
     public void init(Annotation annotation) {
         JaegerContainer metadata = (JaegerContainer) annotation;
         this.image = metadata.image();
-        this.restPort = metadata.restPort();
+        this.port = metadata.useOtlpCollector() ? metadata.otlpPort() : metadata.restPort();
         this.tracePort = metadata.tracePort();
         this.expectedLog = metadata.expectedLog();
+        this.useOtlpCollector = metadata.useOtlpCollector();
     }
 
     @Override

--- a/quarkus-test-service-jaeger/src/main/java/io/quarkus/test/services/containers/JaegerGenericDockerContainerManagedResource.java
+++ b/quarkus-test-service-jaeger/src/main/java/io/quarkus/test/services/containers/JaegerGenericDockerContainerManagedResource.java
@@ -9,6 +9,7 @@ import io.quarkus.test.utils.DockerUtils;
 
 public class JaegerGenericDockerContainerManagedResource extends GenericDockerContainerManagedResource {
 
+    private static final String COLLECTOR_OTLP_ENABLED = "COLLECTOR_OTLP_ENABLED";
     private final JaegerContainerManagedResourceBuilder model;
 
     protected JaegerGenericDockerContainerManagedResource(JaegerContainerManagedResourceBuilder model) {
@@ -28,6 +29,10 @@ public class JaegerGenericDockerContainerManagedResource extends GenericDockerCo
         GenericContainer<?> container = super.initContainer();
         container.addExposedPort(model.getTracePort());
         container.withCreateContainerCmdModifier(cmd -> cmd.withName(DockerUtils.generateDockerContainerName()));
+
+        if (model.shouldUseOtlpCollector()) {
+            container.addEnv(COLLECTOR_OTLP_ENABLED, "true");
+        }
 
         return container;
     }

--- a/quarkus-test-service-jaeger/src/main/java/io/quarkus/test/services/containers/OpenShiftJaegerContainerManagedResource.java
+++ b/quarkus-test-service-jaeger/src/main/java/io/quarkus/test/services/containers/OpenShiftJaegerContainerManagedResource.java
@@ -8,7 +8,7 @@ public class OpenShiftJaegerContainerManagedResource extends OpenShiftContainerM
     private static final String DEPLOYMENT_TEMPLATE_PROPERTY_DEFAULT = "/jaeger-deployment-template.yml";
 
     private static final String TRACE_SUFFIX = "-query";
-    private static final String REST_SUFFIX = "-rest";
+    private static final String COLLECTOR_SUFFIX = "-collector";
 
     private final JaegerContainerManagedResourceBuilder model;
 
@@ -29,7 +29,7 @@ public class OpenShiftJaegerContainerManagedResource extends OpenShiftContainerM
 
     @Override
     protected String getInternalServiceName() {
-        return model.getContext().getName() + REST_SUFFIX;
+        return model.getContext().getName() + COLLECTOR_SUFFIX;
     }
 
     @Override
@@ -44,7 +44,8 @@ public class OpenShiftJaegerContainerManagedResource extends OpenShiftContainerM
     @Override
     protected String replaceDeploymentContent(String content) {
         return super.replaceDeploymentContent(content)
-                .replaceAll(quote("${TRACE_PORT}"), "" + model.getTracePort());
+                .replaceAll(quote("${TRACE_PORT}"), "" + model.getTracePort())
+                .replaceAll(quote("${COLLECTOR_OTLP_ENABLED}"), Boolean.toString(model.shouldUseOtlpCollector()));
     }
 
 }

--- a/quarkus-test-service-jaeger/src/main/resources/jaeger-deployment-template.yml
+++ b/quarkus-test-service-jaeger/src/main/resources/jaeger-deployment-template.yml
@@ -18,6 +18,9 @@ items:
           containers:
             - image: '${IMAGE}'
               name: '${SERVICE_NAME}'
+              env:
+                - name: COLLECTOR_OTLP_ENABLED
+                  value: ${COLLECTOR_OTLP_ENABLED}
               ports:
                 - containerPort: 5775
                   protocol: UDP
@@ -52,12 +55,12 @@ items:
   - apiVersion: v1
     kind: Service
     metadata:
-      name: '${SERVICE_NAME}-rest'
+      name: '${SERVICE_NAME}-collector'
       labels:
         app: '${SERVICE_NAME}'
     spec:
       ports:
-        - name: '${SERVICE_NAME}-rest'
+        - name: '${SERVICE_NAME}-collector'
           port: ${INTERNAL_PORT}
           protocol: TCP
           targetPort: ${INTERNAL_PORT}


### PR DESCRIPTION
### Summary

Enables user to use an OTLP exporter with `io.quarkus.test.services.JaegerContainer#useOtlpCollector` flag. By default, we use the collector over gRPC. Jaeger _all-in-one_ is bumped from 1.30.0 to 1.37.0 as the OTLP collector feature was [only introduced in 1.35.0](https://www.jaegertracing.io/docs/1.36/apis/#opentelemetry-protocol-stable). I replaced deprecated `smallrye-opentracing` with the OpenTelemetry in Examples as it's related to the changes and good test the changes are working both locally and on OC.

Please note that `io.quarkus.test.services.containers.JaegerContainerManagedResourceBuilder#getPort` is now returning value depending on the `io.quarkus.test.services.JaegerContainer#useOtlpCollector`. By default, nothing changes, but if you set the flag to true, OTLP port is returned by this method.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Dependency update
- [x] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)