### PR TITLE
Use OTLP collector by default with Jaeger

### DIFF
--- a/examples/jaeger/src/test/java/io/quarkus/qe/ClientResourceIT.java
+++ b/examples/jaeger/src/test/java/io/quarkus/qe/ClientResourceIT.java
@@ -23,7 +23,7 @@ public class ClientResourceIT {
     private static final String SERVICE_NAME = "test-traced-service";
     private static final String CLIENT_ENDPOINT = "/client";
 
-    @JaegerContainer(useOtlpCollector = true)
+    @JaegerContainer()
     static JaegerService jaeger = new JaegerService();
 
     @QuarkusApplication

--- a/quarkus-test-service-jaeger/src/main/java/io/quarkus/test/services/JaegerContainer.java
+++ b/quarkus-test-service-jaeger/src/main/java/io/quarkus/test/services/JaegerContainer.java
@@ -27,9 +27,10 @@ public @interface JaegerContainer {
     int otlpPort() default 4317;
 
     /**
-     * Switches between {@link #restPort()} and {@link #otlpPort()}. If set to true, the OTLP collector is used.
+     * Switches between {@link #restPort()} and {@link #otlpPort()}.
+     * If set to true, the OTLP collector is used. If set to false, the Jaeger collector is used.
      */
-    boolean useOtlpCollector() default false;
+    boolean useOtlpCollector() default true;
 
     String expectedLog() default "server started";
 


### PR DESCRIPTION
Use OTLP collector by default with Jaeger

Fixes https://github.com/quarkus-qe/quarkus-test-framework/issues/653

This will align the framework (just main) with the upstream strategy to use OTLP exporter by default with OpenTelementry. TS is updated to explicitly define `useOtlpCollector` value (https://github.com/quarkus-qe/quarkus-test-suite/pull/1002) so the future FW update won't break anything.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)