### PR TITLE
Switch some GH builds to Java 17

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       matrix:
         quarkus-version: ["current"]
-        java: [ 11 ]
+        java: [ 11, 17 ]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/cache@v1
@@ -100,7 +100,7 @@ jobs:
     strategy:
       matrix:
         quarkus-version: ["999-SNAPSHOT"]
-        java: [ 11 ]
+        java: [ 11, 17 ]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/cache@v1
@@ -214,7 +214,7 @@ jobs:
     strategy:
       matrix:
         quarkus-version: ["current", "999-SNAPSHOT"]
-        java: [ 11 ]
+        java: [ 17 ]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/cache@v1
@@ -276,7 +276,7 @@ jobs:
     needs: quarkus-main-build
     strategy:
       matrix:
-        java: [ 11 ]
+        java: [ 11, 17 ]
         quarkus-version: ["999-SNAPSHOT"]
     steps:
       - uses: actions/checkout@v1
@@ -333,7 +333,7 @@ jobs:
     needs: quarkus-main-build
     strategy:
       matrix:
-        java: [ 11 ]
+        java: [ 17 ]
         quarkus-version: ["999-SNAPSHOT"]
         graalvm-version: [ "22.2.java17"]
     steps:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -66,7 +66,7 @@ jobs:
     strategy:
       matrix:
         quarkus-version: ["current"]
-        java: [ 11 ]
+        java: [ 17 ]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/cache@v1
@@ -118,7 +118,7 @@ jobs:
     strategy:
       matrix:
         quarkus-version: ["999-SNAPSHOT"]
-        java: [ 11 ]
+        java: [ 17 ]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/cache@v1


### PR DESCRIPTION
### Summary

Daily build: JVM builds with both 11 and 17, native builds with 17.
PR build: JVM Linux builds with 17, JVM Windows stays on 11.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)