### PR TITLE
Knative Client - Fix K8 client method mismatch for Knative Events

### DIFF
--- a/examples/funqy-knative-events/pom.xml
+++ b/examples/funqy-knative-events/pom.xml
@@ -27,15 +27,6 @@
             <groupId>io.quarkus.qe</groupId>
             <artifactId>quarkus-test-knative-events-spi</artifactId>
         </dependency>
-        <!--  FIXME: drop 'openshift-client' and 'knative-client' deps once we migrate to Quarkus 2.14  -->
-        <dependency>
-            <groupId>io.fabric8</groupId>
-            <artifactId>openshift-client</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.fabric8</groupId>
-            <artifactId>knative-client</artifactId>
-        </dependency>
         <dependency>
             <groupId>io.quarkus.qe</groupId>
             <artifactId>quarkus-test-knative-events</artifactId>

--- a/quarkus-test-knative-events/root/pom.xml
+++ b/quarkus-test-knative-events/root/pom.xml
@@ -21,29 +21,6 @@
         <dependency>
             <groupId>io.quarkus.qe</groupId>
             <artifactId>quarkus-test-openshift</artifactId>
-            <!--  FIXME: drop exclusions once we migrate to Quarkus 2.14  -->
-            <exclusions>
-                <exclusion>
-                    <groupId>io.fabric8</groupId>
-                    <artifactId>openshift-client</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.fabric8</groupId>
-                    <artifactId>knative-client</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <!--  this works around conflict between 2.13 and 999-SNAPSHOT  -->
-        <!--  FIXME drop section below once we migrate to Quarkus 2.14  -->
-        <dependency>
-            <groupId>io.fabric8</groupId>
-            <artifactId>openshift-client</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.fabric8</groupId>
-            <artifactId>knative-client</artifactId>
-            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
@@ -779,7 +779,7 @@ public final class OpenShiftClient {
      * @return
      * @param <T>
      */
-    private static <T> Object invokeMethod(Object object, String methodName, T methodParameter, String action,
+    public static <T> Object invokeMethod(Object object, String methodName, T methodParameter, String action,
             Function<T, T[]> paramToArrayConverter) {
 
         // TODO: invoked by reflection as signatures differs between kubernetes-client 6.1.1 and 5.12.3;


### PR DESCRIPTION
### Summary

I tried to work around issues of using 2 different versions of `kubernetes-client` (and oc a kn cl.) used by Quarkus 2.13 (5.12.3) and 999-SNAPSHOT (6.1.1). Some methods are deprecated, but they still works (so we can call them till we migrate to 2.14). The issue is that method signatures has changed (e.g. someone moved method declaration to other interface etc.). This invokes concerned methods via reflection. Delete method is newly without formal parameter as according to impl. only triggers/brokers in used namespace are deleted (not in other namespaces). Previous impl. is not supported in 6.1.1.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)