### PR TITLE
Improve helm usability by adding new commands and shortcuts

### DIFF
--- a/examples/quarkus-helm/src/main/resources/application.properties
+++ b/examples/quarkus-helm/src/main/resources/application.properties
@@ -3,13 +3,10 @@
 quarkus.openshift.route.expose=true
 quarkus.kubernetes.ingress.expose=true
 
-# TODO https://github.com/quarkiverse/quarkus-helm/issues/41
-#quarkus.container-image.image=quay.io/quarkusqeteam/examples-quarkus-helm:v1
 quarkus.container-image.registry=quay.io
 quarkus.container-image.group=quarkusqeteam
 quarkus.container-image.name=examples-quarkus-helm
 quarkus.container-image.tag=v1
-
-quarkus.kubernetes.host=examples-quarkus-helm.apps.ocp4-10.dynamic.quarkus
+quarkus.helm.version=v1
 quarkus.container-image.builder=docker
 

--- a/examples/quarkus-helm/src/test/java/io/quarkus/qe/helm/CommonHelmScenarios.java
+++ b/examples/quarkus-helm/src/test/java/io/quarkus/qe/helm/CommonHelmScenarios.java
@@ -42,13 +42,12 @@ public abstract class CommonHelmScenarios {
                 .then().statusCode(200)
                 .body(is("Hello World!"));
 
-        List<QuarkusHelmClient.ChartListResult> charts = helmClient.getCharts();
-        assertTrue(charts.size() > 0, "Chart " + chartName + " not found. Installation fail");
-        List<String> chartNames = charts.stream()
-                .map(QuarkusHelmClient.ChartListResult::getName)
-                .map(String::trim)
-                .collect(Collectors.toList());
+        List<String> chartNames = helmClient.getChartsNames(chartName);
+        assertTrue(chartNames.size() > 0, "Chart " + chartName + " not found. Installation fail");
         assertThat(chartNames.toArray(), hasItemInArray(chartName));
+
+        assertTrue(helmClient.chartDependencyUpdate(chartFolderName).isSuccessful());
+        assertTrue(helmClient.chartDependencyBuild(chartFolderName).isSuccessful());
     }
 
     @Test

--- a/examples/quarkus-helm/src/test/java/io/quarkus/qe/helm/KubernetesQuarkusHelmClientIT.java
+++ b/examples/quarkus-helm/src/test/java/io/quarkus/qe/helm/KubernetesQuarkusHelmClientIT.java
@@ -3,15 +3,13 @@ package io.quarkus.qe.helm;
 import javax.inject.Inject;
 
 import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Tag;
 
 import io.quarkus.test.bootstrap.QuarkusHelmClient;
 import io.quarkus.test.scenarios.KubernetesScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 
-@Tag("quarkus-helm")
 @KubernetesScenario
-//TODO https://github.com/quarkiverse/quarkus-helm/issues/48
+//TODO OCP user can't create a k8s namespace
 @Disabled
 @DisabledOnNative // Helm is concerned just about image name, Native compilation is not relevant
 public class KubernetesQuarkusHelmClientIT extends CommonHelmScenarios {

--- a/examples/quarkus-helm/src/test/java/io/quarkus/qe/helm/OpenShiftQuarkusHelmClientIT.java
+++ b/examples/quarkus-helm/src/test/java/io/quarkus/qe/helm/OpenShiftQuarkusHelmClientIT.java
@@ -2,18 +2,12 @@ package io.quarkus.qe.helm;
 
 import javax.inject.Inject;
 
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Tag;
-
 import io.quarkus.test.bootstrap.QuarkusHelmClient;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 
-@Tag("quarkus-helm")
 @OpenShiftScenario
 @DisabledOnNative // Helm is concerned just about image name, Native compilation is not relevant
-//TODO https://github.com/quarkiverse/quarkus-helm/issues/48
-@Disabled
 public class OpenShiftQuarkusHelmClientIT extends CommonHelmScenarios {
 
     @Inject

--- a/examples/quarkus-helm/src/test/java/io/quarkus/qe/helm/QuarkusHelmFileClientIT.java
+++ b/examples/quarkus-helm/src/test/java/io/quarkus/qe/helm/QuarkusHelmFileClientIT.java
@@ -9,7 +9,6 @@ import java.nio.file.Paths;
 import javax.inject.Inject;
 
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -19,7 +18,6 @@ import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
 
-@Tag("quarkus-helm")
 @QuarkusScenario
 @DisabledOnQuarkusVersion(version = "1\\..*", reason = "Quarkus Helm not supported")
 @DisabledOnOs(OS.WINDOWS)

--- a/examples/quarkus-helm/src/test/java/io/quarkus/qe/helm/QuarkusKubernetesHelmClientIT.java
+++ b/examples/quarkus-helm/src/test/java/io/quarkus/qe/helm/QuarkusKubernetesHelmClientIT.java
@@ -8,7 +8,6 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.QuarkusHelmClient;
@@ -16,7 +15,6 @@ import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
 
-@Tag("quarkus-helm")
 @QuarkusScenario
 @DisabledOnQuarkusVersion(version = "1\\..*", reason = "Quarkus Helm not supported")
 @DisabledOnNative // Helm is concerned just about image name, Native compilation is not relevant

--- a/examples/quarkus-helm/src/test/java/io/quarkus/qe/helm/QuarkusOpenShiftHelmClientIT.java
+++ b/examples/quarkus-helm/src/test/java/io/quarkus/qe/helm/QuarkusOpenShiftHelmClientIT.java
@@ -7,7 +7,6 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.QuarkusHelmClient;
@@ -15,7 +14,6 @@ import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
 
-@Tag("quarkus-helm")
 @QuarkusScenario
 @DisabledOnQuarkusVersion(version = "1\\..*", reason = "Quarkus Helm not supported")
 @DisabledOnNative // Helm is concerned just about image name, Native compilation is not relevant

--- a/quarkus-test-helm/src/main/java/io/quarkus/test/bootstrap/QuarkusHelmClient.java
+++ b/quarkus-test-helm/src/main/java/io/quarkus/test/bootstrap/QuarkusHelmClient.java
@@ -109,6 +109,22 @@ public class QuarkusHelmClient {
         return chartList;
     }
 
+    public List<String> getChartsNames(String chartName) {
+        List<QuarkusHelmClient.ChartListResult> charts = getCharts();
+        return charts.stream()
+                .map(QuarkusHelmClient.ChartListResult::getName)
+                .map(String::trim)
+                .collect(Collectors.toList());
+    }
+
+    public Result chartDependencyUpdate(String chartFullPath) {
+        return runCliAndWait("dependency", "update", chartFullPath);
+    }
+
+    public Result chartDependencyBuild(String chartFullPath) {
+        return runCliAndWait("dependency", "build", chartFullPath);
+    }
+
     public Map<String, Object> getChartValues(String chartFolderPath) throws FileNotFoundException {
         return getRawYaml("values.yaml", chartFolderPath);
     }


### PR DESCRIPTION
### Summary

- HelmClient `getChartsNames` method was created as a Shortcut method in order to retrieve current chartsNames
- HelmClient `chartDependencyUpdate` and `chartDependencyBuild` was added as new supported helmClient methods.
- Re-Enable `OpenShiftQuarkusHelmClientIT` scenario
- `quarkus-helm"` Tag was used at the beginning in order to enable/disable these tests if a specific `profile/tags` was enabled (currently, we are doing something like this in Quarkus-cli scenario). However, Quarkus-helm is not ignored anymore and always are going to be triggered, so this tag is not required anymore 

Please check the relevant options

- [X] New feature (non-breaking change which adds functionality)
- [X] Refactoring

### Checklist:
- [X] Example scenarios has been updated / added
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)