### PR TITLE
Fix Quarkus args parameters on Quarkus ProdMode

### DIFF
--- a/examples/picocli/pom.xml
+++ b/examples/picocli/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus.qe</groupId>
+        <artifactId>quarkus-test-parent</artifactId>
+        <version>1.3.1.Beta7-SNAPSHOT</version>
+        <relativePath>../../</relativePath>
+    </parent>
+    <artifactId>examples-picocli</artifactId>
+    <name>Quarkus - Test Framework - Examples - Picocli</name>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-picocli</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus.qe</groupId>
+            <artifactId>quarkus-test-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>${quarkus.platform.group-id}</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <version>${quarkus.platform.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/picocli/src/main/java/io/quarkus/qe/picocli/CommandCli.java
+++ b/examples/picocli/src/main/java/io/quarkus/qe/picocli/CommandCli.java
@@ -1,0 +1,26 @@
+package io.quarkus.qe.picocli;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.picocli.runtime.annotations.TopCommand;
+import picocli.CommandLine;
+
+@TopCommand
+@CommandLine.Command(name = "example", mixinStandardHelpOptions = true, subcommands = { HelloWorldExample.class })
+public class CommandCli {
+}
+
+@CommandLine.Command(name = "helloWorld", description = "helloWorld useCase")
+class HelloWorldExample implements Runnable {
+
+    private static final Logger LOG = Logger.getLogger(HelloWorldExample.class);
+
+    @CommandLine.Option(names = { "-n", "--yourName" }, description = "your name", defaultValue = "World")
+    String yourName;
+
+    @Override
+    public void run() {
+        String result = String.format("Hello %s!", yourName);
+        LOG.info(result);
+    }
+}

--- a/examples/picocli/src/main/resources/application.properties
+++ b/examples/picocli/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+# Quarkus app properties goes here

--- a/examples/picocli/src/test/java/io/quarkus/qe/picocli/HelloWorldIT.java
+++ b/examples/picocli/src/test/java/io/quarkus/qe/picocli/HelloWorldIT.java
@@ -1,0 +1,27 @@
+package io.quarkus.qe.picocli;
+
+import static java.util.concurrent.CompletableFuture.runAsync;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.QuarkusApplication;
+
+@QuarkusScenario
+public class HelloWorldIT {
+
+    static final String NAME = "Random";
+
+    @QuarkusApplication
+    static final RestService app = new RestService()
+            .withProperty("quarkus.args", "helloWorld -n " + NAME)
+            .setAutoStart(false);
+
+    @Test
+    public void verifyHelloWorldFormatted() {
+        runAsync(app::start);
+        String expectedOutput = String.format("Hello %s!", NAME);
+        app.logs().assertContains(expectedOutput);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -403,6 +403,7 @@
                 <module>examples/database-oracle</module>
                 <module>examples/external-applications</module>
                 <module>examples/funqy-knative-events</module>
+                <module>examples/picocli</module>
             </modules>
         </profile>
         <profile>

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/ProdLocalhostQuarkusApplicationManagedResource.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/ProdLocalhostQuarkusApplicationManagedResource.java
@@ -1,11 +1,16 @@
 package io.quarkus.test.services.quarkus;
 
+import java.util.Arrays;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+
+import org.apache.commons.lang3.ArrayUtils;
 
 public class ProdLocalhostQuarkusApplicationManagedResource extends LocalhostQuarkusApplicationManagedResource {
 
     private static final String JAVA = "java";
+    private static final String QUARKUS_ARGS_PROPERTY_NAME = "quarkus.args";
 
     private final ProdQuarkusApplicationManagedResourceBuilder model;
 
@@ -16,11 +21,13 @@ public class ProdLocalhostQuarkusApplicationManagedResource extends LocalhostQua
 
     protected List<String> prepareCommand(List<String> systemProperties) {
         List<String> command = new LinkedList<>();
+        String[] cmdArgs = extractQuarkusArgs(systemProperties);
         if (model.getArtifact().getFileName().toString().endsWith(".jar")) {
             command.add(JAVA);
             command.addAll(systemProperties);
             command.add("-jar");
             command.add(model.getArtifact().toAbsolutePath().toString());
+            command.addAll(Arrays.asList(cmdArgs));
         } else {
             command.add(model.getArtifact().toAbsolutePath().toString());
             command.addAll(systemProperties);
@@ -29,4 +36,18 @@ public class ProdLocalhostQuarkusApplicationManagedResource extends LocalhostQua
         return command;
     }
 
+    private String[] extractQuarkusArgs(List<String> systemProperties) {
+        String[] args = ArrayUtils.EMPTY_STRING_ARRAY;
+        Iterator<String> propertiesIt = systemProperties.iterator();
+        while (propertiesIt.hasNext()) {
+            String property = propertiesIt.next();
+            if (property.contains(QUARKUS_ARGS_PROPERTY_NAME)) {
+                propertiesIt.remove();
+                args = property.replace("-D" + QUARKUS_ARGS_PROPERTY_NAME + "=", "").split(" ");
+                break;
+            }
+        }
+
+        return args;
+    }
 }


### PR DESCRIPTION
### Summary

 `What's the motivation to introduce 'quarkus.args' support?` 

There are several scenarios where `quarkus.args` should be supported. For example, all command cli Quarkus application requires this argument. 

This commit allows you to create your quarkus test app by this way:

```
static final String NAME = "Pablo";

  @QuarkusApplication
    static final RestService app = new RestService()
            .withProperty("quarkus.args", "helloWorld -n " + NAME);
```

Currently, this is not supported and your best approach is to do something like this:
```
@RegisterExtension
    static final QuarkusProdModeTest helloWorld = new QuarkusTemporalAppBuilder(helloWorldServer)
            .withApplicationRoot((jar) -> jar.addClasses(Utils.findAllClassesFromSource()))
            .setApplicationName("helloWorld")
            .setApplicationVersion("0.1-SNAPSHOT")
            .setCommandLineParameters("helloWorld", "-n " + NAME)
            .setExpectExit(true).setRun(false);
```

This approach is not integrated with Quarkus test framework so don´t expect to use the default RestAssurance client and other features. You have to do everything by yourself. 


Please check the relevant options

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

### Checklist:
- [X] Example scenarios has been updated / added
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)