### PR TITLE
[1.2.z] Fix OpenShift resource URI caching - clear cache on service stop

### DIFF
--- a/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftExtensionQuickstartUsingDefaultsIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftExtensionQuickstartUsingDefaultsIT.java
@@ -13,7 +13,7 @@ import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
 public class OpenShiftExtensionQuickstartUsingDefaultsIT {
 
-    @GitRepositoryQuarkusApplication(repo = "https://github.com/apache/camel-quarkus-examples.git", contextDir = "file-bindy-ftp", mavenArgs = "-Dopenshift")
+    @GitRepositoryQuarkusApplication(repo = "https://github.com/apache/camel-quarkus-examples.git", branch = "2.13.x", contextDir = "file-bindy-ftp", mavenArgs = "-Dopenshift")
     static final RestService app = new RestService();
 
     @Test

--- a/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftExtensionUsingDockerBuildStrategyQuickstartUsingDefaultsIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftExtensionUsingDockerBuildStrategyQuickstartUsingDefaultsIT.java
@@ -13,7 +13,7 @@ import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtensionAndDockerBuildStrategy)
 public class OpenShiftExtensionUsingDockerBuildStrategyQuickstartUsingDefaultsIT {
 
-    @GitRepositoryQuarkusApplication(repo = "https://github.com/apache/camel-quarkus-examples.git", contextDir = "file-bindy-ftp", mavenArgs = "-Dopenshift")
+    @GitRepositoryQuarkusApplication(repo = "https://github.com/apache/camel-quarkus-examples.git", branch = "2.13.x", contextDir = "file-bindy-ftp", mavenArgs = "-Dopenshift")
     static final RestService app = new RestService();
 
     @Test

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftQuarkusApplicationManagedResource.java
@@ -74,6 +74,7 @@ public abstract class OpenShiftQuarkusApplicationManagedResource<T extends Quark
         }
 
         client.scaleTo(model.getContext().getOwner(), 0);
+        uri = null;
         running = false;
     }
 


### PR DESCRIPTION
Backport 

[Fix OpenShift resource URI caching - clear cache on service stop](https://github.com/quarkus-qe/quarkus-test-framework/pull/656)

- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)