### PR TITLE
Bump quarkus-artemis-jms from 1.3.0 to 2.0.0

### DIFF
--- a/examples/amq-tcp/pom.xml
+++ b/examples/amq-tcp/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>io.quarkiverse.artemis</groupId>
             <artifactId>quarkus-artemis-jms</artifactId>
-            <version>1.3.0</version>
+            <version>2.0.0</version>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/examples/amq-tcp/src/main/resources/application.properties
+++ b/examples/amq-tcp/src/main/resources/application.properties
@@ -1,3 +1,2 @@
-quarkus.artemis.url=tcp://amq-broker-tcp:61616
 quarkus.artemis.username=quarkus
 quarkus.artemis.password=quarkus


### PR DESCRIPTION
Bump quarkus-artemis-jms from 1.3.0 to 2.0.0

Replaces https://github.com/quarkus-qe/quarkus-test-framework/pull/607

Dropping artemis url otherwise we receive `11:26:29,903 INFO [app] - quarkus.artemis.url is set to 'tcp://localhost:64125' but it is build time fixed to 'tcp://amq-broker-tcp:61616'. Did you change the property quarkus.artemis.url after building the application?` and tests fail.
Change introduced in https://github.com/quarkiverse/quarkus-artemis/pull/82

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)