### PR TITLE
Remove Quarkus-helm from example modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -380,7 +380,8 @@
             </activation>
             <modules>
                 <module>examples/quarkus-cli</module>
-                <module>examples/quarkus-helm</module>
+                <!-- TODO: https://github.com/quarkiverse/quarkus-helm/issues/114-->
+                <!-- <module>examples/quarkus-helm</module>-->
                 <module>examples/pingpong</module>
                 <module>examples/restclient</module>
                 <module>examples/greetings</module>


### PR DESCRIPTION
There is an issue on Upstream related to dekorate that make this module fails on compile time
Ref: quarkiverse/quarkus-helm#114
