### PR TITLE
Check logs to ensure Kafka container is ready

### DIFF
--- a/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/BaseKafkaContainerManagedResource.java
+++ b/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/BaseKafkaContainerManagedResource.java
@@ -3,6 +3,7 @@ package io.quarkus.test.services.containers;
 import org.apache.commons.lang3.StringUtils;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
+import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.MountableFile;
 
 import io.quarkus.test.bootstrap.KafkaService;
@@ -11,6 +12,7 @@ import io.quarkus.test.logging.TestContainersLoggingHandler;
 public abstract class BaseKafkaContainerManagedResource extends DockerContainerManagedResource {
 
     private static final String SERVER_PROPERTIES = "server.properties";
+    private static final String EXPECTED_LOG = ".*started \\(kafka.server.KafkaServer\\).*";
 
     protected final KafkaContainerManagedResourceBuilder model;
 
@@ -66,6 +68,8 @@ public abstract class BaseKafkaContainerManagedResource extends DockerContainerM
     @Override
     protected GenericContainer<?> initContainer() {
         GenericContainer<?> kafkaContainer = initKafkaContainer();
+
+        kafkaContainer.waitingFor(Wait.forLogMessage(EXPECTED_LOG, 1));
 
         String kafkaConfigPath = model.getKafkaConfigPath();
         if (StringUtils.isNotEmpty(getServerProperties())) {

--- a/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/model/KafkaVendor.java
+++ b/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/model/KafkaVendor.java
@@ -1,8 +1,8 @@
 package io.quarkus.test.services.containers.model;
 
 public enum KafkaVendor {
-    CONFLUENT("confluentinc/cp-kafka", "6.1.1", 9093, KafkaRegistry.CONFLUENT),
-    STRIMZI("quay.io/strimzi/kafka", "0.28.0-kafka-3.1.0", 9092, KafkaRegistry.APICURIO);
+    CONFLUENT("confluentinc/cp-kafka", "7.2.2", 9093, KafkaRegistry.CONFLUENT),
+    STRIMZI("quay.io/strimzi/kafka", "0.31.1-kafka-3.1.2", 9092, KafkaRegistry.APICURIO);
 
     private final String image;
     private final String defaultVersion;


### PR DESCRIPTION
### Summary

Updates Strimzi and Confluent Kafka images to the latest versions and adds extra check that inspect container logs to determine whether Kafka is ready. After investigating Test Suite [Daily Build #608](https://github.com/quarkus-qe/quarkus-test-suite/actions/runs/3257533483) and `StrimziKafkaStreamIT` itself, I'm not completely sure that Kafka was ready when tests started.

[If I get it right](https://www.testcontainers.org/features/startup_and_waits/), currently we are using default `IsRunningStartupCheckStrategy` strategy that is just checking if container reached running state with start up timeout. I've added additional `WaitStrategy` that makes sure Kafka is ready. We already are doing same in `OpenShiftStrimziKafkaContainerManagedResource`.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Dependency update
- [x] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)