### PR TITLE
Release Quarkus test framework 1.2.0.Final

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 name: Quarkus QE Test Framework
 release:
-  current-version: 1.2.0.Beta16
-  next-version: 1.2.0.Beta17
+  current-version: 1.2.0.Final
+  next-version: 1.2.1.Beta1

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <htmlunit.version>2.67.0</htmlunit.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.13.4.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.13.5.Final</quarkus.platform.version>
         <exclude.tests.with.tags>quarkus-cli</exclude.tests.with.tags>
         <include.tests>**/*IT.java</include.tests>
         <exclude.openshift.tests>**/OpenShift*IT.java</exclude.openshift.tests>


### PR DESCRIPTION
### Summary

Point to Quarkus 2.13.5.Final 

Release Quarkus test Framework 1.2.0.Final based on previous Beta version.