### PR TITLE
Fix OpenShift resource URI caching - clear cache on service stop

### DIFF
--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftQuarkusApplicationManagedResource.java
@@ -74,6 +74,7 @@ public abstract class OpenShiftQuarkusApplicationManagedResource<T extends Quark
         }
 
         client.scaleTo(model.getContext().getOwner(), 0);
+        uri = null;
         running = false;
     }
 


### PR DESCRIPTION
### Summary

Prevents the cached value from distorting status checks on stopped resources.

This fixes `infinispan-client` failures observed in e.g. https://github.com/quarkus-qe/quarkus-test-suite/pull/975.

This is a follow-up to
https://github.com/quarkus-qe/quarkus-test-framework/pull/625, which introduced the caching in order to fix issues in INTEROP environment. See e.g.
https://mpts-prod.psi.redhat.com/dashboard/run/?id=8896.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)