### PR TITLE
Fix 'Image not found' when two scenarios share the same docker image 

### DIFF
--- a/examples/database-postgresql/src/test/java/io/quarkus/qe/database/postgresql/DuplicatedPostgresqlDatabaseIT.java
+++ b/examples/database-postgresql/src/test/java/io/quarkus/qe/database/postgresql/DuplicatedPostgresqlDatabaseIT.java
@@ -1,5 +1,10 @@
 package io.quarkus.qe.database.postgresql;
 
+import static io.quarkus.qe.database.postgresql.PostgresqlDatabaseIT.POSTGRES_IMG;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
 import io.quarkus.test.bootstrap.PostgresqlService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
@@ -7,10 +12,9 @@ import io.quarkus.test.services.Container;
 import io.quarkus.test.services.QuarkusApplication;
 
 @QuarkusScenario
-public class PostgresqlDatabaseIT extends AbstractSqlDatabaseIT {
+public class DuplicatedPostgresqlDatabaseIT {
 
     private static final int POSTGRESQL_PORT = 5432;
-    public static final String POSTGRES_IMG = "docker.io/postgres:13.8";
 
     @Container(image = POSTGRES_IMG, port = POSTGRESQL_PORT, expectedLog = "is ready")
     static PostgresqlService database = new PostgresqlService();
@@ -21,8 +25,11 @@ public class PostgresqlDatabaseIT extends AbstractSqlDatabaseIT {
             .withProperty("quarkus.datasource.password", database.getPassword())
             .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl);
 
-    @Override
-    protected RestService getApp() {
-        return app;
+    //motivation: https://github.com/quarkus-qe/quarkus-test-framework/issues/641
+    @Test
+    public void verifyGlobalPropertyContainerDeleteImageOnStop() {
+        // If test starts means that the run condition between two postgresql scenarios with the same version and
+        // global property 'ts.database.container.delete.image.on.stop=true' has been fixed
+        Assertions.assertTrue(true);
     }
 }

--- a/examples/database-postgresql/src/test/resources/test.properties
+++ b/examples/database-postgresql/src/test/resources/test.properties
@@ -1,3 +1,4 @@
 ts.app.log.enable=true
 ts.database.log.enable=true
 ts.database.openshift.use-internal-service-as-url=true
+ts.database.container.delete.image.on.stop=true

--- a/quarkus-test-images/src/main/java/io/quarkus/test/utils/DockerUtils.java
+++ b/quarkus-test-images/src/main/java/io/quarkus/test/utils/DockerUtils.java
@@ -9,10 +9,12 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang3.StringUtils;
 
 import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.PullImageResultCallback;
 import com.github.dockerjava.api.model.Container;
 import com.github.dockerjava.api.model.Image;
 import com.github.dockerjava.core.DefaultDockerClientConfig;
@@ -29,6 +31,7 @@ public final class DockerUtils {
     private static final String CONTAINER_PREFIX = "ts.global.docker-container-prefix";
     private static final String DOCKERFILE = "Dockerfile";
     private static final String DOCKERFILE_TEMPLATE = "/Dockerfile.%s";
+    private static final Integer DOCKER_PULL_TIMEOUT_SEC = 120;
     private static final String DOCKER = "docker";
     private static final Object LOCK = new Object();
     private static final Random RANDOM = new Random();
@@ -99,6 +102,17 @@ public final class DockerUtils {
      */
     public static void removeImageById(String imageId) {
         dockerClient().removeImageCmd(imageId).withForce(true).exec();
+    }
+
+    public static void pullImageById(String imageId) {
+        try {
+            dockerClient()
+                    .pullImageCmd(imageId)
+                    .exec(new PullImageResultCallback()).awaitCompletion(DOCKER_PULL_TIMEOUT_SEC, TimeUnit.SECONDS);
+
+        } catch (InterruptedException e) {
+            fail("Failed to pull image " + imageId + " . Caused by " + e.getMessage());
+        }
     }
 
     /**


### PR DESCRIPTION
Fix 'Image not found' when two scenarios share the same docker image  version and global property 'container.delete.image.on.stop' is enabled

Fix https://github.com/quarkus-qe/quarkus-test-framework/issues/641

Please check the relevant options

- [X] Bug fix (non-breaking change which fixes an issue)


### Checklist:
- [X] Example scenarios has been updated / added
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)