### PR TITLE
Use JDK17 as default native docker image

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -335,7 +335,7 @@ jobs:
       matrix:
         java: [ 11 ]
         quarkus-version: ["999-SNAPSHOT"]
-        graalvm-version: [ "22.2.0.java11"]
+        graalvm-version: [ "22.2.java17"]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/cache@v1

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftS2iGitRepositoryQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftS2iGitRepositoryQuarkusApplicationManagedResource.java
@@ -24,7 +24,7 @@ public class OpenShiftS2iGitRepositoryQuarkusApplicationManagedResource
     private static final String INTERNAL_MAVEN_REPOSITORY_PROPERTY = "${internal.s2i.maven.remote.repository}";
     private static final PropertyLookup MAVEN_REMOTE_REPOSITORY = new PropertyLookup("s2i.maven.remote.repository");
     private static final PropertyLookup QUARKUS_NATIVE_S2I_FROM_SRC = new PropertyLookup("s2i.openshift.base-native-image",
-            "quay.io/quarkus/ubi-quarkus-native-s2i:22.2-java11");
+            "quay.io/quarkus/ubi-quarkus-native-s2i:22.2-java17");
 
     private final GitRepositoryQuarkusApplicationManagedResourceBuilder model;
 


### PR DESCRIPTION
### Summary

Use JDK17 as the default native docker image

Please check the relevant options

- [X] Dependency update
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)