### PR TITLE
Daily native image version should be 22.2.0.java17 not 22.2.java17

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -335,7 +335,7 @@ jobs:
       matrix:
         java: [ 17 ]
         quarkus-version: ["999-SNAPSHOT"]
-        graalvm-version: [ "22.2.java17"]
+        graalvm-version: [ "22.2.0.java17"]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/cache@v1


### PR DESCRIPTION
### Summary

Daily native issue fix.

Please check the relevant options

- [X] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [X] Example scenarios has been updated / added
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)