### PR TITLE
Fix/nightly build  / jaeger

### DIFF
--- a/examples/jaeger/src/test/java/io/quarkus/qe/ClientResourceIT.java
+++ b/examples/jaeger/src/test/java/io/quarkus/qe/ClientResourceIT.java
@@ -14,10 +14,13 @@ import org.junit.jupiter.api.Test;
 import io.quarkus.test.bootstrap.JaegerService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusSnapshot;
 import io.quarkus.test.services.JaegerContainer;
 import io.quarkus.test.services.QuarkusApplication;
 
 @QuarkusScenario
+//TODO https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.0#opentelemetry
+@DisabledOnQuarkusSnapshot(reason = "HTTP span names are now \"{http.method} {http.route}\" instead of just \"{http.route}\"")
 public class ClientResourceIT {
 
     private static final String SERVICE_NAME = "test-traced-service";


### PR DESCRIPTION
### Summary

MigrationGuide: https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.0#opentelemetry

HTTP span names are now "{http.method} {http.route}" instead of just "{http.route}".

Please check the relevant options

- [X] Bug fix (non-breaking change which fixes an issue)
