### PR TITLE
Move to new s2i native images introduced in Quarkus 2.14

### DIFF
--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/model/QuarkusProperties.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/model/QuarkusProperties.java
@@ -23,7 +23,7 @@ public final class QuarkusProperties {
     public static final PropertyLookup QUARKUS_JVM_S2I = new PropertyLookup("quarkus.s2i.base-jvm-image",
             "registry.access.redhat.com/ubi8/openjdk-17:latest");
     public static final PropertyLookup QUARKUS_NATIVE_S2I = new PropertyLookup("quarkus.s2i.base-native-image",
-            "quay.io/quarkus/ubi-quarkus-native-binary-s2i:1.0");
+            "quay.io/quarkus/ubi-quarkus-native-binary-s2i:2.0");
 
     private QuarkusProperties() {
 

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftS2iGitRepositoryQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftS2iGitRepositoryQuarkusApplicationManagedResource.java
@@ -23,6 +23,7 @@ public class OpenShiftS2iGitRepositoryQuarkusApplicationManagedResource
     private static final String QUARKUS_SOURCE_S2I_SETTINGS_MVN_FILENAME = "settings-mvn.yml";
     private static final String INTERNAL_MAVEN_REPOSITORY_PROPERTY = "${internal.s2i.maven.remote.repository}";
     private static final PropertyLookup MAVEN_REMOTE_REPOSITORY = new PropertyLookup("s2i.maven.remote.repository");
+    // TODO: use ubi-quarkus-native-binary-s2i once upstream https://github.com/quarkusio/quarkus/issues/30829 is fixed
     private static final PropertyLookup QUARKUS_NATIVE_S2I_FROM_SRC = new PropertyLookup("s2i.openshift.base-native-image",
             "quay.io/quarkus/ubi-quarkus-native-s2i:22.2-java17");
 


### PR DESCRIPTION
### Summary

Move to new builder images introduced in Quarkus 2.14

PR with the change - https://github.com/quarkusio/quarkus/pull/27997

NEW is active - https://quay.io/quarkus/ubi-quarkus-native-binary-s2i
OLD is without update for 3 months - https://quay.io/quarkus/ubi-quarkus-native-s2i

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)