### PR TITLE
Quarkus-helm examples: avoid native image build

### DIFF
--- a/examples/quarkus-helm/pom.xml
+++ b/examples/quarkus-helm/pom.xml
@@ -10,7 +10,7 @@
     <artifactId>examples-quarkus-helm</artifactId>
     <name>Quarkus - Test Framework - Examples - Quarkus HELM</name>
     <properties>
-        <quarkus-helm.version>0.0.5</quarkus-helm.version>
+        <quarkus-helm.version>0.0.6</quarkus-helm.version>
     </properties>
 
     <dependencies>
@@ -151,6 +151,19 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <!-- Disable native build on this module -->
+            <!-- Helm is concerned just about image name, Native compilation is not relevant -->
+            <id>native</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <properties>
+                <quarkus.build.skip>true</quarkus.build.skip>
+            </properties>
         </profile>
     </profiles>
 </project>


### PR DESCRIPTION
### Summary

- bump quarkus-helm to 0.0.6 version

- The quarkus-helm example does not have a native test, but the application image is built anyway.
- Methods
   - `installChart(String chartName, String chartFolderPath, Duration timeoutSec, String readinessPath)`
   - `public Result updateChart(String chartName, String chartFolderPath, Duration timeoutSec, String readinessPath)` 
Wasn't working as expected because didn't wait to be ready. We have removed these two method and added a new one in order to cover the same feature:
  - `public void waitToReadiness(String fullReadinessPath, Duration atMost)`

Please check the relevant options

- [X] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [X] Example scenarios has been updated / added
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)