### PR TITLE
Add Funqy Knative Events Function service

### DIFF
--- a/examples/funqy-knative-events/pom.xml
+++ b/examples/funqy-knative-events/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus.qe</groupId>
+        <artifactId>quarkus-test-parent</artifactId>
+        <version>1.2.1.Beta12-SNAPSHOT</version>
+        <relativePath>../../</relativePath>
+    </parent>
+    <artifactId>examples-funqy-knative-events</artifactId>
+    <packaging>jar</packaging>
+    <name>Quarkus - Test Framework - Examples - Funqy - Knative Events</name>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-funqy-knative-events</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-openshift</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client-reactive-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus.qe</groupId>
+            <artifactId>quarkus-test-knative-events-spi</artifactId>
+        </dependency>
+        <!--  FIXME: drop 'openshift-client' and 'knative-client' deps once we migrate to Quarkus 2.14  -->
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>openshift-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>knative-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus.qe</groupId>
+            <artifactId>quarkus-test-knative-events</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>${quarkus.platform.group-id}</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <version>${quarkus.platform.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/funqy-knative-events/src/main/java/io/quarkus/qe/funqy/knativeevents/BrokerClient.java
+++ b/examples/funqy-knative-events/src/main/java/io/quarkus/qe/funqy/knativeevents/BrokerClient.java
@@ -1,0 +1,49 @@
+package io.quarkus.qe.funqy.knativeevents;
+
+import java.util.UUID;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+
+import org.eclipse.microprofile.rest.client.annotation.ClientHeaderParam;
+import org.eclipse.microprofile.rest.client.annotation.RegisterClientHeaders;
+import org.eclipse.microprofile.rest.client.ext.ClientHeadersFactory;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+/**
+ * BrokerClient enables sending of events to the broker.
+ */
+@Consumes("application/json")
+@Produces("application/json")
+@Path("/")
+@RegisterRestClient(configKey = "broker")
+@RegisterClientHeaders(BrokerClient.RequestUUIDHeaderFactory.class)
+public interface BrokerClient {
+
+    @POST
+    @ClientHeaderParam(name = "ce-specversion", value = "1.0")
+    @ClientHeaderParam(name = "ce-source", value = "test")
+    void forwardEventToBroker(@HeaderParam("ce-type") String ceType, String data);
+
+    /**
+     * Adds a unique id of the event as 'ce-id' header parameter.
+     */
+    @ApplicationScoped
+    class RequestUUIDHeaderFactory implements ClientHeadersFactory {
+
+        @Override
+        public MultivaluedMap<String, String> update(MultivaluedMap<String, String> incomingHeaders,
+                MultivaluedMap<String, String> clientOutgoingHeaders) {
+            MultivaluedMap<String, String> result = new MultivaluedHashMap<>();
+            clientOutgoingHeaders.forEach(result::addAll);
+            result.add("ce-id", UUID.randomUUID().toString());
+            return result;
+        }
+    }
+}

--- a/examples/funqy-knative-events/src/main/java/io/quarkus/qe/funqy/knativeevents/SimpleFunctionChain.java
+++ b/examples/funqy-knative-events/src/main/java/io/quarkus/qe/funqy/knativeevents/SimpleFunctionChain.java
@@ -1,0 +1,92 @@
+package io.quarkus.qe.funqy.knativeevents;
+
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.jboss.logging.Logger;
+
+import io.quarkus.funqy.Context;
+import io.quarkus.funqy.Funq;
+import io.quarkus.funqy.knative.events.CloudEvent;
+import io.quarkus.funqy.knative.events.CloudEventMapping;
+import io.quarkus.test.services.knative.eventing.spi.CompoundResponse.StringCompoundResponse;
+import io.quarkus.test.services.knative.eventing.spi.ForwardRequestDTO;
+import io.quarkus.test.services.knative.eventing.spi.ForwardResponseDTO;
+
+/**
+ * Funqy Knative Events Quickstart with additional function that forwards payload to the broker and collect responses.
+ */
+public class SimpleFunctionChain {
+    private static final Logger LOG = Logger.getLogger(SimpleFunctionChain.class);
+    private static final int EXPECTED_NUMBER_OF_RESPONSES = 4;
+    private static volatile StringCompoundResponse compoundResponse = null;
+
+    @RestClient
+    BrokerClient brokerClient;
+
+    /**
+     * Expects knative event of type "defaultChain". Creates event of type "defaultChain.output".
+     *
+     * This function is triggered by an external curl invocation.
+     *
+     * @param input
+     * @return
+     */
+    @Funq
+    public String defaultChain(String input) {
+        LOG.info("*** defaultChain ***");
+        compoundResponse.recordVisit();
+        return input + "::" + "defaultChain";
+    }
+
+    /**
+     * This is triggered by defaultChain and is example of using application.properties to
+     * map the cloud event to this function and to map response. Response will trigger
+     * the annotatedChain function.
+     *
+     * @param input
+     * @return
+     */
+    @Funq
+    public String configChain(String input) {
+        LOG.info("*** configChain ***");
+        compoundResponse.recordVisit();
+        return input + "::" + "configChain";
+    }
+
+    /**
+     * Triggered by configChain output.
+     *
+     * Example of mapping the cloud event via an annotation.
+     *
+     * @param input
+     * @return
+     */
+    @Funq
+    @CloudEventMapping(trigger = "annotated", responseSource = "annotated", responseType = "lastChainLink")
+    public String annotatedChain(String input) {
+        LOG.info("*** annotatedChain ***");
+        compoundResponse.recordVisit();
+        return input + "::" + "annotatedChain";
+    }
+
+    /**
+     * Last event in chain. Has no output. Triggered by annotatedChain.
+     *
+     * @param input
+     */
+    @Funq
+    public void lastChainLink(String input, @Context CloudEvent event) {
+        LOG.info("*** lastChainLink ***");
+        compoundResponse.recordResponse(input + "::" + "lastChainLink");
+    }
+
+    /**
+     * Forward event to the broker and wait for chain responses.
+     */
+    @Funq
+    public ForwardResponseDTO<String> clusterEntrypoint(ForwardRequestDTO<String> requestDTO) {
+        compoundResponse = new StringCompoundResponse(EXPECTED_NUMBER_OF_RESPONSES);
+        brokerClient.forwardEventToBroker(requestDTO.getFilterCloudEventType(), requestDTO.getData());
+        return compoundResponse.waitForResponses().join();
+    }
+
+}

--- a/examples/funqy-knative-events/src/main/resources/application.properties
+++ b/examples/funqy-knative-events/src/main/resources/application.properties
@@ -1,0 +1,5 @@
+quarkus.funqy.knative-events.mapping.configChain.trigger=defaultChain.output
+quarkus.funqy.knative-events.mapping.configChain.response-type=annotated
+quarkus.funqy.knative-events.mapping.configChain.response-source=configChain
+quarkus.rest-client.broker.url=${BROKER_URL:http://localhost:8080}
+quarkus.rest-client.broker.scope=javax.inject.Singleton

--- a/examples/funqy-knative-events/src/test/java/io/quarkus/qe/funqy/knativeevents/OpenShiftUsingExtensionAndServerlessFunqyKnEventsIT.java
+++ b/examples/funqy-knative-events/src/test/java/io/quarkus/qe/funqy/knativeevents/OpenShiftUsingExtensionAndServerlessFunqyKnEventsIT.java
@@ -1,0 +1,69 @@
+package io.quarkus.qe.funqy.knativeevents;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.hamcrest.Matcher;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
+import io.quarkus.test.scenarios.OpenShiftScenario;
+import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.test.services.knative.eventing.FunqyKnativeEventsService;
+import io.quarkus.test.services.knative.eventing.OpenShiftExtensionFunqyKnativeEventsService;
+
+@OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
+public class OpenShiftUsingExtensionAndServerlessFunqyKnEventsIT {
+
+    private static final String INVOKED_FUNCTION = "defaultChain";
+    private static final String DATA = "\"Start\"";
+    private static final Matcher<String> EXPECTED_RESULT_MATCHER = equalTo(
+            "Start::defaultChain::configChain::annotatedChain::lastChainLink");
+
+    @QuarkusApplication
+    static FunqyKnativeEventsService service = new OpenShiftExtensionFunqyKnativeEventsService()
+            .withDefaultBroker()
+            .withTrigger().name("annotatedchain").defaultBroker().filterCloudEventType("annotated").endTrigger()
+            .withTrigger().name("configChain").defaultBroker().filterCloudEventType("defaultChain.output").endTrigger()
+            .withTrigger().name("defaultchain").defaultBroker().filterCloudEventType("defaultChain").endTrigger()
+            .withTrigger().name("lastchainlink").defaultBroker().filterCloudEventType("lastChainLink").endTrigger();
+
+    @Test
+    public void simpleFunctionChainCloudEventGetTest() {
+        final String actualResponse = service
+                .<String> funcInvoker()
+                .cloudEventType(INVOKED_FUNCTION)
+                .data(DATA)
+                .appCloudEventsPlusJsonContentType()
+                .get()
+                .getResponse()
+                .jsonPath()
+                .get("data.response")
+                .toString();
+        assertTrue(EXPECTED_RESULT_MATCHER.matches(actualResponse));
+    }
+
+    @Test
+    public void simpleFunctionChainHttpPostTest() {
+        service
+                .<String> funcInvoker()
+                .appJsonContentType()
+                .cloudEventType(INVOKED_FUNCTION)
+                .data(DATA)
+                .post()
+                .assertBody(EXPECTED_RESULT_MATCHER);
+    }
+
+    @Test
+    public void simpleFunctionChainCloudEventTest() {
+        service
+                .<String> funcInvoker()
+                .appJsonContentType()
+                .cloudEventType(INVOKED_FUNCTION)
+                .data(DATA)
+                .asCloudEventObject()
+                .post()
+                .assertBody(EXPECTED_RESULT_MATCHER);
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,21 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus.qe</groupId>
+                <artifactId>quarkus-test-knative-events</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus.qe</groupId>
+                <artifactId>quarkus-test-knative-events-spi</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus.qe</groupId>
+                <artifactId>quarkus-test-knative-events-parent</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus.qe</groupId>
                 <artifactId>quarkus-test-kubernetes</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -347,6 +362,7 @@
                 <module>quarkus-test-images</module>
                 <module>quarkus-test-kubernetes</module>
                 <module>quarkus-test-openshift</module>
+                <module>quarkus-test-knative-events</module>
                 <module>quarkus-test-service-consul</module>
                 <module>quarkus-test-service-keycloak</module>
                 <module>quarkus-test-service-kafka</module>
@@ -385,6 +401,7 @@
                 <module>examples/database-postgresql</module>
                 <module>examples/database-oracle</module>
                 <module>examples/external-applications</module>
+                <module>examples/funqy-knative-events</module>
             </modules>
         </profile>
         <profile>

--- a/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/BaseService.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/BaseService.java
@@ -34,8 +34,8 @@ public class BaseService<T extends Service> implements Service {
     private static final String SERVICE_STARTUP_CHECK_POLL_INTERVAL = "startup.check-poll-interval";
     private static final Duration SERVICE_STARTUP_CHECK_POLL_INTERVAL_DEFAULT = Duration.ofSeconds(2);
 
+    protected ServiceContext context;
     private final ServiceLoader<ServiceListener> listeners = ServiceLoader.load(ServiceListener.class);
-
     private final List<Action> onPreStartActions = new LinkedList<>();
     private final List<Action> onPostStartActions = new LinkedList<>();
     private final Map<String, String> properties = new HashMap<>();
@@ -45,7 +45,6 @@ public class BaseService<T extends Service> implements Service {
     private ManagedResource managedResource;
     private String serviceName;
     private Configuration configuration;
-    private ServiceContext context;
     private boolean autoStart = true;
 
     @Override

--- a/quarkus-test-knative-events/pom.xml
+++ b/quarkus-test-knative-events/pom.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus.qe</groupId>
+        <artifactId>quarkus-test-parent</artifactId>
+        <version>1.2.1.Beta12-SNAPSHOT</version>
+    </parent>
+    <artifactId>quarkus-test-knative-events-parent</artifactId>
+    <name>Quarkus - Test Framework - Knative Events - Parent</name>
+    <packaging>pom</packaging>
+    <modules>
+        <module>root</module>
+        <module>spi</module>
+    </modules>
+</project>

--- a/quarkus-test-knative-events/root/pom.xml
+++ b/quarkus-test-knative-events/root/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus.qe</groupId>
+        <artifactId>quarkus-test-knative-events-parent</artifactId>
+        <version>1.2.1.Beta12-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <artifactId>quarkus-test-knative-events</artifactId>
+    <name>Quarkus - Test Framework - Knative Events</name>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus.qe</groupId>
+            <artifactId>quarkus-test-knative-events-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus.qe</groupId>
+            <artifactId>quarkus-test-openshift</artifactId>
+            <!--  FIXME: drop exclusions once we migrate to Quarkus 2.14  -->
+            <exclusions>
+                <exclusion>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>openshift-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>knative-client</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!--  this works around conflict between 2.13 and 999-SNAPSHOT  -->
+        <!--  FIXME drop section below once we migrate to Quarkus 2.14  -->
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>openshift-client</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>knative-client</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/quarkus-test-knative-events/root/src/main/java/io/quarkus/test/services/knative/eventing/FunqyKnativeEventsService.java
+++ b/quarkus-test-knative-events/root/src/main/java/io/quarkus/test/services/knative/eventing/FunqyKnativeEventsService.java
@@ -1,0 +1,428 @@
+package io.quarkus.test.services.knative.eventing;
+
+import static java.util.Objects.requireNonNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.eclipse.jetty.http.HttpStatus;
+import org.hamcrest.Matcher;
+
+import io.fabric8.knative.client.KnativeClient;
+import io.fabric8.knative.eventing.v1.Broker;
+import io.fabric8.knative.eventing.v1.BrokerBuilder;
+import io.fabric8.knative.eventing.v1.Trigger;
+import io.fabric8.kubernetes.client.Watch;
+import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.WatcherException;
+import io.quarkus.test.bootstrap.BaseService;
+import io.quarkus.test.bootstrap.OpenShiftExtensionBootstrap;
+import io.quarkus.test.bootstrap.inject.OpenShiftClient;
+import io.quarkus.test.services.knative.eventing.spi.ForwardRequestDTO;
+import io.quarkus.test.services.knative.eventing.spi.ForwardResponseDTO;
+import io.quarkus.test.utils.AwaitilityUtils;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+import io.restassured.specification.RequestSpecification;
+
+/**
+ * Represents service with one or more Funqy functions within a Knative Events environment.
+ */
+public class FunqyKnativeEventsService extends BaseService<FunqyKnativeEventsService> {
+
+    private static final String CLUSTER_ENTRYPOINT_PATH = "clusterEntrypoint";
+    private static final String DEFAULT_BROKER_NAME = "default";
+    private static final String READY = "Ready";
+    private final Set<TriggerBuilder> triggerBuilders = new HashSet<>();
+    private Broker broker;
+    private Trigger[] triggers = null;
+    private KnativeClient knativeClient;
+
+    public FunqyKnativeEventsService() {
+        super();
+        createBrokerAndBuildTriggersOnPreStart();
+        createTriggersOnPostStart();
+        // delete brokers and triggers on shutdown
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            deleteTriggers();
+            deleteBroker();
+        }));
+    }
+
+    private void deleteBroker() {
+        // FIXME: check delete result once we migrate to Quarkus 2.14 (see below)
+        getKnClient().brokers().delete(broker);
+    }
+
+    private void deleteTriggers() {
+        if (triggers != null && triggers.length > 0) {
+            for (Trigger trigger : triggers) {
+                getKnClient().triggers().delete(trigger);
+                // FIXME: for compatibility reasons between Kubernetes-client 6.1.1 (used by 999-SNAPSHOT)
+                //  and 5.12.3 (used by latest final 2.13) we don't check delete result;
+                //  we should do that once we migrate to 2.14
+            }
+        }
+    }
+
+    private KnativeClient getKnClient() {
+        if (knativeClient == null) {
+            knativeClient = context.<OpenShiftClient> get(OpenShiftExtensionBootstrap.CLIENT).getKnClient();
+        }
+        return knativeClient;
+    }
+
+    private void buildTriggers(String serviceName) {
+        triggers = triggerBuilders
+                .stream()
+                .map(triggerBuilder -> triggerBuilder.build(serviceName))
+                .toArray(Trigger[]::new);
+    }
+
+    public FunqyKnativeEventsService withDefaultBroker() {
+        return withBroker(DEFAULT_BROKER_NAME);
+    }
+
+    public FunqyKnativeEventsService withBroker(String brokerName) {
+
+        if (broker != null) {
+            throw new RuntimeException("Broker has already been defined. Only one broker is supported");
+        }
+
+        broker = new BrokerBuilder()
+                .withNewMetadata()
+                .withName(brokerName)
+                .endMetadata()
+                .build();
+        return this;
+    }
+
+    public TriggerBuilder withTrigger() {
+        return new TriggerBuilder(this);
+    }
+
+    private void createBrokerAndBuildTriggersOnPreStart() {
+        onPreStart(service -> {
+
+            // we can only build triggers once we know service name
+            buildTriggers(getName());
+
+            // at least one broker must be created
+            if (broker == null) {
+                fail(FunqyKnativeEventsService.class.getName() + " - You must configure exactly one Knative broker.");
+            }
+
+            // set broker URL reachable within cluster, so that rest client can forward our requests to broker
+            withProperty("broker-url", String.format("http://broker-ingress.knative-eventing.svc.cluster.local/%s/%s",
+                    getKnClient().getNamespace(), broker.getMetadata().getName()));
+
+            // create broker
+            broker = getKnClient().brokers().create(broker);
+            // wait until the broker is ready
+            final AtomicBoolean isBrokerReady = new AtomicBoolean(false);
+            // access events as long as the broker is not ready, or we run out of time
+            try (var ignored = watchBrokerEventsTillItsReady(broker.getMetadata().getName(), isBrokerReady)) {
+                AwaitilityUtils.untilIsTrue(isBrokerReady::get);
+            }
+        });
+    }
+
+    /**
+     * Triggers must be created once Knative service is ready.
+     */
+    private void createTriggersOnPostStart() {
+        onPostStart(service -> {
+            // at least one trigger must be created
+            if (triggers == null || triggers.length == 0) {
+                fail(FunqyKnativeEventsService.class.getName() + " - You must configure at least one trigger.");
+            }
+
+            for (int i = 0; i < triggers.length; i++) {
+                // create trigger
+                triggers[i] = getKnClient().triggers().create(triggers[i]);
+                // wait until the trigger is ready
+                final AtomicBoolean isTriggerReady = new AtomicBoolean(false);
+                // access events as long as the trigger is not ready, or we run out of time
+                try (var ignored = watchTriggerEventsTillItsReady(triggers[i].getMetadata().getName(), isTriggerReady)) {
+                    AwaitilityUtils.untilIsTrue(isTriggerReady::get);
+                }
+            }
+        });
+    }
+
+    private Watch watchBrokerEventsTillItsReady(String brokerName, AtomicBoolean isBrokerReady) {
+        return getKnClient()
+                .brokers()
+                .watch(new Watcher<>() {
+                    @Override
+                    public void eventReceived(Action action, Broker broker1) {
+                        if (isOurBroker(broker1) && hasStatus(broker1)) {
+                            isBrokerReady.set(isBrokerReady(broker1));
+                        }
+                    }
+
+                    private boolean isBrokerReady(Broker broker) {
+                        return broker
+                                .getStatus()
+                                .getConditions()
+                                .stream()
+                                .anyMatch(condition -> READY.equals(condition.getType())
+                                        && Boolean.parseBoolean(condition.getStatus()));
+                    }
+
+                    private boolean hasStatus(Broker broker) {
+                        return broker.getStatus() != null && broker.getStatus().getConditions() != null
+                                && !broker.getStatus().getConditions().isEmpty();
+                    }
+
+                    private boolean isOurBroker(Broker broker) {
+                        return broker != null && brokerName.equals(broker.getMetadata().getName());
+                    }
+
+                    @Override
+                    public void onClose(WatcherException e) {
+                        fail("Broker '%s' state can't be retrieved.", e);
+                    }
+                });
+    }
+
+    private Watch watchTriggerEventsTillItsReady(String triggerName, AtomicBoolean isTriggerReady) {
+        return getKnClient()
+                .triggers()
+                .watch(new Watcher<>() {
+                    @Override
+                    public void eventReceived(Action action, Trigger trigger) {
+                        if (isOurTrigger(trigger) && hasStatus(trigger)) {
+                            isTriggerReady.set(isTriggerReady(trigger));
+                        }
+                    }
+
+                    private boolean isTriggerReady(Trigger trigger) {
+                        return trigger
+                                .getStatus()
+                                .getConditions()
+                                .stream()
+                                .anyMatch(condition -> READY.equals(condition.getType())
+                                        && Boolean.parseBoolean(condition.getStatus()));
+                    }
+
+                    private boolean hasStatus(Trigger trigger) {
+                        return trigger.getStatus() != null && trigger.getStatus().getConditions() != null
+                                && !trigger.getStatus().getConditions().isEmpty();
+                    }
+
+                    private boolean isOurTrigger(Trigger trigger) {
+                        return trigger != null && triggerName.equals(trigger.getMetadata().getName());
+                    }
+
+                    @Override
+                    public void onClose(WatcherException e) {
+                        fail("Trigger '%s' state can't be retrieved.", e);
+                    }
+                });
+    }
+
+    /**
+     * Directly invokes Funqy function 'clusterEntrypoint' that forwards payload and headers to the broker and
+     * returns response.
+     */
+    public <T> FuncInvoker<T> funcInvoker() {
+        return new FuncInvoker<>(getURI().getRestAssuredStyleUri());
+    }
+
+    public interface ForwardResponseValidator<T> {
+        ForwardResponseValidator<T> assertBody(Matcher<T> matcher);
+
+        Response getResponse();
+    }
+
+    public static final class FuncInvoker<T> {
+
+        private static final String APPLICATION_CLOUD_EVENTS_PLUS_JSON = "application/cloudevents+json";
+        private final RequestSpecification request;
+        private String cloudEventType = null;
+        private String path = "";
+        private T data = null;
+
+        private FuncInvoker(String baseUrl) {
+            request = RestAssured
+                    .given()
+                    .baseUri(requireNonNull(baseUrl));
+        }
+
+        public FuncInvoker<T> appJsonContentType() {
+            request.contentType(ContentType.JSON);
+            return this;
+        }
+
+        public FuncInvoker<T> appCloudEventsPlusJsonContentType() {
+            requireClouedEventType();
+            requireNonNull(data, "Please set property 'data' first.");
+            path = "";
+            request.contentType(APPLICATION_CLOUD_EVENTS_PLUS_JSON);
+            request.body(new CloudEventData<>(data, cloudEventType));
+            return this;
+        }
+
+        public FuncInvoker<T> cloudEventType(String cloudEventType) {
+            this.cloudEventType = cloudEventType;
+            path = CLUSTER_ENTRYPOINT_PATH;
+            return this;
+        }
+
+        public FuncInvoker<T> data(T data) {
+            request.body(new ForwardRequestDTO<>(data, requireNonNull(cloudEventType)));
+            this.data = data;
+            return this;
+        }
+
+        /**
+         * Function will be invoked with a CloudEvent object.
+         * Can't be used together with {@link #APPLICATION_CLOUD_EVENTS_PLUS_JSON}.
+         */
+        public FuncInvoker<T> asCloudEventObject() {
+
+            // helps to determine proper path
+            requireClouedEventType();
+            path = "";
+
+            request
+                    .header("ce-specversion", "1.0")
+                    .header("ce-id", UUID.randomUUID().toString())
+                    .header("ce-type", CLUSTER_ENTRYPOINT_PATH)
+                    .header("ce-source", "test");
+            return this;
+        }
+
+        private void requireClouedEventType() {
+            requireNonNull(cloudEventType, "Please set 'cloudEventType' first.");
+        }
+
+        public ForwardResponseValidator<T> post() {
+            return validate(request.post(path));
+        }
+
+        public ForwardResponseValidator<T> get() {
+            return validate(request.get(path));
+        }
+
+        private ForwardResponseValidator<T> validate(Response response) {
+            if (response.statusCode() == HttpStatus.NOT_FOUND_404) {
+                // We need Funqy function that forward cloud events to the broker. Brokers are internal by design.
+                // We need a way to send events to the broker. We could expose another service, or use 'DomainMapping', but
+                // that's less efficient than using existing app. 'clusterEndpoint' is a Funqy function that we call directly.
+                throw new IllegalStateException("Cluster endpoint is missing. Please expose Funqy function 'clusterEntrypoint'"
+                        + " that forwards messages to the broker.");
+            }
+            return new ForwardResponseValidator<T>() {
+                @Override
+                public ForwardResponseValidator<T> assertBody(Matcher<T> matcher) {
+                    assertTrue(matcher.matches(response.as(ForwardResponseDTO.class).getResponse()));
+                    return this;
+                }
+
+                public Response getResponse() {
+                    return response;
+                }
+            };
+        }
+
+        private static final class CloudEventData<T> {
+            private final ForwardRequestDTO<T> data;
+
+            CloudEventData(T data, String cloudEventType) {
+                this.data = new ForwardRequestDTO<>(data, cloudEventType);
+            }
+
+            public String getId() {
+                return UUID.randomUUID() + "";
+            }
+
+            public String getSpecversion() {
+                return "1.0";
+            }
+
+            public String getSource() {
+                return "test";
+            }
+
+            public String getType() {
+                return CLUSTER_ENTRYPOINT_PATH;
+            }
+
+            public ForwardRequestDTO<T> getData() {
+                return data;
+            }
+
+            public String getDatacontenttype() {
+                return "application/json";
+            }
+        }
+    }
+
+    public static final class TriggerBuilder {
+
+        private String name = null;
+        private String broker = null;
+        private String filterCloudEventType = null;
+
+        private final FunqyKnativeEventsService service;
+
+        private TriggerBuilder(FunqyKnativeEventsService service) {
+            this.service = service;
+        }
+
+        public TriggerBuilder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public TriggerBuilder filterCloudEventType(String filterCloudEventType) {
+            this.filterCloudEventType = filterCloudEventType;
+            return this;
+        }
+
+        public TriggerBuilder defaultBroker() {
+            return broker(DEFAULT_BROKER_NAME);
+        }
+
+        public TriggerBuilder broker(String broker) {
+            this.broker = broker;
+            return this;
+        }
+
+        public FunqyKnativeEventsService endTrigger() {
+            service.triggerBuilders.add(this);
+            return service;
+        }
+
+        private Trigger build(String serviceName) {
+
+            // build trigger
+            return new io.fabric8.knative.eventing.v1.TriggerBuilder()
+                    .withNewMetadata()
+                    .withName(name.toLowerCase())
+                    .endMetadata()
+                    .withNewSpec()
+                    .withBroker(broker)
+                    .withNewFilter()
+                    .addToAttributes("type", filterCloudEventType)
+                    .endFilter()
+                    .withNewSubscriber()
+                    .withNewRef()
+                    .withApiVersion("v1")
+                    .withKind("Service")
+                    .withName(serviceName)
+                    .endRef()
+                    .endSubscriber()
+                    .endSpec()
+                    .build();
+        }
+    }
+
+}

--- a/quarkus-test-knative-events/root/src/main/java/io/quarkus/test/services/knative/eventing/OpenShiftExtensionFunqyKnativeEventsService.java
+++ b/quarkus-test-knative-events/root/src/main/java/io/quarkus/test/services/knative/eventing/OpenShiftExtensionFunqyKnativeEventsService.java
@@ -1,0 +1,18 @@
+package io.quarkus.test.services.knative.eventing;
+
+import io.quarkus.test.bootstrap.ScenarioContext;
+import io.quarkus.test.bootstrap.ServiceContext;
+
+public class OpenShiftExtensionFunqyKnativeEventsService extends FunqyKnativeEventsService {
+
+    @Override
+    public ServiceContext register(String serviceName, ScenarioContext context) {
+        // we set deployment target and registry so that every test don't have to do it (and it's in one place)
+        final String serviceScopePrefix = "ts." + serviceName;
+        System.setProperty(serviceScopePrefix + ".quarkus.kubernetes.deployment-target", "knative");
+        System.setProperty(serviceScopePrefix + ".quarkus.container-image.registry",
+                "image-registry.openshift-image-registry.svc:5000");
+        return super.register(serviceName, context);
+    }
+
+}

--- a/quarkus-test-knative-events/spi/pom.xml
+++ b/quarkus-test-knative-events/spi/pom.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus.qe</groupId>
+        <artifactId>quarkus-test-knative-events-parent</artifactId>
+        <version>1.2.1.Beta12-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <artifactId>quarkus-test-knative-events-spi</artifactId>
+    <name>Quarkus - Test Framework - Knative Events - SPI</name>
+    <dependencies>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/quarkus-test-knative-events/spi/src/main/java/io/quarkus/test/services/knative/eventing/spi/CompoundResponse.java
+++ b/quarkus-test-knative-events/spi/src/main/java/io/quarkus/test/services/knative/eventing/spi/CompoundResponse.java
@@ -1,0 +1,63 @@
+package io.quarkus.test.services.knative.eventing.spi;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.awaitility.Awaitility;
+
+public abstract class CompoundResponse<T> {
+
+    private static final int TIMEOUT_SECONDS = 30;
+    private final int expectedNumOfResponses;
+    private final AtomicInteger actualNumOfResponses;
+
+    protected CompoundResponse(int expectedNumOfResponses) {
+        this.expectedNumOfResponses = expectedNumOfResponses;
+        this.actualNumOfResponses = new AtomicInteger(0);
+    }
+
+    public final void recordVisit() {
+        actualNumOfResponses.incrementAndGet();
+    }
+
+    public final void recordResponse(T response) {
+        addResponse(response);
+        actualNumOfResponses.incrementAndGet();
+    }
+
+    public final CompoundResponse<T> waitForResponses() {
+        Awaitility.await().atMost(Duration.ofSeconds(TIMEOUT_SECONDS)).until(this::isDone);
+        return this;
+    }
+
+    public final ForwardResponseDTO<T> join() {
+        return new ForwardResponseDTO<T>(getJoinedResponse());
+    }
+
+    protected abstract void addResponse(T response);
+
+    protected abstract T getJoinedResponse();
+
+    private boolean isDone() {
+        return actualNumOfResponses.get() == expectedNumOfResponses;
+    }
+
+    public static final class StringCompoundResponse extends CompoundResponse<String> {
+
+        private final StringBuffer stringBuffer = new StringBuffer();
+
+        public StringCompoundResponse(int expectedNumOfResponses) {
+            super(expectedNumOfResponses);
+        }
+
+        @Override
+        protected void addResponse(String response) {
+            stringBuffer.append(response);
+        }
+
+        @Override
+        protected String getJoinedResponse() {
+            return stringBuffer.toString();
+        }
+    }
+}

--- a/quarkus-test-knative-events/spi/src/main/java/io/quarkus/test/services/knative/eventing/spi/ForwardRequestDTO.java
+++ b/quarkus-test-knative-events/spi/src/main/java/io/quarkus/test/services/knative/eventing/spi/ForwardRequestDTO.java
@@ -1,0 +1,42 @@
+package io.quarkus.test.services.knative.eventing.spi;
+
+public class ForwardRequestDTO<T> {
+
+    private T data;
+
+    private String filterCloudEventType;
+
+    public ForwardRequestDTO(T data, String filterCloudEventType) {
+        this.data = data;
+        this.filterCloudEventType = filterCloudEventType;
+    }
+
+    public ForwardRequestDTO() {
+
+    }
+
+    public T getData() {
+        return data;
+    }
+
+    public void setData(T data) {
+        this.data = data;
+    }
+
+    public String getFilterCloudEventType() {
+        return filterCloudEventType;
+    }
+
+    public void setFilterCloudEventType(String filterCloudEventType) {
+        this.filterCloudEventType = filterCloudEventType;
+    }
+
+    @Override
+    public String toString() {
+        return "ForwardDTO{"
+                + " data='" + data + '\''
+                + ", filterCloudEventType='" + filterCloudEventType + '\''
+                + '}';
+    }
+
+}

--- a/quarkus-test-knative-events/spi/src/main/java/io/quarkus/test/services/knative/eventing/spi/ForwardResponseDTO.java
+++ b/quarkus-test-knative-events/spi/src/main/java/io/quarkus/test/services/knative/eventing/spi/ForwardResponseDTO.java
@@ -1,0 +1,30 @@
+package io.quarkus.test.services.knative.eventing.spi;
+
+public class ForwardResponseDTO<T> {
+
+    private T response;
+
+    public ForwardResponseDTO(T response) {
+        this.response = response;
+    }
+
+    public ForwardResponseDTO() {
+
+    }
+
+    public T getResponse() {
+        return response;
+    }
+
+    public void setResponse(T response) {
+        this.response = response;
+    }
+
+    @Override
+    public String toString() {
+        return "ForwardResponseDTO{"
+                + "response=" + response
+                + '}';
+    }
+
+}

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
@@ -593,6 +593,10 @@ public final class OpenShiftClient {
         return scenarioId;
     }
 
+    public KnativeClient getKnClient() {
+        return kn;
+    }
+
     /**
      * Delete test resources.
      */


### PR DESCRIPTION
### Summary

This PR provides basic functionality needed to test Funqy Knative Eventing - ways to create Knative Eventing triggers and broker. There is also a new example that shows how you can test Funqy functions with Knative Eventing. The example is adjusted Quarkus Quickstart. As newly we require Knative Eventing installed, we need to wait till CI PR is merged before we trigger OC runs (I tested this PR with 4.8, CI uses 4.11).

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)