### PR TITLE
Use Quarkus 3 Alpha 3 and migrate to Jakarta

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -149,7 +149,7 @@ jobs:
 #          password: ${{ secrets.CI_REGISTRY_PASSWORD }}
       - name: Build Quarkus CLI
         run: |
-          git clone https://github.com/quarkusio/quarkus.git && cd quarkus/devtools/cli && mvn -B -s ../../../.github/mvn-settings.xml clean install -Dquickly -Prelocations
+          git clone https://github.com/quarkusio/quarkus.git && cd quarkus/devtools/cli && mvn -B -s ../../../.github/mvn-settings.xml clean install -Dquickly -Dno-test-modules -Prelocations
       - name: Install Quarkus CLI
         run: |
           cat <<EOF > ./quarkus-dev-cli

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -155,7 +155,7 @@ jobs:
         run: tar -xzf maven-repo.tgz -C ~
       - name: Build Quarkus CLI
         run: |
-          git clone https://github.com/quarkusio/quarkus.git && cd quarkus/devtools/cli && mvn -B -s ../../../.github/mvn-settings.xml clean install -Dquickly -Prelocations
+          git clone https://github.com/quarkusio/quarkus.git && cd quarkus/devtools/cli && mvn -B -s ../../../.github/mvn-settings.xml clean install -Dquickly -Dno-test-modules -Prelocations
       - name: Install Quarkus CLI
         run: |
           cat <<EOF > ./quarkus-dev-cli

--- a/examples/amq-amqp/src/main/java/io/quarkus/qe/amqp/PriceConsumer.java
+++ b/examples/amq-amqp/src/main/java/io/quarkus/qe/amqp/PriceConsumer.java
@@ -3,10 +3,10 @@ package io.quarkus.qe.amqp;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
-import javax.enterprise.context.ApplicationScoped;
-
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.jboss.logging.Logger;
+
+import jakarta.enterprise.context.ApplicationScoped;
 
 @ApplicationScoped
 public class PriceConsumer {

--- a/examples/amq-amqp/src/main/java/io/quarkus/qe/amqp/PriceProducer.java
+++ b/examples/amq-amqp/src/main/java/io/quarkus/qe/amqp/PriceProducer.java
@@ -2,12 +2,11 @@ package io.quarkus.qe.amqp;
 
 import java.time.Duration;
 
-import javax.enterprise.context.ApplicationScoped;
-
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
 import org.jboss.logging.Logger;
 
 import io.smallrye.mutiny.Multi;
+import jakarta.enterprise.context.ApplicationScoped;
 
 @ApplicationScoped
 public class PriceProducer {

--- a/examples/amq-amqp/src/main/java/io/quarkus/qe/amqp/PriceResource.java
+++ b/examples/amq-amqp/src/main/java/io/quarkus/qe/amqp/PriceResource.java
@@ -1,11 +1,11 @@
 package io.quarkus.qe.amqp;
 
-import javax.inject.Inject;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 
 @Path("/")
 public class PriceResource {

--- a/examples/amq-tcp/src/main/java/io/quarkus/qe/tcp/FileResource.java
+++ b/examples/amq-tcp/src/main/java/io/quarkus/qe/tcp/FileResource.java
@@ -2,10 +2,10 @@ package io.quarkus.qe.tcp;
 
 import java.io.IOException;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 @Path("/file")
 public class FileResource {

--- a/examples/amq-tcp/src/main/java/io/quarkus/qe/tcp/PriceConsumer.java
+++ b/examples/amq-tcp/src/main/java/io/quarkus/qe/tcp/PriceConsumer.java
@@ -1,12 +1,13 @@
 package io.quarkus.qe.tcp;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
 import javax.jms.ConnectionFactory;
 import javax.jms.JMSConsumer;
 import javax.jms.JMSContext;
 import javax.jms.Message;
 import javax.jms.Session;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 
 /**
  * A bean consuming prices from the JMS queue.

--- a/examples/amq-tcp/src/main/java/io/quarkus/qe/tcp/PriceProducer.java
+++ b/examples/amq-tcp/src/main/java/io/quarkus/qe/tcp/PriceProducer.java
@@ -5,14 +5,14 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.event.Observes;
 import javax.jms.ConnectionFactory;
 import javax.jms.JMSContext;
 import javax.jms.Session;
 
 import io.quarkus.runtime.ShutdownEvent;
 import io.quarkus.runtime.StartupEvent;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
 
 /**
  * A bean producing random prices every 5 seconds and sending them to the prices JMS queue.

--- a/examples/amq-tcp/src/main/java/io/quarkus/qe/tcp/PriceResource.java
+++ b/examples/amq-tcp/src/main/java/io/quarkus/qe/tcp/PriceResource.java
@@ -1,10 +1,10 @@
 package io.quarkus.qe.tcp;
 
-import javax.inject.Inject;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 /**
  * A simple resource showing the last price.

--- a/examples/amq-tcp/src/test/java/io/quarkus/qe/tcp/OpenShiftTcpAmqIT.java
+++ b/examples/amq-tcp/src/test/java/io/quarkus/qe/tcp/OpenShiftTcpAmqIT.java
@@ -1,7 +1,11 @@
 package io.quarkus.qe.tcp;
 
+import org.junit.jupiter.api.Disabled;
+
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
+// TODO: enable with next Quarkus Artemis bump
+@Disabled("Disabled until Quarkus Artemis using Jakarta is released")
 @OpenShiftScenario
 public class OpenShiftTcpAmqIT extends TcpAmqIT {
 

--- a/examples/amq-tcp/src/test/java/io/quarkus/qe/tcp/TcpAmqIT.java
+++ b/examples/amq-tcp/src/test/java/io/quarkus/qe/tcp/TcpAmqIT.java
@@ -9,6 +9,7 @@ import static org.hamcrest.Matchers.lessThan;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.AmqService;
@@ -19,6 +20,8 @@ import io.quarkus.test.services.AmqContainer;
 import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.test.services.containers.model.AmqProtocol;
 
+// TODO: enable with next Quarkus Artemis bump
+@Disabled("Disabled until Quarkus Artemis using Jakarta is released")
 @QuarkusScenario
 public class TcpAmqIT {
 

--- a/examples/blocking-reactive-model/pom.xml
+++ b/examples/blocking-reactive-model/pom.xml
@@ -11,10 +11,6 @@
     <name>Quarkus - Test Framework - Examples - Blocking + Reactive Model</name>
     <dependencies>
         <dependency>
-            <groupId>org.jboss.spec.javax.ws.rs</groupId>
-            <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc</artifactId>
         </dependency>
@@ -32,6 +28,10 @@
             <groupId>io.quarkus.qe</groupId>
             <artifactId>quarkus-test-kubernetes</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>
     </dependencies>
     <build>

--- a/examples/blocking-reactive-model/src/main/java/io/quarkus/qe/GreetingResource.java
+++ b/examples/blocking-reactive-model/src/main/java/io/quarkus/qe/GreetingResource.java
@@ -1,9 +1,9 @@
 package io.quarkus.qe;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 @Path("/hello")
 public class GreetingResource {

--- a/examples/consul/src/main/java/io/quarkus/qe/GreetingResource.java
+++ b/examples/consul/src/main/java/io/quarkus/qe/GreetingResource.java
@@ -1,11 +1,11 @@
 package io.quarkus.qe;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 @Path("/api")
 public class GreetingResource {

--- a/examples/database-mysql/src/main/java/io/quarkus/qe/database/mysql/ApplicationExceptionMapper.java
+++ b/examples/database-mysql/src/main/java/io/quarkus/qe/database/mysql/ApplicationExceptionMapper.java
@@ -1,12 +1,12 @@
 package io.quarkus.qe.database.mysql;
 
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
-import javax.ws.rs.ext.Provider;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
 
 @Provider
 public class ApplicationExceptionMapper implements ExceptionMapper<Exception> {

--- a/examples/database-mysql/src/main/java/io/quarkus/qe/database/mysql/Book.java
+++ b/examples/database-mysql/src/main/java/io/quarkus/qe/database/mysql/Book.java
@@ -1,10 +1,9 @@
 package io.quarkus.qe.database.mysql;
 
-import javax.persistence.Entity;
-import javax.persistence.Table;
-import javax.validation.constraints.NotBlank;
-
 import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
 
 @Entity
 @Table(name = "book")

--- a/examples/database-mysql/src/main/java/io/quarkus/qe/database/mysql/BookResource.java
+++ b/examples/database-mysql/src/main/java/io/quarkus/qe/database/mysql/BookResource.java
@@ -2,22 +2,21 @@ package io.quarkus.qe.database.mysql;
 
 import java.util.List;
 
-import javax.transaction.Transactional;
-import javax.validation.Valid;
-import javax.ws.rs.ClientErrorException;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.GET;
-import javax.ws.rs.NotFoundException;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-
 import io.quarkus.panache.common.Sort;
+import jakarta.transaction.Transactional;
+import jakarta.validation.Valid;
+import jakarta.ws.rs.ClientErrorException;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 
 @Path("/book")
 @Produces(MediaType.APPLICATION_JSON)

--- a/examples/database-mysql/src/main/java/io/quarkus/qe/database/mysql/NotFoundExceptionMapper.java
+++ b/examples/database-mysql/src/main/java/io/quarkus/qe/database/mysql/NotFoundExceptionMapper.java
@@ -1,9 +1,9 @@
 package io.quarkus.qe.database.mysql;
 
-import javax.ws.rs.NotFoundException;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
-import javax.ws.rs.ext.Provider;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
 
 // workaround for Quarkus providing its own NotFoundExceptionMapper
 // which is more specific than our ApplicationExceptionMapper

--- a/examples/database-mysql/src/main/java/io/quarkus/qe/database/mysql/ValidationExceptionMapper.java
+++ b/examples/database-mysql/src/main/java/io/quarkus/qe/database/mysql/ValidationExceptionMapper.java
@@ -1,14 +1,14 @@
 package io.quarkus.qe.database.mysql;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.ConstraintViolationException;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
-import javax.ws.rs.ext.Provider;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
 
 @Provider
 public class ValidationExceptionMapper implements ExceptionMapper<ConstraintViolationException> {

--- a/examples/database-oracle/src/main/java/io/quarkus/qe/database/oracle/ApplicationExceptionMapper.java
+++ b/examples/database-oracle/src/main/java/io/quarkus/qe/database/oracle/ApplicationExceptionMapper.java
@@ -1,12 +1,12 @@
 package io.quarkus.qe.database.oracle;
 
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
-import javax.ws.rs.ext.Provider;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
 
 @Provider
 public class ApplicationExceptionMapper implements ExceptionMapper<Exception> {

--- a/examples/database-oracle/src/main/java/io/quarkus/qe/database/oracle/Book.java
+++ b/examples/database-oracle/src/main/java/io/quarkus/qe/database/oracle/Book.java
@@ -1,10 +1,9 @@
 package io.quarkus.qe.database.oracle;
 
-import javax.persistence.Entity;
-import javax.persistence.Table;
-import javax.validation.constraints.NotBlank;
-
 import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
 
 @Entity
 @Table(name = "book")

--- a/examples/database-oracle/src/main/java/io/quarkus/qe/database/oracle/BookResource.java
+++ b/examples/database-oracle/src/main/java/io/quarkus/qe/database/oracle/BookResource.java
@@ -2,22 +2,21 @@ package io.quarkus.qe.database.oracle;
 
 import java.util.List;
 
-import javax.transaction.Transactional;
-import javax.validation.Valid;
-import javax.ws.rs.ClientErrorException;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.GET;
-import javax.ws.rs.NotFoundException;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-
 import io.quarkus.panache.common.Sort;
+import jakarta.transaction.Transactional;
+import jakarta.validation.Valid;
+import jakarta.ws.rs.ClientErrorException;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 
 @Path("/book")
 @Produces(MediaType.APPLICATION_JSON)

--- a/examples/database-oracle/src/main/java/io/quarkus/qe/database/oracle/NotFoundExceptionMapper.java
+++ b/examples/database-oracle/src/main/java/io/quarkus/qe/database/oracle/NotFoundExceptionMapper.java
@@ -1,9 +1,9 @@
 package io.quarkus.qe.database.oracle;
 
-import javax.ws.rs.NotFoundException;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
-import javax.ws.rs.ext.Provider;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
 
 @Provider
 public class NotFoundExceptionMapper implements ExceptionMapper<NotFoundException> {

--- a/examples/database-oracle/src/main/java/io/quarkus/qe/database/oracle/ValidationExceptionMapper.java
+++ b/examples/database-oracle/src/main/java/io/quarkus/qe/database/oracle/ValidationExceptionMapper.java
@@ -1,14 +1,14 @@
 package io.quarkus.qe.database.oracle;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.ConstraintViolationException;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
-import javax.ws.rs.ext.Provider;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
 
 @Provider
 public class ValidationExceptionMapper implements ExceptionMapper<ConstraintViolationException> {

--- a/examples/database-postgresql/src/main/java/io/quarkus/qe/database/postgresql/ApplicationExceptionMapper.java
+++ b/examples/database-postgresql/src/main/java/io/quarkus/qe/database/postgresql/ApplicationExceptionMapper.java
@@ -1,12 +1,12 @@
 package io.quarkus.qe.database.postgresql;
 
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
-import javax.ws.rs.ext.Provider;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
 
 @Provider
 public class ApplicationExceptionMapper implements ExceptionMapper<Exception> {

--- a/examples/database-postgresql/src/main/java/io/quarkus/qe/database/postgresql/Book.java
+++ b/examples/database-postgresql/src/main/java/io/quarkus/qe/database/postgresql/Book.java
@@ -1,10 +1,9 @@
 package io.quarkus.qe.database.postgresql;
 
-import javax.persistence.Entity;
-import javax.persistence.Table;
-import javax.validation.constraints.NotBlank;
-
 import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
 
 @Entity
 @Table(name = "book")

--- a/examples/database-postgresql/src/main/java/io/quarkus/qe/database/postgresql/BookResource.java
+++ b/examples/database-postgresql/src/main/java/io/quarkus/qe/database/postgresql/BookResource.java
@@ -2,22 +2,21 @@ package io.quarkus.qe.database.postgresql;
 
 import java.util.List;
 
-import javax.transaction.Transactional;
-import javax.validation.Valid;
-import javax.ws.rs.ClientErrorException;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.GET;
-import javax.ws.rs.NotFoundException;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-
 import io.quarkus.panache.common.Sort;
+import jakarta.transaction.Transactional;
+import jakarta.validation.Valid;
+import jakarta.ws.rs.ClientErrorException;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 
 @Path("/book")
 @Produces(MediaType.APPLICATION_JSON)

--- a/examples/database-postgresql/src/main/java/io/quarkus/qe/database/postgresql/NotFoundExceptionMapper.java
+++ b/examples/database-postgresql/src/main/java/io/quarkus/qe/database/postgresql/NotFoundExceptionMapper.java
@@ -1,9 +1,9 @@
 package io.quarkus.qe.database.postgresql;
 
-import javax.ws.rs.NotFoundException;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
-import javax.ws.rs.ext.Provider;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
 
 // workaround for Quarkus providing its own NotFoundExceptionMapper
 // which is more specific than our ApplicationExceptionMapper

--- a/examples/database-postgresql/src/main/java/io/quarkus/qe/database/postgresql/ValidationExceptionMapper.java
+++ b/examples/database-postgresql/src/main/java/io/quarkus/qe/database/postgresql/ValidationExceptionMapper.java
@@ -1,14 +1,14 @@
 package io.quarkus.qe.database.postgresql;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.ConstraintViolationException;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
-import javax.ws.rs.ext.Provider;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
 
 @Provider
 public class ValidationExceptionMapper implements ExceptionMapper<ConstraintViolationException> {

--- a/examples/external-applications/src/test/java/io/quarkus/qe/DevModeQuickstartUsingDefaultsIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/DevModeQuickstartUsingDefaultsIT.java
@@ -1,6 +1,7 @@
 package io.quarkus.qe;
 
 import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -10,6 +11,8 @@ import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 
+// TODO: enable when Quarkus QuickStarts migrates to Quarkus 3
+@Disabled("Disabled until Quarkus QuickStarts migrates to Quarkus 3")
 @QuarkusScenario
 @DisabledOnNative
 @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Windows does not support long file paths")

--- a/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftContainerRegistryQuickstartUsingDefaultsIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftContainerRegistryQuickstartUsingDefaultsIT.java
@@ -1,9 +1,13 @@
 package io.quarkus.qe;
 
+import org.junit.jupiter.api.Disabled;
+
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusSnapshot;
 
+// TODO: enable when Quarkus QuickStarts migrates to Quarkus 3
+@Disabled("Disabled until Quarkus QuickStarts migrates to Quarkus 3")
 @DisabledOnQuarkusSnapshot(reason = "999-SNAPSHOT is not available in the Maven repositories in OpenShift")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingContainerRegistry)
 public class OpenShiftContainerRegistryQuickstartUsingDefaultsIT extends QuickstartUsingDefaultsIT {

--- a/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftExtensionQuickstartUsingDefaultsIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftExtensionQuickstartUsingDefaultsIT.java
@@ -1,6 +1,7 @@
 package io.quarkus.qe;
 
 import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
@@ -9,6 +10,8 @@ import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusSnapshot;
 import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 
+// TODO: enable when Quarkus QuickStarts migrates to Quarkus 3
+@Disabled("Disabled until Quarkus QuickStarts migrates to Quarkus 3")
 @DisabledOnQuarkusSnapshot(reason = "999-SNAPSHOT is not available in the Maven repositories in OpenShift")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
 public class OpenShiftExtensionQuickstartUsingDefaultsIT {

--- a/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftExtensionUsingDockerBuildStrategyQuickstartUsingDefaultsIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftExtensionUsingDockerBuildStrategyQuickstartUsingDefaultsIT.java
@@ -1,6 +1,7 @@
 package io.quarkus.qe;
 
 import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
@@ -9,6 +10,8 @@ import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusSnapshot;
 import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 
+// TODO: enable when Quarkus QuickStarts migrates to Quarkus 3
+@Disabled("Disabled until Quarkus QuickStarts migrates to Quarkus 3")
 @DisabledOnQuarkusSnapshot(reason = "999-SNAPSHOT is not available in the Maven repositories in OpenShift")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtensionAndDockerBuildStrategy)
 public class OpenShiftExtensionUsingDockerBuildStrategyQuickstartUsingDefaultsIT {

--- a/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftS2iQuickstartUsingDefaultsIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftS2iQuickstartUsingDefaultsIT.java
@@ -1,8 +1,12 @@
 package io.quarkus.qe;
 
+import org.junit.jupiter.api.Disabled;
+
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusSnapshot;
 
+// TODO: enable when Quarkus QuickStarts migrates to Quarkus 3
+@Disabled("Disabled until Quarkus QuickStarts migrates to Quarkus 3")
 @DisabledOnQuarkusSnapshot(reason = "999-SNAPSHOT is not available in the Maven repositories in OpenShift")
 @OpenShiftScenario
 public class OpenShiftS2iQuickstartUsingDefaultsIT extends QuickstartUsingDefaultsIT {

--- a/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftS2iQuickstartUsingUberJarIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftS2iQuickstartUsingUberJarIT.java
@@ -1,6 +1,7 @@
 package io.quarkus.qe;
 
 import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
@@ -9,6 +10,8 @@ import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusSnapshot;
 import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 
+// TODO: enable when Quarkus QuickStarts migrates to Quarkus 3
+@Disabled("Disabled until Quarkus QuickStarts migrates to Quarkus 3")
 @DisabledOnNative(reason = "This is to verify uber-jar, so it does not make sense on Native")
 @DisabledOnQuarkusSnapshot(reason = "999-SNAPSHOT is not available in the Maven repositories in OpenShift")
 @OpenShiftScenario

--- a/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftTodoDemoIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftTodoDemoIT.java
@@ -1,9 +1,13 @@
 package io.quarkus.qe;
 
+import org.junit.jupiter.api.Disabled;
+
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusSnapshot;
 
+// TODO: enable when Quarkus QuickStarts migrates to Quarkus 3
+@Disabled("Disabled until Quarkus QuickStarts migrates to Quarkus 3")
 @DisabledOnQuarkusSnapshot(reason = "999-SNAPSHOT is not available in the Maven repositories in OpenShift")
 @DisabledOnNative(reason = "Native + s2i not supported")
 @OpenShiftScenario

--- a/examples/external-applications/src/test/java/io/quarkus/qe/QuickstartUsingDefaultsIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/QuickstartUsingDefaultsIT.java
@@ -1,6 +1,7 @@
 package io.quarkus.qe;
 
 import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -9,6 +10,8 @@ import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 
+// TODO: enable when Quarkus QuickStarts migrates to Quarkus 3
+@Disabled("Disabled until Quarkus QuickStarts migrates to Quarkus 3")
 @QuarkusScenario
 @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Windows does not support long file paths")
 public class QuickstartUsingDefaultsIT {

--- a/examples/external-applications/src/test/java/io/quarkus/qe/QuickstartUsingUsingUberJarIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/QuickstartUsingUsingUberJarIT.java
@@ -1,6 +1,7 @@
 package io.quarkus.qe;
 
 import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -10,6 +11,8 @@ import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 
+// TODO: enable when Quarkus QuickStarts migrates to Quarkus 3
+@Disabled("Disabled until Quarkus QuickStarts migrates to Quarkus 3")
 @QuarkusScenario
 @DisabledOnNative(reason = "This is to verify uber-jar, so it does not make sense on Native")
 @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Windows does not support long file paths")

--- a/examples/external-applications/src/test/java/io/quarkus/qe/TodoDemoIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/TodoDemoIT.java
@@ -1,6 +1,7 @@
 package io.quarkus.qe;
 
 import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
@@ -8,6 +9,8 @@ import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 
+// TODO: enable when Quarkus QuickStarts migrates to Quarkus 3
+@Disabled("Disabled until Quarkus 3 is released and TODO application migrates to it")
 @DisabledOnNative(reason = "This scenario is using uber-jar, so it's incompatible with Native")
 @QuarkusScenario
 public class TodoDemoIT {

--- a/examples/funqy-knative-events/src/main/java/io/quarkus/qe/funqy/knativeevents/BrokerClient.java
+++ b/examples/funqy-knative-events/src/main/java/io/quarkus/qe/funqy/knativeevents/BrokerClient.java
@@ -2,19 +2,19 @@ package io.quarkus.qe.funqy.knativeevents;
 
 import java.util.UUID;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.HeaderParam;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MultivaluedHashMap;
-import javax.ws.rs.core.MultivaluedMap;
-
 import org.eclipse.microprofile.rest.client.annotation.ClientHeaderParam;
 import org.eclipse.microprofile.rest.client.annotation.RegisterClientHeaders;
 import org.eclipse.microprofile.rest.client.ext.ClientHeadersFactory;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
 
 /**
  * BrokerClient enables sending of events to the broker.

--- a/examples/funqy-knative-events/src/main/resources/application.properties
+++ b/examples/funqy-knative-events/src/main/resources/application.properties
@@ -2,4 +2,4 @@ quarkus.funqy.knative-events.mapping.configChain.trigger=defaultChain.output
 quarkus.funqy.knative-events.mapping.configChain.response-type=annotated
 quarkus.funqy.knative-events.mapping.configChain.response-source=configChain
 quarkus.rest-client.broker.url=${BROKER_URL:http://localhost:8080}
-quarkus.rest-client.broker.scope=javax.inject.Singleton
+quarkus.rest-client.broker.scope=jakarta.inject.Singleton

--- a/examples/greetings/src/main/java/io/quarkus/qe/GreetingResource.java
+++ b/examples/greetings/src/main/java/io/quarkus/qe/GreetingResource.java
@@ -2,12 +2,12 @@ package io.quarkus.qe;
 
 import java.io.IOException;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 @Path("/greeting")
 public class GreetingResource {

--- a/examples/greetings/src/main/java/io/quarkus/qe/ReactiveGreetingResource.java
+++ b/examples/greetings/src/main/java/io/quarkus/qe/ReactiveGreetingResource.java
@@ -1,13 +1,12 @@
 package io.quarkus.qe;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import io.smallrye.mutiny.Uni;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 @Path("/reactive-greeting")
 public class ReactiveGreetingResource {

--- a/examples/greetings/src/main/java/io/quarkus/qe/ValidateCustomProperty.java
+++ b/examples/greetings/src/main/java/io/quarkus/qe/ValidateCustomProperty.java
@@ -1,12 +1,11 @@
 package io.quarkus.qe;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.event.Observes;
-
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 
 import io.quarkus.runtime.StartupEvent;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
 
 @ApplicationScoped
 public class ValidateCustomProperty {

--- a/examples/https/src/main/java/io/quarkus/qe/GreetingResource.java
+++ b/examples/https/src/main/java/io/quarkus/qe/GreetingResource.java
@@ -1,9 +1,9 @@
 package io.quarkus.qe;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 @Path("/greeting")
 public class GreetingResource {

--- a/examples/infinispan/src/main/java/io/quarkus/qe/books/Book.java
+++ b/examples/infinispan/src/main/java/io/quarkus/qe/books/Book.java
@@ -2,10 +2,10 @@ package io.quarkus.qe.books;
 
 import java.util.Objects;
 
-import javax.validation.constraints.NotBlank;
-
 import org.infinispan.protostream.annotations.ProtoFactory;
 import org.infinispan.protostream.annotations.ProtoField;
+
+import jakarta.validation.constraints.NotBlank;
 
 public class Book {
 

--- a/examples/infinispan/src/main/java/io/quarkus/qe/books/BookCacheInitializer.java
+++ b/examples/infinispan/src/main/java/io/quarkus/qe/books/BookCacheInitializer.java
@@ -1,13 +1,12 @@
 package io.quarkus.qe.books;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.event.Observes;
-import javax.inject.Inject;
-
 import org.infinispan.client.hotrod.RemoteCacheManager;
 import org.infinispan.commons.configuration.XMLStringConfiguration;
 
 import io.quarkus.runtime.StartupEvent;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
 
 @ApplicationScoped
 public class BookCacheInitializer {

--- a/examples/infinispan/src/main/java/io/quarkus/qe/books/BookResource.java
+++ b/examples/infinispan/src/main/java/io/quarkus/qe/books/BookResource.java
@@ -1,18 +1,17 @@
 package io.quarkus.qe.books;
 
-import javax.inject.Inject;
-import javax.validation.Valid;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-
 import org.infinispan.client.hotrod.RemoteCache;
 
 import io.quarkus.infinispan.client.Remote;
+import jakarta.inject.Inject;
+import jakarta.validation.Valid;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 @Path("/book")
 public class BookResource {

--- a/examples/jaeger/pom.xml
+++ b/examples/jaeger/pom.xml
@@ -16,7 +16,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-opentelemetry-exporter-otlp</artifactId>
+            <artifactId>quarkus-opentelemetry</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus.qe</groupId>

--- a/examples/jaeger/src/main/java/io/quarkus/qe/ClientResource.java
+++ b/examples/jaeger/src/main/java/io/quarkus/qe/ClientResource.java
@@ -1,11 +1,10 @@
 package io.quarkus.qe;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-
 import io.opentelemetry.api.trace.Span;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 @Path("/client")
 public class ClientResource {

--- a/examples/kafka-registry/src/main/java/io/quarkus/qe/kafka/VerticleDeployer.java
+++ b/examples/kafka-registry/src/main/java/io/quarkus/qe/kafka/VerticleDeployer.java
@@ -1,15 +1,14 @@
 package io.quarkus.qe.kafka;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.event.Observes;
-import javax.enterprise.inject.Instance;
-import javax.inject.Inject;
-
 import io.quarkus.qe.kafka.config.VertxKProducerConfig;
 import io.quarkus.qe.kafka.producers.StockPriceProducer;
 import io.quarkus.runtime.StartupEvent;
 import io.smallrye.mutiny.vertx.core.AbstractVerticle;
 import io.vertx.mutiny.core.Vertx;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
 
 @ApplicationScoped
 public class VerticleDeployer {

--- a/examples/kafka-registry/src/main/java/io/quarkus/qe/kafka/consumer/KStockPriceConsumer.java
+++ b/examples/kafka-registry/src/main/java/io/quarkus/qe/kafka/consumer/KStockPriceConsumer.java
@@ -2,9 +2,6 @@ package io.quarkus.qe.kafka.consumer;
 
 import java.util.function.BiConsumer;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-
 import org.eclipse.microprofile.reactive.messaging.Acknowledgment;
 import org.eclipse.microprofile.reactive.messaging.Channel;
 import org.eclipse.microprofile.reactive.messaging.Emitter;
@@ -18,6 +15,8 @@ import io.quarkus.qe.kafka.status;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.vertx.core.AbstractVerticle;
 import io.smallrye.reactive.messaging.annotations.Broadcast;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 
 @ApplicationScoped
 public class KStockPriceConsumer extends AbstractVerticle {

--- a/examples/kafka-registry/src/main/java/io/quarkus/qe/kafka/producers/StockPriceProducer.java
+++ b/examples/kafka-registry/src/main/java/io/quarkus/qe/kafka/producers/StockPriceProducer.java
@@ -4,9 +4,6 @@ import java.util.Random;
 import java.util.function.BiConsumer;
 import java.util.stream.IntStream;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-
 import org.eclipse.microprofile.reactive.messaging.Channel;
 import org.eclipse.microprofile.reactive.messaging.Emitter;
 import org.eclipse.microprofile.reactive.messaging.OnOverflow;
@@ -16,6 +13,8 @@ import io.quarkus.qe.kafka.StockPrice;
 import io.quarkus.qe.kafka.config.VertxKProducerConfig;
 import io.quarkus.qe.kafka.status;
 import io.smallrye.mutiny.Uni;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 
 @ApplicationScoped
 public class StockPriceProducer {

--- a/examples/kafka-registry/src/main/java/io/quarkus/qe/kafka/rest/StockPriceMonitor.java
+++ b/examples/kafka-registry/src/main/java/io/quarkus/qe/kafka/rest/StockPriceMonitor.java
@@ -1,14 +1,14 @@
 package io.quarkus.qe.kafka.rest;
 
-import javax.inject.Inject;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-
 import org.eclipse.microprofile.reactive.messaging.Channel;
 import org.jboss.resteasy.annotations.SseElementType;
 import org.reactivestreams.Publisher;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 @Path("/stock")
 public class StockPriceMonitor {

--- a/examples/kafka-registry/src/test/java/io/quarkus/qe/ConfluentKafkaWithRegistryMessagingIT.java
+++ b/examples/kafka-registry/src/test/java/io/quarkus/qe/ConfluentKafkaWithRegistryMessagingIT.java
@@ -5,11 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.sse.SseEventSource;
-
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.KafkaService;
@@ -19,6 +14,10 @@ import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.KafkaContainer;
 import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.test.services.containers.model.KafkaVendor;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.sse.SseEventSource;
 
 @QuarkusScenario
 public class ConfluentKafkaWithRegistryMessagingIT {

--- a/examples/kafka-registry/src/test/java/io/quarkus/qe/StrimziKafkaWithRegistryMessagingIT.java
+++ b/examples/kafka-registry/src/test/java/io/quarkus/qe/StrimziKafkaWithRegistryMessagingIT.java
@@ -6,11 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.sse.SseEventSource;
-
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.KafkaService;
@@ -20,6 +15,10 @@ import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.KafkaContainer;
 import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.test.services.containers.model.KafkaVendor;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.sse.SseEventSource;
 
 @QuarkusScenario
 public class StrimziKafkaWithRegistryMessagingIT {

--- a/examples/kafka-streams/src/main/java/io/quarkus/qe/kafka/producer/LoginEventsProducer.java
+++ b/examples/kafka-streams/src/main/java/io/quarkus/qe/kafka/producer/LoginEventsProducer.java
@@ -5,8 +5,6 @@ import java.util.Base64;
 import java.util.List;
 import java.util.Random;
 
-import javax.enterprise.context.ApplicationScoped;
-
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
 
@@ -15,6 +13,7 @@ import io.quarkus.qe.kafka.streams.WindowedLoginDeniedStream;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.reactive.messaging.kafka.Record;
 import io.vertx.core.json.Json;
+import jakarta.enterprise.context.ApplicationScoped;
 
 @ApplicationScoped
 public class LoginEventsProducer {

--- a/examples/kafka-streams/src/main/java/io/quarkus/qe/kafka/rest/AlertMonitor.java
+++ b/examples/kafka-streams/src/main/java/io/quarkus/qe/kafka/rest/AlertMonitor.java
@@ -1,16 +1,15 @@
 package io.quarkus.qe.kafka.rest;
 
-import javax.inject.Inject;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-
 import org.eclipse.microprofile.reactive.messaging.Channel;
 import org.jboss.resteasy.annotations.SseElementType;
 import org.reactivestreams.Publisher;
 
 import io.quarkus.qe.kafka.streams.WindowedLoginDeniedStream;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 @Path("/monitor")
 public class AlertMonitor {

--- a/examples/kafka-streams/src/main/java/io/quarkus/qe/kafka/streams/WindowedLoginDeniedStream.java
+++ b/examples/kafka-streams/src/main/java/io/quarkus/qe/kafka/streams/WindowedLoginDeniedStream.java
@@ -1,12 +1,9 @@
 package io.quarkus.qe.kafka.streams;
 
-import static javax.ws.rs.core.Response.Status.FORBIDDEN;
-import static javax.ws.rs.core.Response.Status.UNAUTHORIZED;
+import static jakarta.ws.rs.core.Response.Status.FORBIDDEN;
+import static jakarta.ws.rs.core.Response.Status.UNAUTHORIZED;
 
 import java.time.Duration;
-
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Produces;
 
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
@@ -24,6 +21,8 @@ import io.quarkus.kafka.client.serialization.JsonbSerde;
 import io.quarkus.qe.kafka.model.LoginAggregation;
 import io.quarkus.qe.kafka.model.LoginAttempt;
 import io.smallrye.reactive.messaging.annotations.Broadcast;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
 
 @ApplicationScoped
 public class WindowedLoginDeniedStream {

--- a/examples/kafka-streams/src/test/java/io/quarkus/qe/AlertMonitorIT.java
+++ b/examples/kafka-streams/src/test/java/io/quarkus/qe/AlertMonitorIT.java
@@ -5,11 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.sse.SseEventSource;
-
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.KafkaService;
@@ -19,6 +14,10 @@ import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.KafkaContainer;
 import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.test.services.containers.model.KafkaVendor;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.sse.SseEventSource;
 
 @QuarkusScenario
 public class AlertMonitorIT {

--- a/examples/kafka/src/main/java/io/quarkus/qe/PriceConsumer.java
+++ b/examples/kafka/src/main/java/io/quarkus/qe/PriceConsumer.java
@@ -3,9 +3,9 @@ package io.quarkus.qe;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
-import javax.enterprise.context.ApplicationScoped;
-
 import org.eclipse.microprofile.reactive.messaging.Incoming;
+
+import jakarta.enterprise.context.ApplicationScoped;
 
 /**
  * A simple resource retrieving the in-memory "my-data-stream" and sending the items as server-sent events.

--- a/examples/kafka/src/main/java/io/quarkus/qe/PriceConverter.java
+++ b/examples/kafka/src/main/java/io/quarkus/qe/PriceConverter.java
@@ -1,11 +1,10 @@
 package io.quarkus.qe;
 
-import javax.enterprise.context.ApplicationScoped;
-
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
 
 import io.smallrye.reactive.messaging.annotations.Broadcast;
+import jakarta.enterprise.context.ApplicationScoped;
 
 /**
  * A bean consuming data from the "prices" Kafka topic and applying some conversion.

--- a/examples/kafka/src/main/java/io/quarkus/qe/PriceGenerator.java
+++ b/examples/kafka/src/main/java/io/quarkus/qe/PriceGenerator.java
@@ -3,11 +3,10 @@ package io.quarkus.qe;
 import java.time.Duration;
 import java.util.Random;
 
-import javax.enterprise.context.ApplicationScoped;
-
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
 
 import io.smallrye.mutiny.Multi;
+import jakarta.enterprise.context.ApplicationScoped;
 
 /**
  * A bean producing random prices every 1 seconds.

--- a/examples/kafka/src/main/java/io/quarkus/qe/PriceResource.java
+++ b/examples/kafka/src/main/java/io/quarkus/qe/PriceResource.java
@@ -1,10 +1,10 @@
 package io.quarkus.qe;
 
-import javax.inject.Inject;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 /**
  * A simple resource retrieving the in-memory "my-data-stream" and sending the items as server-sent events.

--- a/examples/keycloak/src/main/java/io/quarkus/qe/AdminResource.java
+++ b/examples/keycloak/src/main/java/io/quarkus/qe/AdminResource.java
@@ -1,15 +1,14 @@
 package io.quarkus.qe;
 
-import javax.annotation.security.RolesAllowed;
-import javax.inject.Inject;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-
 import org.eclipse.microprofile.jwt.JsonWebToken;
 
 import io.quarkus.security.identity.SecurityIdentity;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 @Path("/admin")
 @RolesAllowed("test-admin-role")

--- a/examples/keycloak/src/main/java/io/quarkus/qe/UserResource.java
+++ b/examples/keycloak/src/main/java/io/quarkus/qe/UserResource.java
@@ -1,15 +1,14 @@
 package io.quarkus.qe;
 
-import javax.annotation.security.RolesAllowed;
-import javax.inject.Inject;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-
 import org.eclipse.microprofile.jwt.JsonWebToken;
 
 import io.quarkus.security.identity.SecurityIdentity;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 @Path("/user")
 @RolesAllowed("test-user-role")

--- a/examples/microprofile/src/main/java/io/quarkus/qe/GreetingResource.java
+++ b/examples/microprofile/src/main/java/io/quarkus/qe/GreetingResource.java
@@ -1,9 +1,9 @@
 package io.quarkus.qe;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 @Path("/greeting")
 public class GreetingResource {

--- a/examples/microprofile/src/test/java/io/quarkus/qe/VerifyNonAppEndpointsIT.java
+++ b/examples/microprofile/src/test/java/io/quarkus/qe/VerifyNonAppEndpointsIT.java
@@ -32,7 +32,6 @@ public class VerifyNonAppEndpointsIT {
     public void verifyNonAppRootPathIsWorking() {
         givenRootPath("/api");
         givenNonAppRootPath("/q");
-        givenNonAppRootRedirectedIsDisabled();
         whenUpdateProperties();
         thenNonAppEndpointsShouldBeOk("/q");
     }
@@ -41,7 +40,6 @@ public class VerifyNonAppEndpointsIT {
     public void verifyNonAppRootPathIsWorkingWhenRootPathChanged() {
         givenRootPath("/");
         givenNonAppRootPath("/q");
-        givenNonAppRootRedirectedIsDisabled();
         whenUpdateProperties();
         thenNonAppEndpointsShouldBeOk("/q");
     }
@@ -50,7 +48,6 @@ public class VerifyNonAppEndpointsIT {
     public void verifyNonAppRootPathIsNotRedirected() {
         givenRootPath("/api");
         givenNonAppRootPath("/");
-        givenNonAppRootRedirectedIsDisabled();
         whenUpdateProperties();
         thenNonAppEndpointsShouldBeNotFound("/api");
     }
@@ -61,9 +58,6 @@ public class VerifyNonAppEndpointsIT {
     public void verifyNonAppRootPathIsRedirected() {
         givenRootPath("/api");
         givenNonAppRootPath("/q");
-        givenNonAppRootRedirectedIsEnabled();
-        whenUpdateProperties();
-        thenNonAppEndpointsShouldBeRedirected("/api");
     }
 
     private void givenNonAppRootPath(String path) {
@@ -74,28 +68,8 @@ public class VerifyNonAppEndpointsIT {
         app.withProperty("quarkus.http.root-path", path);
     }
 
-    private void givenNonAppRootRedirectedIsEnabled() {
-        givenNonAppRootRedirectedIs(true);
-    }
-
-    private void givenNonAppRootRedirectedIsDisabled() {
-        givenNonAppRootRedirectedIs(false);
-    }
-
-    private void givenNonAppRootRedirectedIs(boolean flag) {
-        app.withProperty("quarkus.http.redirect-to-non-application-root-path", "" + flag);
-    }
-
     private void whenUpdateProperties() {
         app.restart();
-    }
-
-    private void thenNonAppEndpointsShouldBeRedirected(String basePath) {
-        for (String endpoint : NON_APP_ENDPOINTS) {
-            untilAsserted(() -> app.given().redirects().follow(false).get(basePath + endpoint).getStatusCode(),
-                    actual -> assertEquals(HttpStatus.SC_MOVED_PERMANENTLY, actual,
-                            "Endpoint '" + endpoint + "' is not redirected"));
-        }
     }
 
     private void thenNonAppEndpointsShouldBeOk(String basePath) {

--- a/examples/pingpong/src/main/java/io/quarkus/qe/PingResource.java
+++ b/examples/pingpong/src/main/java/io/quarkus/qe/PingResource.java
@@ -1,9 +1,9 @@
 package io.quarkus.qe;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 @Path("/ping")
 public class PingResource {

--- a/examples/pingpong/src/main/java/io/quarkus/qe/PongResource.java
+++ b/examples/pingpong/src/main/java/io/quarkus/qe/PongResource.java
@@ -1,9 +1,9 @@
 package io.quarkus.qe;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 @Path("/pong")
 public class PongResource {

--- a/examples/quarkus-cli/src/test/java/io/quarkus/qe/QuarkusCliClientIT.java
+++ b/examples/quarkus-cli/src/test/java/io/quarkus/qe/QuarkusCliClientIT.java
@@ -29,6 +29,8 @@ public class QuarkusCliClientIT {
     static final String RESTEASY_REACTIVE_EXTENSION = "quarkus-resteasy-reactive";
     static final String SMALLRYE_HEALTH_EXTENSION = "quarkus-smallrye-health";
     static final int CMD_DELAY_SEC = 3;
+    // TODO: we only specify stream till first Quarkus 3 final is released to avoid javax/jakarta conflicts
+    private static final String STREAM_VERSION = "3.0";
 
     @Inject
     static QuarkusCliClient cliClient;
@@ -36,7 +38,8 @@ public class QuarkusCliClientIT {
     @Test
     public void shouldCreateApplicationOnJvm() {
         // Create application
-        QuarkusCliRestService app = cliClient.createApplication("app");
+        QuarkusCliRestService app = cliClient.createApplication("app",
+                QuarkusCliClient.CreateApplicationRequest.defaults().withStream(STREAM_VERSION));
 
         // Should build on Jvm
         QuarkusCliClient.Result result = app.buildOnJvm();
@@ -50,7 +53,8 @@ public class QuarkusCliClientIT {
     @Test
     public void shouldCreateExtension() {
         // Create extension
-        QuarkusCliDefaultService app = cliClient.createExtension("extension-abc");
+        QuarkusCliDefaultService app = cliClient.createExtension("extension-abc",
+                QuarkusCliClient.CreateExtensionRequest.defaults().withStream(STREAM_VERSION));
 
         // Should build on Jvm
         QuarkusCliClient.Result result = app.buildOnJvm();
@@ -59,7 +63,8 @@ public class QuarkusCliClientIT {
 
     @Test
     public void shouldCreateApplicationUsingArtifactId() {
-        QuarkusCliRestService app = cliClient.createApplication("com.mycompany:my-app");
+        QuarkusCliRestService app = cliClient.createApplication("com.mycompany:my-app",
+                QuarkusCliClient.CreateApplicationRequest.defaults().withStream(STREAM_VERSION));
         assertEquals("my-app", app.getServiceFolder().getFileName().toString(), "The application directory differs.");
 
         QuarkusCliClient.Result result = app.buildOnJvm();
@@ -69,7 +74,8 @@ public class QuarkusCliClientIT {
     @Test
     public void shouldAddAndRemoveExtensions() throws InterruptedException {
         // Create application
-        QuarkusCliRestService app = cliClient.createApplication("app");
+        QuarkusCliRestService app = cliClient.createApplication("app",
+                QuarkusCliClient.CreateApplicationRequest.defaults().withStream(STREAM_VERSION));
 
         // By default, it installs only "quarkus-resteasy-reactive"
         assertInstalledExtensions(app, RESTEASY_REACTIVE_EXTENSION);

--- a/examples/restclient/src/main/java/io/quarkus/qe/PingResource.java
+++ b/examples/restclient/src/main/java/io/quarkus/qe/PingResource.java
@@ -1,12 +1,12 @@
 package io.quarkus.qe;
 
-import javax.inject.Inject;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-
 import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 @Path("/ping")
 public class PingResource {

--- a/examples/restclient/src/main/java/io/quarkus/qe/PongClient.java
+++ b/examples/restclient/src/main/java/io/quarkus/qe/PongClient.java
@@ -1,11 +1,11 @@
 package io.quarkus.qe;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 @RegisterRestClient
 @Path("/pong")

--- a/examples/restclient/src/main/java/io/quarkus/qe/PongResource.java
+++ b/examples/restclient/src/main/java/io/quarkus/qe/PongResource.java
@@ -1,9 +1,9 @@
 package io.quarkus.qe;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 @Path("/pong")
 public class PongResource {

--- a/extensions/metrics/src/main/java/io/quarkus/qe/GreetingResource.java
+++ b/extensions/metrics/src/main/java/io/quarkus/qe/GreetingResource.java
@@ -1,9 +1,9 @@
 package io.quarkus.qe;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 @Path("/greeting")
 public class GreetingResource {

--- a/extensions/tracing/src/main/java/io/quarkus/qe/GreetingResource.java
+++ b/extensions/tracing/src/main/java/io/quarkus/qe/GreetingResource.java
@@ -1,9 +1,9 @@
 package io.quarkus.qe;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 @Path("/greeting")
 public class GreetingResource {

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <htmlunit.version>2.70.0</htmlunit.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.15.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>3.0.0.Alpha3</quarkus.platform.version>
         <exclude.tests.with.tags>quarkus-cli</exclude.tests.with.tags>
         <include.tests>**/*IT.java</include.tests>
         <exclude.openshift.tests>**/OpenShift*IT.java</exclude.openshift.tests>

--- a/quarkus-test-cli/src/test/java/io/quarkus/test/QuarkusCliClientIT.java
+++ b/quarkus-test-cli/src/test/java/io/quarkus/test/QuarkusCliClientIT.java
@@ -1,5 +1,6 @@
 package io.quarkus.test;
 
+import static io.quarkus.test.bootstrap.QuarkusCliClient.CreateApplicationRequest.defaults;
 import static io.quarkus.test.utils.AwaitilityUtils.untilAsserted;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -35,6 +36,8 @@ public class QuarkusCliClientIT {
     static final String RESTEASY_REACTIVE_JACKSON_EXTENSION = "quarkus-resteasy-reactive-jackson";
     static final String SMALLRYE_HEALTH_EXTENSION = "quarkus-smallrye-health";
     static final int CMD_DELAY_SEC = 3;
+    // TODO: we only specify stream till first Quarkus 3 final is released to avoid javax/jakarta conflicts
+    private static final String STREAM_VERSION = "3.0";
 
     @Inject
     static QuarkusCliClient cliClient;
@@ -51,7 +54,7 @@ public class QuarkusCliClientIT {
     @Test
     public void shouldCreateApplicationOnJvm() {
         // Create application
-        QuarkusCliRestService app = cliClient.createApplication("app");
+        QuarkusCliRestService app = cliClient.createApplication("app", defaults().withStream(STREAM_VERSION));
 
         // Should build on Jvm
         QuarkusCliClient.Result result = app.buildOnJvm();
@@ -67,7 +70,7 @@ public class QuarkusCliClientIT {
     @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Windows does not support Linux containers yet")
     public void shouldBuildApplicationOnNativeUsingDocker() {
         // Create application
-        QuarkusCliRestService app = cliClient.createApplication("app");
+        QuarkusCliRestService app = cliClient.createApplication("app", defaults().withStream(STREAM_VERSION));
 
         // Should build on Native
         QuarkusCliClient.Result result = app.buildOnNative();
@@ -78,8 +81,8 @@ public class QuarkusCliClientIT {
     public void shouldCreateApplicationWithCodeStarter() {
         // Create application with Resteasy Jackson
         QuarkusCliRestService app = cliClient.createApplication("app",
-                QuarkusCliClient.CreateApplicationRequest.defaults().withExtensions(RESTEASY_SPRING_WEB_EXTENSION,
-                        RESTEASY_REACTIVE_JACKSON_EXTENSION));
+                defaults().withExtensions(RESTEASY_SPRING_WEB_EXTENSION,
+                        RESTEASY_REACTIVE_JACKSON_EXTENSION).withStream(STREAM_VERSION));
 
         // Verify By default, it installs only "quarkus-resteasy"
         assertInstalledExtensions(app, RESTEASY_SPRING_WEB_EXTENSION, RESTEASY_REACTIVE_JACKSON_EXTENSION);
@@ -91,7 +94,7 @@ public class QuarkusCliClientIT {
 
     @Test
     public void shouldCreateApplicationUsingArtifactId() {
-        QuarkusCliRestService app = cliClient.createApplication("com.mycompany:my-app");
+        QuarkusCliRestService app = cliClient.createApplication("com.mycompany:my-app", defaults().withStream(STREAM_VERSION));
         assertEquals("my-app", app.getServiceFolder().getFileName().toString(), "The application directory differs.");
 
         QuarkusCliClient.Result result = app.buildOnJvm();
@@ -101,7 +104,7 @@ public class QuarkusCliClientIT {
     @Test
     public void shouldAddAndRemoveExtensions() throws InterruptedException {
         // Create application
-        QuarkusCliRestService app = cliClient.createApplication("app");
+        QuarkusCliRestService app = cliClient.createApplication("app", defaults().withStream(STREAM_VERSION));
 
         // By default, it installs only "quarkus-resteasy-reactive"
         assertInstalledExtensions(app, RESTEASY_REACTIVE_EXTENSION);


### PR DESCRIPTION
### Summary

Bumps Quarkus from 2.15.1.Final to 3 Alpha 3 and migrate `javax` dependencies to `jakarta`.

With https://github.com/quarkusio/quarkus/commit/e94ac2b8a2c973b81a23498b288fba4f6df7e76a configuration property `quarkus.http.redirect-to-non-application-root-path` does not exists anymore, therefore the part of tests that used it is removed.

Quarkus Quickstarts, TODO application and Quarkus Artemis are still using `javax`, therefore we need to disable these tests till they are using Quarkus 3.

Quarkus DEV cli tests must be disabled as generated app contains `javax` imports as the latest Quarkus final version is used.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring
- [ ] Dependency update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)