### PR TITLE
Make tests works with kubernetes-client 6.1.1 and 5.12.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,9 +49,6 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>2.12.0.Final</quarkus.platform.version>
-        <!--  TODO: once we migrate to Quarkus 2.13, delete 'kubernetes-client-bom' and 'dekorate' from dependency management (see below)  -->
-        <kubernetes-client.version>6.1.1</kubernetes-client.version>
-        <dekorate.version>3.0.0</dekorate.version>
         <exclude.tests.with.tags>quarkus-cli</exclude.tests.with.tags>
         <include.tests>**/*IT.java</include.tests>
         <exclude.openshift.tests>**/OpenShift*IT.java</exclude.openshift.tests>
@@ -75,72 +72,6 @@
     </distributionManagement>
     <dependencyManagement>
         <dependencies>
-            <!--  TODO: remove kubernetes-client-bom and dekorate dependencies once we migrate to Quarkus 2.13  -->
-            <!-- START: kubernetes-client-bom and dekorate dependencies  -->
-            <dependency>
-                <groupId>io.fabric8</groupId>
-                <artifactId>kubernetes-client-bom</artifactId>
-                <version>${kubernetes-client.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>io.dekorate</groupId>
-                <artifactId>kubernetes-annotations</artifactId>
-                <version>${dekorate.version}</version>
-                <classifier>noapt</classifier>
-            </dependency>
-            <dependency>
-                <groupId>io.dekorate</groupId>
-                <artifactId>openshift-annotations</artifactId>
-                <version>${dekorate.version}</version>
-                <classifier>noapt</classifier>
-            </dependency>
-            <dependency>
-                <groupId>io.dekorate</groupId>
-                <artifactId>knative-annotations</artifactId>
-                <version>${dekorate.version}</version>
-                <classifier>noapt</classifier>
-            </dependency>
-            <dependency>
-                <groupId>io.dekorate</groupId>
-                <artifactId>servicebinding-annotations</artifactId>
-                <version>${dekorate.version}</version>
-                <classifier>noapt</classifier>
-            </dependency>
-            <dependency>
-                <groupId>io.dekorate</groupId>
-                <artifactId>helm-annotations</artifactId>
-                <version>${dekorate.version}</version>
-                <classifier>noapt</classifier>
-            </dependency>
-            <dependency>
-                <groupId>io.dekorate</groupId>
-                <artifactId>certmanager-annotations</artifactId>
-                <version>${dekorate.version}</version>
-                <classifier>noapt</classifier>
-            </dependency>
-            <dependency>
-                <groupId>io.dekorate</groupId>
-                <artifactId>s2i-annotations</artifactId>
-                <version>${dekorate.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.dekorate</groupId>
-                <artifactId>docker-annotations</artifactId>
-                <version>${dekorate.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.dekorate</groupId>
-                <artifactId>option-annotations</artifactId>
-                <version>${dekorate.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.dekorate</groupId>
-                <artifactId>dekorate-core</artifactId>
-                <version>${dekorate.version}</version>
-            </dependency>
-            <!-- END: kubernetes-client-bom and dekorate dependencies  -->
             <dependency>
                 <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>${quarkus.platform.artifact-id}</artifactId>

--- a/quarkus-test-kubernetes/src/main/java/io/quarkus/test/bootstrap/inject/KubectlClient.java
+++ b/quarkus-test-kubernetes/src/main/java/io/quarkus/test/bootstrap/inject/KubectlClient.java
@@ -40,10 +40,9 @@ import io.fabric8.kubernetes.api.model.ServicePort;
 import io.fabric8.kubernetes.api.model.VolumeMount;
 import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.fabric8.kubernetes.client.utils.Serialization;
-import io.fabric8.openshift.client.OpenShiftClient;
+import io.fabric8.openshift.client.DefaultOpenShiftClient;
+import io.fabric8.openshift.client.NamespacedOpenShiftClient;
 import io.fabric8.openshift.client.OpenShiftConfig;
 import io.fabric8.openshift.client.OpenShiftConfigBuilder;
 import io.quarkus.test.bootstrap.Service;
@@ -68,22 +67,17 @@ public final class KubectlClient {
     private static final int HTTP_PORT_DEFAULT = 80;
 
     private final String currentNamespace;
-    private final KubernetesClient masterClient;
-    private final OpenShiftClient client;
+    private final DefaultOpenShiftClient masterClient;
+    private final NamespacedOpenShiftClient client;
     private final String scenarioId;
 
     private KubectlClient(String scenarioUniqueName) {
         this.scenarioId = scenarioUniqueName;
-        final String activeNamespace;
-        try (var client = new KubernetesClientBuilder().build()) {
-            activeNamespace = client.getNamespace();
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to create KubectlClient: ", e);
-        }
+        String activeNamespace = new DefaultOpenShiftClient().getNamespace();
         currentNamespace = ENABLED_EPHEMERAL_NAMESPACES.getAsBoolean() ? createNamespace() : activeNamespace;
         OpenShiftConfig config = new OpenShiftConfigBuilder().withTrustCerts(true).withNamespace(currentNamespace).build();
-        masterClient = new KubernetesClientBuilder().withConfig(config).build();
-        client = masterClient.adapt(OpenShiftClient.class);
+        masterClient = new DefaultOpenShiftClient(config);
+        client = masterClient.inNamespace(currentNamespace);
         setCurrentSessionNamespace(currentNamespace);
     }
 


### PR DESCRIPTION
### Summary

Our Test Framework uses final Quarkus version (currently 2.12) that is using `io.fabric8:kubernetes-client` in version `5.12.3`. However when we run tests with `999-SNAPSHOT`, version `6.1.1` is used. That causes issues as the framework was compiled with 5.12.3 and the two versions are not fully compatible. So far (I didn't run all the tests locally, we simply need to find out), only incompatibility that really bothers us is in the signature of `io.fabric8.kubernetes.client.Client#adapt` ([please see source code](https://github.com/fabric8io/kubernetes-client/blob/master/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/Client.java#L76)). Signature changes from `<C extends Client> C adapt(Class<C> var1)` to `<C> C adapt(Class<C> var1)` which is not really relevant for us.

This PR reverts https://github.com/quarkus-qe/quarkus-test-framework/pull/558 and invokes `adapt` with reflection.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)