### PR TITLE
Fix OpenShiftClient NPE when trying to enrich template and disable tests using OpenShift extension

### DIFF
--- a/examples/consul/src/test/java/io/quarkus/qe/OpenShiftUsingExtensionBuildTimeGreetingResourceIT.java
+++ b/examples/consul/src/test/java/io/quarkus/qe/OpenShiftUsingExtensionBuildTimeGreetingResourceIT.java
@@ -1,8 +1,11 @@
 package io.quarkus.qe;
 
+import org.junit.jupiter.api.Disabled;
+
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
 public class OpenShiftUsingExtensionBuildTimeGreetingResourceIT extends BuildTimeGreetingResourceIT {
 }

--- a/examples/funqy-knative-events/src/test/java/io/quarkus/qe/funqy/knativeevents/OpenShiftUsingExtensionAndServerlessFunqyKnEventsIT.java
+++ b/examples/funqy-knative-events/src/test/java/io/quarkus/qe/funqy/knativeevents/OpenShiftUsingExtensionAndServerlessFunqyKnEventsIT.java
@@ -4,6 +4,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.hamcrest.Matcher;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
@@ -12,6 +13,7 @@ import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.test.services.knative.eventing.FunqyKnativeEventsService;
 import io.quarkus.test.services.knative.eventing.OpenShiftExtensionFunqyKnativeEventsService;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
 public class OpenShiftUsingExtensionAndServerlessFunqyKnEventsIT {
 

--- a/examples/keycloak/src/test/java/io/quarkus/qe/OpenShiftUsingDockerBuildStrategySecurityResourceIT.java
+++ b/examples/keycloak/src/test/java/io/quarkus/qe/OpenShiftUsingDockerBuildStrategySecurityResourceIT.java
@@ -1,8 +1,11 @@
 package io.quarkus.qe;
 
+import org.junit.jupiter.api.Disabled;
+
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtensionAndDockerBuildStrategy)
 public class OpenShiftUsingDockerBuildStrategySecurityResourceIT extends SecurityResourceIT {
 }

--- a/examples/keycloak/src/test/java/io/quarkus/qe/OpenShiftUsingExtensionLegacyKeycloakIT.java
+++ b/examples/keycloak/src/test/java/io/quarkus/qe/OpenShiftUsingExtensionLegacyKeycloakIT.java
@@ -1,8 +1,11 @@
 package io.quarkus.qe;
 
+import org.junit.jupiter.api.Disabled;
+
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
 public class OpenShiftUsingExtensionLegacyKeycloakIT extends LegacyKeycloakIT {
 }

--- a/examples/keycloak/src/test/java/io/quarkus/qe/OpenShiftUsingExtensionSecurityResourceIT.java
+++ b/examples/keycloak/src/test/java/io/quarkus/qe/OpenShiftUsingExtensionSecurityResourceIT.java
@@ -1,8 +1,11 @@
 package io.quarkus.qe;
 
+import org.junit.jupiter.api.Disabled;
+
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
 public class OpenShiftUsingExtensionSecurityResourceIT extends SecurityResourceIT {
 }

--- a/examples/pingpong/src/test/java/io/quarkus/qe/OpenShiftUsingExtensionAndDockerBuildAndServerlessPingPongResourceIT.java
+++ b/examples/pingpong/src/test/java/io/quarkus/qe/OpenShiftUsingExtensionAndDockerBuildAndServerlessPingPongResourceIT.java
@@ -1,8 +1,11 @@
 package io.quarkus.qe;
 
+import org.junit.jupiter.api.Disabled;
+
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtensionAndDockerBuildStrategy)
 public class OpenShiftUsingExtensionAndDockerBuildAndServerlessPingPongResourceIT extends PingPongResourceIT {
 }

--- a/examples/pingpong/src/test/java/io/quarkus/qe/OpenShiftUsingExtensionAndDockerBuildPingPongResourceIT.java
+++ b/examples/pingpong/src/test/java/io/quarkus/qe/OpenShiftUsingExtensionAndDockerBuildPingPongResourceIT.java
@@ -1,8 +1,11 @@
 package io.quarkus.qe;
 
+import org.junit.jupiter.api.Disabled;
+
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtensionAndDockerBuildStrategy)
 public class OpenShiftUsingExtensionAndDockerBuildPingPongResourceIT extends PingPongResourceIT {
 }

--- a/examples/pingpong/src/test/java/io/quarkus/qe/OpenShiftUsingExtensionAndServerlessPingPongResourceIT.java
+++ b/examples/pingpong/src/test/java/io/quarkus/qe/OpenShiftUsingExtensionAndServerlessPingPongResourceIT.java
@@ -1,8 +1,11 @@
 package io.quarkus.qe;
 
+import org.junit.jupiter.api.Disabled;
+
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
 public class OpenShiftUsingExtensionAndServerlessPingPongResourceIT extends PingPongResourceIT {
 }

--- a/examples/pingpong/src/test/java/io/quarkus/qe/OpenShiftUsingExtensionComputedValuesUsingCustomPropertiesPingPongResourceIT.java
+++ b/examples/pingpong/src/test/java/io/quarkus/qe/OpenShiftUsingExtensionComputedValuesUsingCustomPropertiesPingPongResourceIT.java
@@ -1,8 +1,11 @@
 package io.quarkus.qe;
 
+import org.junit.jupiter.api.Disabled;
+
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
 public class OpenShiftUsingExtensionComputedValuesUsingCustomPropertiesPingPongResourceIT
         extends ComputedValuesUsingCustomPropertiesPingPongResourceIT {

--- a/examples/pingpong/src/test/java/io/quarkus/qe/OpenShiftUsingExtensionPingPongResourceIT.java
+++ b/examples/pingpong/src/test/java/io/quarkus/qe/OpenShiftUsingExtensionPingPongResourceIT.java
@@ -1,8 +1,11 @@
 package io.quarkus.qe;
 
+import org.junit.jupiter.api.Disabled;
+
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/31228")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
 public class OpenShiftUsingExtensionPingPongResourceIT extends PingPongResourceIT {
 }

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
@@ -870,7 +870,7 @@ public final class OpenShiftClient {
     }
 
     private List<HasMetadata> loadYaml(String template) {
-        return client.load(new ByteArrayInputStream(template.getBytes())).get();
+        return client.load(new ByteArrayInputStream(template.getBytes())).items();
     }
 
     private String generateRandomProjectName() {


### PR DESCRIPTION
### Summary

- Please see _quarkus-main-rhel8-jdk17-openshift-ci-distributed-ts-jvm-ocp-4/_ run number 60 for faulty behavior. I verified locally this fixes the issue. The problem is that `get` method behavior has changed and it only return results from OC, however we use `io.fabric8.kubernetes.client.KubernetesClient#load` simply to parse template file.
- Tests using Quarkus OpenShift extension are disabled due to https://github.com/quarkusio/quarkus/issues/31228

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)