### PR TITLE
Fix `QuarkusCliClientIT#shouldVersionMatchQuarkusVersion` by using `--version` rather than `version` option

### DIFF
--- a/quarkus-test-cli/src/test/java/io/quarkus/test/QuarkusCliClientIT.java
+++ b/quarkus-test-cli/src/test/java/io/quarkus/test/QuarkusCliClientIT.java
@@ -45,7 +45,7 @@ public class QuarkusCliClientIT {
     @Test
     public void shouldVersionMatchQuarkusVersion() {
         // Using option
-        assertEquals(QuarkusProperties.getVersion(), cliClient.run("version").getOutput());
+        assertEquals(QuarkusProperties.getVersion(), cliClient.run("--version").getOutput());
 
         // Using shortcut
         assertEquals(QuarkusProperties.getVersion(), cliClient.run("-v").getOutput());


### PR DESCRIPTION
### Summary

There is no such command as `quarkus version` anymore, we should use `quarkus --version` or `quarkus -v`. `quarkus -v` is already tested, therefore now we also test `--version`. Daily runs are failing over this.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)