### PR TITLE
Fix git Maven params

### DIFF
--- a/examples/external-applications/src/test/java/io/quarkus/qe/QuickstartUsingUsingUberJarIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/QuickstartUsingUsingUberJarIT.java
@@ -15,7 +15,7 @@ import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Windows does not support long file paths")
 public class QuickstartUsingUsingUberJarIT {
 
-    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", contextDir = "getting-started", mavenArgs = "-Dquarkus.package.type=uber-jar -DskipTests=true -Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus.platform.version=${QUARKUS_VERSION}")
+    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", contextDir = "getting-started", mavenArgs = "-Dquarkus.package.type=uber-jar -DskipTests=true -Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus.platform.version=${QUARKUS_PLATFORM_VERSION}")
     static final RestService app = new RestService();
 
     @Test

--- a/examples/external-applications/src/test/java/io/quarkus/qe/TodoDemoIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/TodoDemoIT.java
@@ -12,7 +12,7 @@ import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 @QuarkusScenario
 public class TodoDemoIT {
     private static final String REPO = "https://github.com/quarkusio/todo-demo-app.git";
-    private static final String DEFAULT_ARGS = "-DskipTests=true -Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus.platform.version=${QUARKUS_VERSION} ";
+    private static final String DEFAULT_ARGS = "-DskipTests=true -Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus.platform.version=${QUARKUS_PLATFORM_VERSION} ";
     private static final String UBER = "-Dquarkus.package.type=uber-jar ";
 
     @GitRepositoryQuarkusApplication(repo = REPO, mavenArgs = DEFAULT_ARGS + UBER)

--- a/examples/external-applications/src/test/resources/uber-jar-quarkus-s2i-source-build-template.yml
+++ b/examples/external-applications/src/test/resources/uber-jar-quarkus-s2i-source-build-template.yml
@@ -33,7 +33,7 @@ items:
         sourceStrategy:
           env:
             - name: MAVEN_ARGS
-              value: -s /configuration/settings.xml ${GIT_MAVEN_ARGS} -Dquarkus.platform.version=${QUARKUS_VERSION} -Dquarkus-plugin.version=${QUARKUS_VERSION} -Dquarkus.package.uber-jar -Dquarkus.openshift.jar-file-name=quarkus-run
+              value: -s /configuration/settings.xml ${GIT_MAVEN_ARGS} -Dquarkus.platform.version=${QUARKUS_PLATFORM_VERSION} -Dquarkus-plugin.version=${QUARKUS_PLATFORM_VERSION} -Dquarkus.package.uber-jar -Dquarkus.openshift.jar-file-name=quarkus-run
           from:
             kind: DockerImage
             name: ${QUARKUS_S2I_BUILDER_IMAGE}

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/GitRepositoryQuarkusApplication.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/GitRepositoryQuarkusApplication.java
@@ -15,7 +15,7 @@ public @interface GitRepositoryQuarkusApplication {
     String contextDir() default "";
 
     String mavenArgs() default "-DskipTests=true -DskipITs=true "
-            + "-Dquarkus.platform.version=${QUARKUS_VERSION} "
+            + "-Dquarkus.platform.version=${QUARKUS_PLATFORM_VERSION} "
             + "-Dquarkus-plugin.version=${QUARKUS-PLUGIN_VERSION} "
             + "-Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID}";
 

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/GitRepositoryLocalhostQuarkusApplicationManagedResource.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/GitRepositoryLocalhostQuarkusApplicationManagedResource.java
@@ -1,7 +1,6 @@
 package io.quarkus.test.services.quarkus;
 
 import static io.quarkus.test.services.quarkus.GitRepositoryResourceBuilderUtils.cloneRepository;
-import static io.quarkus.test.services.quarkus.GitRepositoryResourceBuilderUtils.getEffectivePropertiesForGitRepository;
 import static io.quarkus.test.services.quarkus.GitRepositoryResourceBuilderUtils.mavenBuild;
 
 import java.nio.file.Path;
@@ -44,15 +43,13 @@ public class GitRepositoryLocalhostQuarkusApplicationManagedResource
 
     @Override
     protected List<String> prepareCommand(List<String> systemProperties) {
-        List<String> effectiveProperties = getEffectivePropertiesForGitRepository(systemProperties);
-
         // Dev mode
         if (model.isDevMode()) {
-            return MavenUtils.devModeMavenCommand(model.getContext(), effectiveProperties);
+            return MavenUtils.devModeMavenCommand(model.getContext(), systemProperties);
         }
 
         // JVM or Native
-        return super.prepareCommand(effectiveProperties);
+        return super.prepareCommand(systemProperties);
     }
 
     @Override

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/GitRepositoryQuarkusApplicationManagedResourceBuilder.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/GitRepositoryQuarkusApplicationManagedResourceBuilder.java
@@ -13,7 +13,7 @@ import io.quarkus.test.services.quarkus.model.QuarkusProperties;
 
 public class GitRepositoryQuarkusApplicationManagedResourceBuilder extends ProdQuarkusApplicationManagedResourceBuilder {
 
-    protected static final String QUARKUS_VERSION_PROPERTY = "${QUARKUS_VERSION}";
+    protected static final String QUARKUS_PLATFORM_VERSION_PROPERTY = "${QUARKUS_PLATFORM_VERSION}";
     protected static final String QUARKUS_PLUGIN_VERSION_PROPERTY = "${QUARKUS-PLUGIN_VERSION}";
     protected static final String QUARKUS_PLATFORM_GROUP_ID_PROPERTY = "${QUARKUS_PLATFORM_GROUP-ID}";
 
@@ -50,7 +50,7 @@ public class GitRepositoryQuarkusApplicationManagedResourceBuilder extends ProdQ
         return mavenArgs
                 .replaceAll(quote(QUARKUS_PLATFORM_GROUP_ID_PROPERTY), QuarkusProperties.PLATFORM_GROUP_ID.get())
                 .replaceAll(quote(QUARKUS_PLUGIN_VERSION_PROPERTY), QuarkusProperties.getPluginVersion())
-                .replaceAll(quote(QUARKUS_VERSION_PROPERTY), QuarkusProperties.getVersion());
+                .replaceAll(quote(QUARKUS_PLATFORM_VERSION_PROPERTY), QuarkusProperties.getVersion());
     }
 
     @Override

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/GitRepositoryResourceBuilderUtils.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/GitRepositoryResourceBuilderUtils.java
@@ -1,10 +1,6 @@
 package io.quarkus.test.services.quarkus;
 
-import static io.quarkus.test.services.quarkus.model.QuarkusProperties.PLUGIN_VERSION;
-
 import java.util.Arrays;
-import java.util.LinkedList;
-import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -12,10 +8,6 @@ import io.quarkus.test.utils.GitUtils;
 import io.quarkus.test.utils.MavenUtils;
 
 public final class GitRepositoryResourceBuilderUtils {
-
-    private static final String QUARKUS_VERSION = "quarkus.version";
-    private static final String QUARKUS_PLUGIN_VERSION = "quarkus-plugin.version";
-    private static final String QUARKUS_VERSION_VALUE = "${quarkus.platform.version}";
 
     private GitRepositoryResourceBuilderUtils() {
 
@@ -30,18 +22,7 @@ public final class GitRepositoryResourceBuilderUtils {
 
     public static void mavenBuild(final GitRepositoryQuarkusApplicationManagedResourceBuilder model) {
         String[] mvnArgs = StringUtils.split(model.getMavenArgsWithVersion(), " ");
-        List<String> effectiveProperties = getEffectivePropertiesForGitRepository(Arrays.asList(mvnArgs));
-        MavenUtils.build(model.getContext(), model.getApplicationFolder(), effectiveProperties);
+        MavenUtils.build(model.getContext(), model.getApplicationFolder(), Arrays.asList(mvnArgs));
     }
 
-    public static List<String> getEffectivePropertiesForGitRepository(List<String> properties) {
-        List<String> effectiveProperties = new LinkedList<>(properties);
-        effectiveProperties.add(MavenUtils.withProperty(QUARKUS_VERSION, QUARKUS_VERSION_VALUE));
-
-        if (StringUtils.isEmpty(PLUGIN_VERSION.get())) {
-            effectiveProperties.add(MavenUtils.withProperty(QUARKUS_PLUGIN_VERSION, QUARKUS_VERSION_VALUE));
-        }
-
-        return effectiveProperties;
-    }
 }

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftS2iGitRepositoryQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftS2iGitRepositoryQuarkusApplicationManagedResource.java
@@ -1,7 +1,7 @@
 package io.quarkus.test.services.quarkus;
 
 import static io.quarkus.test.services.quarkus.GitRepositoryQuarkusApplicationManagedResourceBuilder.QUARKUS_PLATFORM_GROUP_ID_PROPERTY;
-import static io.quarkus.test.services.quarkus.GitRepositoryQuarkusApplicationManagedResourceBuilder.QUARKUS_VERSION_PROPERTY;
+import static io.quarkus.test.services.quarkus.GitRepositoryQuarkusApplicationManagedResourceBuilder.QUARKUS_PLATFORM_VERSION_PROPERTY;
 import static io.quarkus.test.services.quarkus.model.QuarkusProperties.PLATFORM_GROUP_ID;
 import static io.quarkus.test.services.quarkus.model.QuarkusProperties.QUARKUS_JVM_S2I;
 import static java.util.regex.Pattern.quote;
@@ -76,7 +76,7 @@ public class OpenShiftS2iGitRepositoryQuarkusApplicationManagedResource
     }
 
     protected String replaceDeploymentContent(String content) {
-        String quarkusVersion = QuarkusProperties.getVersion();
+        String quarkusPlatformVersion = QuarkusProperties.getVersion();
         String quarkusS2iBaseImage = getQuarkusS2iBaseImage();
         String mavenArgs = model.getMavenArgsWithVersion();
 
@@ -87,7 +87,7 @@ public class OpenShiftS2iGitRepositoryQuarkusApplicationManagedResource
                 .replaceAll(quote("${CONTEXT_DIR}"), model.getContextDir())
                 .replaceAll(quote("${GIT_MAVEN_ARGS}"), mavenArgs)
                 .replaceAll(quote(QUARKUS_PLATFORM_GROUP_ID_PROPERTY), PLATFORM_GROUP_ID.get())
-                .replaceAll(quote(QUARKUS_VERSION_PROPERTY), quarkusVersion);
+                .replaceAll(quote(QUARKUS_PLATFORM_VERSION_PROPERTY), quarkusPlatformVersion);
     }
 
     private String getQuarkusS2iBaseImage() {

--- a/quarkus-test-openshift/src/main/resources/quarkus-s2i-source-build-template.yml
+++ b/quarkus-test-openshift/src/main/resources/quarkus-s2i-source-build-template.yml
@@ -33,7 +33,7 @@ items:
         sourceStrategy:
           env:
             - name: MAVEN_ARGS
-              value: -s /configuration/settings.xml ${GIT_MAVEN_ARGS} -Dquarkus.version=${QUARKUS_VERSION} -Dquarkus.platform.version=${QUARKUS_VERSION} -Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus-plugin.version=${QUARKUS_VERSION}
+              value: -s /configuration/settings.xml ${GIT_MAVEN_ARGS} -Dquarkus.platform.version=${QUARKUS_PLATFORM_VERSION} -Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus-plugin.version=${QUARKUS_PLATFORM_VERSION}
           from:
             kind: DockerImage
             name: ${QUARKUS_S2I_BUILDER_IMAGE}


### PR DESCRIPTION
### Summary

Maven arguments for GitRepository apps should be provided only via https://github.com/quarkus-qe/quarkus-test-framework/blob/main/quarkus-test-core/src/main/java/io/quarkus/test/services/GitRepositoryQuarkusApplication.java#L17 - so i've removed hardcoded `quarkus.version` and `quarkus-plugin.version` from `GitRepositoryResourceBuilderUtils` (i can add them as default to https://github.com/quarkus-qe/quarkus-test-framework/blob/main/quarkus-test-core/src/main/java/io/quarkus/test/services/GitRepositoryQuarkusApplication.java#L17 if you wish).

Also i've modified S2I template because it was using the same ENV variable for both `quarkus.version` and `quarkus.platform.version` which is not true in case of Platform build.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)