### PR TITLE
Make OpenShift service expose configurable

### DIFF
--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/BuildOpenShiftQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/BuildOpenShiftQuarkusApplicationManagedResource.java
@@ -1,6 +1,5 @@
 package io.quarkus.test.services.quarkus;
 
-import static io.quarkus.test.services.quarkus.QuarkusApplicationManagedResourceBuilder.HTTP_PORT_DEFAULT;
 import static io.quarkus.test.services.quarkus.model.QuarkusProperties.QUARKUS_JVM_S2I;
 import static io.quarkus.test.services.quarkus.model.QuarkusProperties.QUARKUS_NATIVE_S2I;
 import static java.util.regex.Pattern.quote;
@@ -43,10 +42,6 @@ public class BuildOpenShiftQuarkusApplicationManagedResource
                 StringUtils.substringBeforeLast(s2iImage, IMAGE_TAG_SEPARATOR))
                 .replaceAll(quote("${QUARKUS_S2I_IMAGE_BUILDER_VERSION}"), s2iVersion)
                 .replaceAll(quote("${ARTIFACT}"), model.getArtifact().getFileName().toString());
-    }
-
-    private void exposeServices() {
-        client.expose(model.getContext().getOwner(), HTTP_PORT_DEFAULT);
     }
 
     private void startBuild() {

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/ContainerRegistryOpenShiftQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/ContainerRegistryOpenShiftQuarkusApplicationManagedResource.java
@@ -1,6 +1,5 @@
 package io.quarkus.test.services.quarkus;
 
-import static io.quarkus.test.services.quarkus.QuarkusApplicationManagedResourceBuilder.HTTP_PORT_DEFAULT;
 import static java.util.regex.Pattern.quote;
 
 import io.quarkus.test.utils.DockerUtils;
@@ -32,10 +31,6 @@ public class ContainerRegistryOpenShiftQuarkusApplicationManagedResource
     protected String replaceDeploymentContent(String content) {
         return content.replaceAll(quote("${IMAGE}"), image)
                 .replaceAll(quote("${ARTIFACT}"), model.getArtifact().getFileName().toString());
-    }
-
-    private void exposeServices() {
-        client.expose(model.getContext().getOwner(), HTTP_PORT_DEFAULT);
     }
 
     private String createImageAndPush() {

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/TemplateOpenShiftQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/TemplateOpenShiftQuarkusApplicationManagedResource.java
@@ -1,5 +1,6 @@
 package io.quarkus.test.services.quarkus;
 
+import static io.quarkus.test.services.quarkus.QuarkusApplicationManagedResourceBuilder.HTTP_PORT_DEFAULT;
 import static java.util.regex.Pattern.quote;
 
 import java.util.Collections;
@@ -12,6 +13,11 @@ import io.quarkus.test.logging.Log;
 public abstract class TemplateOpenShiftQuarkusApplicationManagedResource<T extends QuarkusApplicationManagedResourceBuilder>
         extends OpenShiftQuarkusApplicationManagedResource<T> {
 
+    /**
+     * Configuration property that turns on/off service exposure.
+     * If property is not set at all, service is going to be exposed.
+     */
+    private static final String EXPOSE_SERVICE = "openshift.expose-service";
     private static final String DEPLOYMENT_SERVICE_PROPERTY = "openshift.service";
     private static final String DEPLOYMENT_TEMPLATE_PROPERTY = "openshift.template";
     private static final String DEPLOYMENT = "openshift.yml";
@@ -33,6 +39,13 @@ public abstract class TemplateOpenShiftQuarkusApplicationManagedResource<T exten
     protected void doInit() {
         applyTemplate();
         awaitForImageStreams();
+    }
+
+    protected void exposeServices() {
+        final String shouldExposeServiceStr = model.getContext().getOwner().getConfiguration().get(EXPOSE_SERVICE);
+        if (shouldExposeServiceStr == null || Boolean.parseBoolean(shouldExposeServiceStr)) {
+            client.expose(model.getContext().getOwner(), HTTP_PORT_DEFAULT);
+        }
     }
 
     @Override


### PR DESCRIPTION
### Summary

Now it's not possible to deploy app to OpenShift using existing deployment strategies without exposing service, however sometimes you need more sophisticated route to expose/or you don't want to expose service at all. In my case, I'm deploying Quarkus serverless function that exist within Knative eventing namespace and I'm need to communicate only with broker, not this service (so far, I didn't even found a way to expose it and I don't think it's desirable). This PR adds flag that allows you to disable exposing service like this:

`ts.app.openshift.expose-service=false`

If the property is not set, nothing changed at all. I also merged two identical methods into one (refactoring part).

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)