### PR TITLE
Fix OpenShift resource host/port caching - clear cache on service stop

### DIFF
--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftQuarkusApplicationManagedResource.java
@@ -73,6 +73,8 @@ public abstract class OpenShiftQuarkusApplicationManagedResource<T extends Quark
         }
 
         client.scaleTo(model.getContext().getOwner(), 0);
+        host = null;
+        port = -1;
         running = false;
     }
 


### PR DESCRIPTION
### Summary

Loose backport of https://github.com/quarkus-qe/quarkus-test-framework/pull/656.
Related to https://github.com/quarkus-qe/quarkus-test-framework/pull/623.

Prevents the cached value from distorting status checks on stopped resources.

This fixes `infinispan-client` failures similar to the ones observed in e.g. quarkus-qe/quarkus-test-suite#975.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)