### PR TITLE
Fix OpenShiftClient failures

### DIFF
--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/ExtensionOpenShiftQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/ExtensionOpenShiftQuarkusApplicationManagedResource.java
@@ -113,6 +113,10 @@ public class ExtensionOpenShiftQuarkusApplicationManagedResource
         args.add(withContainerImageGroup(namespace));
         args.add(withLabelsForWatching());
         args.add(withLabelsForScenarioId());
+
+        // TODO: remove once https://github.com/quarkusio/quarkus/issues/28108 is fixed
+        args.add(withJarFileName());
+
         withEnvVars(args);
         withBaseImageProperties(args);
         withAdditionalArguments(args);
@@ -160,6 +164,10 @@ public class ExtensionOpenShiftQuarkusApplicationManagedResource
 
     private String withContainerName() {
         return withProperty(QUARKUS_CONTAINER_NAME, model.getContext().getName());
+    }
+
+    private String withJarFileName() {
+        return withProperty("quarkus.openshift.jar-file-name", "quarkus-run.jar");
     }
 
     private String withContainerImageGroup(String namespace) {


### PR DESCRIPTION
### Summary

This PR does 2 things (blimey) in 2 commits (so we could independently revert them):
- There has been ongoing issues when we are selecting `OpenShiftClient` method that we want to invoke. You can reproduce it f.e. with `mvn clean verify -Dit.test=OpenShiftApiServerConfigSecretConfigIT -Dopenshift -Dquarkus.openshift.jar-file-name=quarkus-run.jar -f config/` in Quarkus Test Suite project. I run several tests and the solution you suggested in previous PR was a right way to go. I made mistake not to accept it. Now, method is chosen based on param's class assignability.

- Works around https://github.com/quarkusio/quarkus/issues/28108 by setting JAR file name explicitly. The issue is both in TFW (f.e. `OpenShiftUsingExtensionComputedValuesUsingCustomPropertiesPingPongResourceIT`) and TS whenever `OpenShiftDeploymentStrategy.UsingOpenShiftExtension` is used.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)