### PR TITLE
Migrate to Hibernate 6 - use dedicated table sequences

### DIFF
--- a/examples/database-mysql/src/main/java/io/quarkus/qe/database/mysql/Book.java
+++ b/examples/database-mysql/src/main/java/io/quarkus/qe/database/mysql/Book.java
@@ -1,14 +1,22 @@
 package io.quarkus.qe.database.mysql;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotBlank;
 
-import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
 
 @Entity
 @Table(name = "book")
-public class Book extends PanacheEntity {
+public class Book extends PanacheEntityBase {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    public Long id;
+
     @NotBlank(message = "book title must be set")
     public String title;
 

--- a/examples/database-mysql/src/main/resources/import.sql
+++ b/examples/database-mysql/src/main/resources/import.sql
@@ -1,8 +1,7 @@
-INSERT INTO book (id, title, author) VALUES (1, 'Foundation', 'Isaac Asimov');
-INSERT INTO book (id, title, author) VALUES (2, '2001: A Space Odyssey', 'Arthur C. Clarke');
-INSERT INTO book (id, title, author) VALUES (3, 'Stranger in a Strange Land', 'Robert A. Heinlein');
-INSERT INTO book (id, title, author) VALUES (4, 'Ender''s Game', 'Orson Scott Card');
-INSERT INTO book (id, title, author) VALUES (5, 'Hyperion', 'Dan Simmons');
-INSERT INTO book (id, title, author) VALUES (6, 'Anathem', 'Neal Stephenson');
-INSERT INTO book (id, title, author) VALUES (7, 'Perdido Street Station', 'China Miéville');
-UPDATE hibernate_sequence SET next_val = 8;
+INSERT INTO book (title, author) VALUES ('Foundation', 'Isaac Asimov');
+INSERT INTO book (title, author) VALUES ('2001: A Space Odyssey', 'Arthur C. Clarke');
+INSERT INTO book (title, author) VALUES ('Stranger in a Strange Land', 'Robert A. Heinlein');
+INSERT INTO book (title, author) VALUES ('Ender''s Game', 'Orson Scott Card');
+INSERT INTO book (title, author) VALUES ('Hyperion', 'Dan Simmons');
+INSERT INTO book (title, author) VALUES ('Anathem', 'Neal Stephenson');
+INSERT INTO book (title, author) VALUES ('Perdido Street Station', 'China Miéville');

--- a/examples/database-mysql/src/test/resources/import-in-test.sql
+++ b/examples/database-mysql/src/test/resources/import-in-test.sql
@@ -1,8 +1,7 @@
-INSERT INTO book (id, title, author) VALUES (1, 'Foundation', 'Isaac Asimov');
-INSERT INTO book (id, title, author) VALUES (2, '2001: A Space Odyssey', 'Arthur C. Clarke');
-INSERT INTO book (id, title, author) VALUES (3, 'Stranger in a Strange Land', 'Robert A. Heinlein');
-INSERT INTO book (id, title, author) VALUES (4, 'Ender''s Game', 'Orson Scott Card');
-INSERT INTO book (id, title, author) VALUES (5, 'Hyperion', 'Dan Simmons');
-INSERT INTO book (id, title, author) VALUES (6, 'Anathem', 'Neal Stephenson');
-INSERT INTO book (id, title, author) VALUES (7, 'Perdido Street Station', 'China Miéville');
-UPDATE hibernate_sequence SET next_val = 8;
+INSERT INTO book (title, author) VALUES ('Foundation', 'Isaac Asimov');
+INSERT INTO book (title, author) VALUES ('2001: A Space Odyssey', 'Arthur C. Clarke');
+INSERT INTO book (title, author) VALUES ('Stranger in a Strange Land', 'Robert A. Heinlein');
+INSERT INTO book (title, author) VALUES ('Ender''s Game', 'Orson Scott Card');
+INSERT INTO book (title, author) VALUES ('Hyperion', 'Dan Simmons');
+INSERT INTO book (title, author) VALUES ('Anathem', 'Neal Stephenson');
+INSERT INTO book (title, author) VALUES ('Perdido Street Station', 'China Miéville');

--- a/examples/database-oracle/src/main/java/io/quarkus/qe/database/oracle/Book.java
+++ b/examples/database-oracle/src/main/java/io/quarkus/qe/database/oracle/Book.java
@@ -1,14 +1,24 @@
 package io.quarkus.qe.database.oracle;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotBlank;
 
-import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
 
 @Entity
 @Table(name = "book")
-public class Book extends PanacheEntity {
+public class Book extends PanacheEntityBase {
+
+    @Id
+    @SequenceGenerator(name = "bookSequence", sequenceName = "Book_SEQ", allocationSize = 1)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "bookSequence")
+    public Long id;
+
     @NotBlank(message = "book title must be set")
     public String title;
 

--- a/examples/database-oracle/src/main/resources/import.sql
+++ b/examples/database-oracle/src/main/resources/import.sql
@@ -1,7 +1,7 @@
-INSERT INTO book (id, title, author) VALUES (hibernate_sequence.NEXTVAL, 'Foundation', 'Isaac Asimov');
-INSERT INTO book (id, title, author) VALUES (hibernate_sequence.NEXTVAL, '2001: A Space Odyssey', 'Arthur C. Clarke');
-INSERT INTO book (id, title, author) VALUES (hibernate_sequence.NEXTVAL, 'Stranger in a Strange Land', 'Robert A. Heinlein');
-INSERT INTO book (id, title, author) VALUES (hibernate_sequence.NEXTVAL, 'Ender''s Game', 'Orson Scott Card');
-INSERT INTO book (id, title, author) VALUES (hibernate_sequence.NEXTVAL, 'Hyperion', 'Dan Simmons');
-INSERT INTO book (id, title, author) VALUES (hibernate_sequence.NEXTVAL, 'Anathem', 'Neal Stephenson');
-INSERT INTO book (id, title, author) VALUES (hibernate_sequence.NEXTVAL, 'Perdido Street Station', 'China Miéville');
+INSERT INTO book (id, title, author) VALUES (Book_SEQ.NEXTVAL, 'Foundation', 'Isaac Asimov');
+INSERT INTO book (id, title, author) VALUES (Book_SEQ.NEXTVAL, '2001: A Space Odyssey', 'Arthur C. Clarke');
+INSERT INTO book (id, title, author) VALUES (Book_SEQ.NEXTVAL, 'Stranger in a Strange Land', 'Robert A. Heinlein');
+INSERT INTO book (id, title, author) VALUES (Book_SEQ.NEXTVAL, 'Ender''s Game', 'Orson Scott Card');
+INSERT INTO book (id, title, author) VALUES (Book_SEQ.NEXTVAL, 'Hyperion', 'Dan Simmons');
+INSERT INTO book (id, title, author) VALUES (Book_SEQ.NEXTVAL, 'Anathem', 'Neal Stephenson');
+INSERT INTO book (id, title, author) VALUES (Book_SEQ.NEXTVAL, 'Perdido Street Station', 'China Miéville');

--- a/examples/database-oracle/src/test/resources/import-in-test.sql
+++ b/examples/database-oracle/src/test/resources/import-in-test.sql
@@ -1,7 +1,7 @@
-INSERT INTO book (id, title, author) VALUES (hibernate_sequence.NEXTVAL, 'Foundation', 'Isaac Asimov');
-INSERT INTO book (id, title, author) VALUES (hibernate_sequence.NEXTVAL, '2001: A Space Odyssey', 'Arthur C. Clarke');
-INSERT INTO book (id, title, author) VALUES (hibernate_sequence.NEXTVAL, 'Stranger in a Strange Land', 'Robert A. Heinlein');
-INSERT INTO book (id, title, author) VALUES (hibernate_sequence.NEXTVAL, 'Ender''s Game', 'Orson Scott Card');
-INSERT INTO book (id, title, author) VALUES (hibernate_sequence.NEXTVAL, 'Hyperion', 'Dan Simmons');
-INSERT INTO book (id, title, author) VALUES (hibernate_sequence.NEXTVAL, 'Anathem', 'Neal Stephenson');
-INSERT INTO book (id, title, author) VALUES (hibernate_sequence.NEXTVAL, 'Perdido Street Station', 'China Miéville');
+INSERT INTO book (id, title, author) VALUES (Book_SEQ.NEXTVAL, 'Foundation', 'Isaac Asimov');
+INSERT INTO book (id, title, author) VALUES (Book_SEQ.NEXTVAL, '2001: A Space Odyssey', 'Arthur C. Clarke');
+INSERT INTO book (id, title, author) VALUES (Book_SEQ.NEXTVAL, 'Stranger in a Strange Land', 'Robert A. Heinlein');
+INSERT INTO book (id, title, author) VALUES (Book_SEQ.NEXTVAL, 'Ender''s Game', 'Orson Scott Card');
+INSERT INTO book (id, title, author) VALUES (Book_SEQ.NEXTVAL, 'Hyperion', 'Dan Simmons');
+INSERT INTO book (id, title, author) VALUES (Book_SEQ.NEXTVAL, 'Anathem', 'Neal Stephenson');
+INSERT INTO book (id, title, author) VALUES (Book_SEQ.NEXTVAL, 'Perdido Street Station', 'China Miéville');

--- a/examples/database-postgresql/src/main/java/io/quarkus/qe/database/postgresql/Book.java
+++ b/examples/database-postgresql/src/main/java/io/quarkus/qe/database/postgresql/Book.java
@@ -1,14 +1,24 @@
 package io.quarkus.qe.database.postgresql;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotBlank;
 
-import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
 
 @Entity
 @Table(name = "book")
-public class Book extends PanacheEntity {
+public class Book extends PanacheEntityBase {
+
+    @Id
+    @SequenceGenerator(name = "bookSequence", sequenceName = "Book_SEQ", allocationSize = 1)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "bookSequence")
+    public Long id;
+
     @NotBlank(message = "book title must be set")
     public String title;
 

--- a/examples/database-postgresql/src/main/resources/import.sql
+++ b/examples/database-postgresql/src/main/resources/import.sql
@@ -1,7 +1,7 @@
-INSERT INTO book (id, title, author) VALUES (nextval('hibernate_sequence'), 'Foundation', 'Isaac Asimov');
-INSERT INTO book (id, title, author) VALUES (nextval('hibernate_sequence'), '2001: A Space Odyssey', 'Arthur C. Clarke');
-INSERT INTO book (id, title, author) VALUES (nextval('hibernate_sequence'), 'Stranger in a Strange Land', 'Robert A. Heinlein');
-INSERT INTO book (id, title, author) VALUES (nextval('hibernate_sequence'), 'Ender''s Game', 'Orson Scott Card');
-INSERT INTO book (id, title, author) VALUES (nextval('hibernate_sequence'), 'Hyperion', 'Dan Simmons');
-INSERT INTO book (id, title, author) VALUES (nextval('hibernate_sequence'), 'Anathem', 'Neal Stephenson');
-INSERT INTO book (id, title, author) VALUES (nextval('hibernate_sequence'), 'Perdido Street Station', 'China Miéville');
+INSERT INTO book (id, title, author) VALUES (nextval('Book_SEQ'), 'Foundation', 'Isaac Asimov');
+INSERT INTO book (id, title, author) VALUES (nextval('Book_SEQ'), '2001: A Space Odyssey', 'Arthur C. Clarke');
+INSERT INTO book (id, title, author) VALUES (nextval('Book_SEQ'), 'Stranger in a Strange Land', 'Robert A. Heinlein');
+INSERT INTO book (id, title, author) VALUES (nextval('Book_SEQ'), 'Ender''s Game', 'Orson Scott Card');
+INSERT INTO book (id, title, author) VALUES (nextval('Book_SEQ'), 'Hyperion', 'Dan Simmons');
+INSERT INTO book (id, title, author) VALUES (nextval('Book_SEQ'), 'Anathem', 'Neal Stephenson');
+INSERT INTO book (id, title, author) VALUES (nextval('Book_SEQ'), 'Perdido Street Station', 'China Miéville');

--- a/examples/database-postgresql/src/test/resources/import-in-test.sql
+++ b/examples/database-postgresql/src/test/resources/import-in-test.sql
@@ -1,7 +1,7 @@
-INSERT INTO book (id, title, author) VALUES (nextval('hibernate_sequence'), 'Foundation', 'Isaac Asimov');
-INSERT INTO book (id, title, author) VALUES (nextval('hibernate_sequence'), '2001: A Space Odyssey', 'Arthur C. Clarke');
-INSERT INTO book (id, title, author) VALUES (nextval('hibernate_sequence'), 'Stranger in a Strange Land', 'Robert A. Heinlein');
-INSERT INTO book (id, title, author) VALUES (nextval('hibernate_sequence'), 'Ender''s Game', 'Orson Scott Card');
-INSERT INTO book (id, title, author) VALUES (nextval('hibernate_sequence'), 'Hyperion', 'Dan Simmons');
-INSERT INTO book (id, title, author) VALUES (nextval('hibernate_sequence'), 'Anathem', 'Neal Stephenson');
-INSERT INTO book (id, title, author) VALUES (nextval('hibernate_sequence'), 'Perdido Street Station', 'China Miéville');
+INSERT INTO book (id, title, author) VALUES (nextval('Book_SEQ'), 'Foundation', 'Isaac Asimov');
+INSERT INTO book (id, title, author) VALUES (nextval('Book_SEQ'), '2001: A Space Odyssey', 'Arthur C. Clarke');
+INSERT INTO book (id, title, author) VALUES (nextval('Book_SEQ'), 'Stranger in a Strange Land', 'Robert A. Heinlein');
+INSERT INTO book (id, title, author) VALUES (nextval('Book_SEQ'), 'Ender''s Game', 'Orson Scott Card');
+INSERT INTO book (id, title, author) VALUES (nextval('Book_SEQ'), 'Hyperion', 'Dan Simmons');
+INSERT INTO book (id, title, author) VALUES (nextval('Book_SEQ'), 'Anathem', 'Neal Stephenson');
+INSERT INTO book (id, title, author) VALUES (nextval('Book_SEQ'), 'Perdido Street Station', 'China Miéville');


### PR DESCRIPTION
### Summary

Hibernate sequence shouldn't be used anymore, we should use dedicated sequences or identity strategy. Daily runs are failing because of this.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)