### PR TITLE
Fix OpenShiftStrimziOperatorKafkaWithoutRegistryMessagingIT

### DIFF
--- a/quarkus-test-service-kafka/src/main/resources/strimzi-operator-kafka-instance.yaml
+++ b/quarkus-test-service-kafka/src/main/resources/strimzi-operator-kafka-instance.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kafka-instance
 spec:
   kafka:
-    version: 3.1.0
+    version: 3.3.1
     replicas: 1
     listeners:
       - name: plain


### PR DESCRIPTION
### Summary

We install `strimzi-cluster-operator.v0.32.0` that does not recognize Kafka version 3.1.0 version, we should use the latest Kafka version `3.3.1` - https://kafka.apache.org/downloads.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)