### PR TITLE
Fix OC failures - migrate io.fabric8 Kubernetes Client to 6.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,9 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>2.12.0.Final</quarkus.platform.version>
+        <!--  TODO: once we migrate to Quarkus 2.13, delete 'kubernetes-client-bom' and 'dekorate' from dependency management (see below)  -->
+        <kubernetes-client.version>6.1.1</kubernetes-client.version>
+        <dekorate.version>3.0.0</dekorate.version>
         <exclude.tests.with.tags>quarkus-cli</exclude.tests.with.tags>
         <include.tests>**/*IT.java</include.tests>
         <exclude.openshift.tests>**/OpenShift*IT.java</exclude.openshift.tests>
@@ -72,6 +75,72 @@
     </distributionManagement>
     <dependencyManagement>
         <dependencies>
+            <!--  TODO: remove kubernetes-client-bom and dekorate dependencies once we migrate to Quarkus 2.13  -->
+            <!-- START: kubernetes-client-bom and dekorate dependencies  -->
+            <dependency>
+                <groupId>io.fabric8</groupId>
+                <artifactId>kubernetes-client-bom</artifactId>
+                <version>${kubernetes-client.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.dekorate</groupId>
+                <artifactId>kubernetes-annotations</artifactId>
+                <version>${dekorate.version}</version>
+                <classifier>noapt</classifier>
+            </dependency>
+            <dependency>
+                <groupId>io.dekorate</groupId>
+                <artifactId>openshift-annotations</artifactId>
+                <version>${dekorate.version}</version>
+                <classifier>noapt</classifier>
+            </dependency>
+            <dependency>
+                <groupId>io.dekorate</groupId>
+                <artifactId>knative-annotations</artifactId>
+                <version>${dekorate.version}</version>
+                <classifier>noapt</classifier>
+            </dependency>
+            <dependency>
+                <groupId>io.dekorate</groupId>
+                <artifactId>servicebinding-annotations</artifactId>
+                <version>${dekorate.version}</version>
+                <classifier>noapt</classifier>
+            </dependency>
+            <dependency>
+                <groupId>io.dekorate</groupId>
+                <artifactId>helm-annotations</artifactId>
+                <version>${dekorate.version}</version>
+                <classifier>noapt</classifier>
+            </dependency>
+            <dependency>
+                <groupId>io.dekorate</groupId>
+                <artifactId>certmanager-annotations</artifactId>
+                <version>${dekorate.version}</version>
+                <classifier>noapt</classifier>
+            </dependency>
+            <dependency>
+                <groupId>io.dekorate</groupId>
+                <artifactId>s2i-annotations</artifactId>
+                <version>${dekorate.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.dekorate</groupId>
+                <artifactId>docker-annotations</artifactId>
+                <version>${dekorate.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.dekorate</groupId>
+                <artifactId>option-annotations</artifactId>
+                <version>${dekorate.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.dekorate</groupId>
+                <artifactId>dekorate-core</artifactId>
+                <version>${dekorate.version}</version>
+            </dependency>
+            <!-- END: kubernetes-client-bom and dekorate dependencies  -->
             <dependency>
                 <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>${quarkus.platform.artifact-id}</artifactId>


### PR DESCRIPTION
### Summary

`DefaultOpenShiftClient` has been [deprecated](https://developers.redhat.com/articles/2022/07/15/new-http-clients-java-generator-and-more-fabric8-600#other_improvements) in 6.1.1 and calling `adapt` is throwing `NoSuchMethodError` exception as you can see below:
```
java.lang.NoSuchMethodError: io.fabric8.openshift.client.NamespacedOpenShiftClient.adapt(Ljava/lang/Class;)Ljava/lang/Object;
```
Currently the Test Framework is using Quarkus 2.12.0.Final that provides `io.fabric8.kubernetes-client` in version `5.12.3`, however when running our TS with Quarkus 999-SNAPSHOT, `6.1.1` is used. We need to make our TFW compatible with 6.1.1, therefore I declare the version explicitly. It's necessary to use BOM as transitive dependencies are otherwise managed by the Quarkus 2.12.0.Final. In order to override Quarkus dependency management, I had to place the BOM to the `quarkus-test-kubernetes` and `quarkus-test-openshift`.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)