### PR TITLE
[1.2.z] Bump Quarkus to 2.13.7.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <htmlunit.version>2.67.0</htmlunit.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.13.6.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.13.7.Final</quarkus.platform.version>
         <exclude.tests.with.tags>quarkus-cli</exclude.tests.with.tags>
         <include.tests>**/*IT.java</include.tests>
         <exclude.openshift.tests>**/OpenShift*IT.java</exclude.openshift.tests>


### PR DESCRIPTION
### Summary

Upgrade Quarkus version to 2.13.7.Final

Please check the relevant options
- [X] Dependency update