### PR TITLE
Fix OC tests failing over VertxHttpClientBuilder missing class exception

### DIFF
--- a/quarkus-test-openshift/pom.xml
+++ b/quarkus-test-openshift/pom.xml
@@ -23,6 +23,10 @@
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-httpclient-vertx</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
             <artifactId>knative-client</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
### Summary

https://github.com/quarkusio/quarkus/commit/cee96ad1067c16cd1dc3d34f7447837808f67846 added necessity to add `kubernetes-httpclient-vertx` as quarkus-kubernetes-client-internal module has `kubernetes-httpclient-vertx` only in `provided` scope. That makes sense if you use Quarkus Kubernetes client that provides the dependency. Technically `quarkus-openshift` extension only contains `quarkus-kubernetes-client-internal` for some config reasons and does not use `quarkus-kubernetes-client`. However we use `io.fabric8.openshift.client.impl.OpenShiftClientImpl` directly, the client uses `io.fabric8.kubernetes.client.utils.HttpClientUtils` that statically acquires `io.quarkus.kubernetes.client.runtime.QuarkusHttpClientFactory` from `quarkus-kubernetes-client-internal` and here comes the problem as the dependency is missing. I do believe this not a Quarkus bug as if you are going to use io.frabic8 stuff directly, you need to handle dependencies yourself.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)