### PR TITLE
Update dependencies and images to latest versions

### DIFF
--- a/coverage-report/pom.xml
+++ b/coverage-report/pom.xml
@@ -15,7 +15,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
-                <version>1.6.0</version>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>copy-classes-and-source</id>

--- a/examples/consul/src/test/java/io/quarkus/qe/GreetingResourceIT.java
+++ b/examples/consul/src/test/java/io/quarkus/qe/GreetingResourceIT.java
@@ -12,6 +12,6 @@ public class GreetingResourceIT extends BaseGreetingResourceIT {
      * and as it does not exist, it will use the default image.
      */
     // TODO use official image when/if this fixed https://github.com/hashicorp/docker-consul/issues/184
-    @Container(image = "${property.do.not.exist:docker.io/bitnami/consul:1.12.0}", expectedLog = "Synced node info", port = 8500)
+    @Container(image = "${property.do.not.exist:docker.io/bitnami/consul:1.13.1}", expectedLog = "Synced node info", port = 8500)
     static ConsulService consul = new ConsulService().onPostStart(BaseGreetingResourceIT::onLoadConfigureConsul);
 }

--- a/examples/database-mysql/src/test/java/io/quarkus/qe/database/mysql/AbstractMysqlReusableInstance.java
+++ b/examples/database-mysql/src/test/java/io/quarkus/qe/database/mysql/AbstractMysqlReusableInstance.java
@@ -14,7 +14,7 @@ public abstract class AbstractMysqlReusableInstance extends AbstractSqlDatabaseI
      * property `ts.database.container.reusable` is enabled on test.properties
      **/
 
-    @Container(image = "docker.io/mysql:8.0.27", port = 3306, expectedLog = "port: 3306  MySQL Community Server")
+    @Container(image = "docker.io/mysql:8.0.30", port = 3306, expectedLog = "port: 3306  MySQL Community Server")
     public static MySqlService database = new MySqlService();
 
     static Integer containerPort;

--- a/examples/database-oracle/src/test/java/io/quarkus/qe/database/oracle/DevModeOracleDatabaseIT.java
+++ b/examples/database-oracle/src/test/java/io/quarkus/qe/database/oracle/DevModeOracleDatabaseIT.java
@@ -19,7 +19,7 @@ public class DevModeOracleDatabaseIT extends AbstractSqlDatabaseIT {
     static final String ORACLE_DATABASE = "mydb";
     static final int ORACLE_PORT = 1521;
 
-    @Container(image = "docker.io/gvenzl/oracle-xe:21-slim", port = ORACLE_PORT, expectedLog = "DATABASE IS READY TO USE!")
+    @Container(image = "docker.io/gvenzl/oracle-xe:21-slim-faststart", port = ORACLE_PORT, expectedLog = "DATABASE IS READY TO USE!")
     static DefaultService database = new DefaultService()
             .withProperty("APP_USER", ORACLE_USER)
             .withProperty("APP_USER_PASSWORD", ORACLE_PASSWORD)

--- a/examples/database-oracle/src/test/java/io/quarkus/qe/database/oracle/OracleDatabaseIT.java
+++ b/examples/database-oracle/src/test/java/io/quarkus/qe/database/oracle/OracleDatabaseIT.java
@@ -11,7 +11,7 @@ import io.quarkus.test.services.QuarkusApplication;
 @QuarkusScenario
 public class OracleDatabaseIT extends AbstractSqlDatabaseIT {
 
-    @Container(image = "docker.io/gvenzl/oracle-xe:21-slim", port = ORACLE_PORT, expectedLog = "DATABASE IS READY TO USE!")
+    @Container(image = "docker.io/gvenzl/oracle-xe:21-slim-faststart", port = ORACLE_PORT, expectedLog = "DATABASE IS READY TO USE!")
     static OracleService database = new OracleService();
 
     @QuarkusApplication

--- a/examples/database-postgresql/src/test/java/io/quarkus/qe/database/postgresql/PostgresqlDatabaseIT.java
+++ b/examples/database-postgresql/src/test/java/io/quarkus/qe/database/postgresql/PostgresqlDatabaseIT.java
@@ -11,7 +11,7 @@ public class PostgresqlDatabaseIT extends AbstractSqlDatabaseIT {
 
     private static final int POSTGRESQL_PORT = 5432;
 
-    @Container(image = "docker.io/postgres:13.6", port = POSTGRESQL_PORT, expectedLog = "is ready")
+    @Container(image = "docker.io/postgres:13.8", port = POSTGRESQL_PORT, expectedLog = "is ready")
     static PostgresqlService database = new PostgresqlService();
 
     @QuarkusApplication

--- a/examples/infinispan/src/test/java/io/quarkus/qe/books/BasicInfinispanBookCacheIT.java
+++ b/examples/infinispan/src/test/java/io/quarkus/qe/books/BasicInfinispanBookCacheIT.java
@@ -9,7 +9,7 @@ import io.quarkus.test.services.QuarkusApplication;
 @QuarkusScenario
 public class BasicInfinispanBookCacheIT extends BaseBookCacheIT {
 
-    @Container(image = "docker.io/infinispan/server:12.1", expectedLog = "Infinispan Server.*started in", port = 11222)
+    @Container(image = "docker.io/infinispan/server:13.0", expectedLog = "Infinispan Server.*started in", port = 11222)
     static final InfinispanService infinispan = new InfinispanService();
 
     @QuarkusApplication

--- a/examples/infinispan/src/test/java/io/quarkus/qe/books/UsingJksInfinispanBookCacheIT.java
+++ b/examples/infinispan/src/test/java/io/quarkus/qe/books/UsingJksInfinispanBookCacheIT.java
@@ -9,7 +9,7 @@ import io.quarkus.test.services.QuarkusApplication;
 @QuarkusScenario
 public class UsingJksInfinispanBookCacheIT extends BaseBookCacheIT {
 
-    @Container(image = "docker.io/infinispan/server:12.1", expectedLog = "Infinispan Server.*started in", port = 11222)
+    @Container(image = "docker.io/infinispan/server:13.0", expectedLog = "Infinispan Server.*started in", port = 11222)
     static final InfinispanService infinispan = new InfinispanService()
             .withConfigFile("jks-config.yaml")
             .withSecretFiles("jks/server.jks");

--- a/examples/kafka-registry/pom.xml
+++ b/examples/kafka-registry/pom.xml
@@ -10,9 +10,7 @@
     <artifactId>examples-kafka-registry</artifactId>
     <name>Quarkus - Test Framework - Examples - Kafka with Registry</name>
     <properties>
-        <!-- confluent AVRO serializer 7.1.2 is not supported by native mode -->
-        <!-- TODO https://github.com/quarkusio/quarkus/issues/26428 -->
-        <confluent.kafka-avro-serializer.version>7.0.3</confluent.kafka-avro-serializer.version>
+        <confluent.kafka-avro-serializer.version>7.2.1</confluent.kafka-avro-serializer.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
### Summary

### Update docker images to latest versions

Wherever possible.
Images synchronized with Quarkus upstream or updated to the latest
applicable version.
Note to `docker.io/infinispan/server:13.0`: there is a newer tag `14.0`,
but `quarkus-infinispan-client` uses Infinispan `13.0.10` which does not
work with server version `14.0`.

### Update maven dependencies to latest versions

New versions inspected using `mvn versions:display-dependency-updates`.
Maven plugins updated to latest available version.

### Switch to gvenzl/oracle-xe:21-slim-faststart

Faststart image has faster startup in exchange for bigger image size.
See
https://github.com/gvenzl/oci-oracle-xe/pkgs/container/oracle-xe#image-flavors.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)