### PR TITLE
Bump Quarkus-helm to 0.0.7 and Quarkus platform to 2.13.0.Final

### DIFF
--- a/examples/quarkus-helm/pom.xml
+++ b/examples/quarkus-helm/pom.xml
@@ -10,7 +10,7 @@
     <artifactId>examples-quarkus-helm</artifactId>
     <name>Quarkus - Test Framework - Examples - Quarkus HELM</name>
     <properties>
-        <quarkus-helm.version>0.0.6</quarkus-helm.version>
+        <quarkus-helm.version>0.0.7</quarkus-helm.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <htmlunit.version>2.64.0</htmlunit.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.13.0.CR1</quarkus.platform.version>
+        <quarkus.platform.version>2.13.0.Final</quarkus.platform.version>
         <exclude.tests.with.tags>quarkus-cli</exclude.tests.with.tags>
         <include.tests>**/*IT.java</include.tests>
         <exclude.openshift.tests>**/OpenShift*IT.java</exclude.openshift.tests>


### PR DESCRIPTION
### Summary

Quarkus-helm 0.0.7 requires Quarkus 2.13.0.Final

Please check the relevant options
- [X] Dependency update


### Checklist:
- [X] Example scenarios has been updated / added
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)