### PR TITLE
Funqy Kn Events - Don't delete brokers and triggers as we delete project

### DIFF
--- a/quarkus-test-knative-events/root/src/main/java/io/quarkus/test/services/knative/eventing/FunqyKnativeEventsService.java
+++ b/quarkus-test-knative-events/root/src/main/java/io/quarkus/test/services/knative/eventing/FunqyKnativeEventsService.java
@@ -48,21 +48,6 @@ public class FunqyKnativeEventsService extends BaseService<FunqyKnativeEventsSer
         super();
         createBrokerAndBuildTriggersOnPreStart();
         createTriggersOnPostStart();
-        // delete brokers and triggers on shutdown
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            deleteTriggers();
-            deleteBroker();
-        }));
-    }
-
-    private void deleteBroker() {
-        // FIXME: check delete result once we migrate to Quarkus 2.14 (see below)
-        getKnClient().brokers().delete();
-    }
-
-    private void deleteTriggers() {
-        // FIXME: check delete result once we migrate to Quarkus 2.14 (see below)
-        getKnClient().triggers().delete();
     }
 
     private KnativeClient getKnClient() {


### PR DESCRIPTION
### Summary

I mentioned that my shutdown hook doesn't work properly as it tries delete trigger/broker in already deleted OpenShift namespace (it has not affect on test results, so this issue is not urgent). For a long time I wasn't sure whether it's actually necessary to delete them, for Knative Eventing to work it needs `knative-eventing` namespace and docs doesn't explain broker relation to `knative-eventing` namespace (e.g. is it for sure there won't be some fragments left?). Today I run couple of tests and when you delete ephemeral namespace, you also delete any reference to trigger/broker I could find. They are deleted together with the namespace. At least for Kn Sources (related) reference says they are [deleted with namespace](https://knative.dev/docs/eventing/sources/apiserversource/getting-started/#create-an-apiserversource-object).

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)