### PR TITLE
support shared containers network feature

### DIFF
--- a/examples/temporal/pom.xml
+++ b/examples/temporal/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus.qe</groupId>
+        <artifactId>quarkus-test-parent</artifactId>
+        <version>1.3.1.Beta7-SNAPSHOT</version>
+        <relativePath>../../</relativePath>
+    </parent>
+    <artifactId>examples-temporal</artifactId>
+    <name>Quarkus - Test Framework - Examples - Temporal</name>
+    <properties>
+        <temporal-sdk.version>1.17.0</temporal-sdk.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-reactive</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.temporal</groupId>
+            <artifactId>temporal-sdk</artifactId>
+            <version>${temporal-sdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus.qe</groupId>
+            <artifactId>quarkus-test-service-database</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus.qe</groupId>
+            <artifactId>quarkus-test-containers</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>${quarkus.platform.group-id}</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <version>${quarkus.platform.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+    <profiles>
+        <profile>
+            <!-- Disable native build on this module -->
+            <!-- Currently is not supported by temporal -->
+            <id>native</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <properties>
+                <quarkus.build.skip>true</quarkus.build.skip>
+            </properties>
+        </profile>
+    </profiles>
+</project>

--- a/examples/temporal/src/main/java/io/quarkus/qe/FormatActivity.java
+++ b/examples/temporal/src/main/java/io/quarkus/qe/FormatActivity.java
@@ -1,0 +1,26 @@
+package io.quarkus.qe;
+
+import java.time.Duration;
+
+import io.temporal.activity.ActivityInterface;
+import io.temporal.activity.ActivityMethod;
+import io.temporal.activity.ActivityOptions;
+import io.temporal.common.RetryOptions;
+
+@ActivityInterface
+public interface FormatActivity {
+
+    int ACTIVITY_TIMEOUT_SEC = 10;
+    int ACTIVITY_MAX_ATTEMPTS = 2;
+
+    ActivityOptions FORMAT_ACTIVITY_DEFAULT_OPTS = ActivityOptions.newBuilder()
+            .setScheduleToCloseTimeout(Duration.ofSeconds(ACTIVITY_TIMEOUT_SEC))
+            .setRetryOptions(RetryOptions.newBuilder()
+                    .setInitialInterval(Duration.ofSeconds(1))
+                    .setMaximumAttempts(ACTIVITY_MAX_ATTEMPTS)
+                    .build())
+            .build();
+
+    @ActivityMethod
+    String composeGreeting(String name);
+}

--- a/examples/temporal/src/main/java/io/quarkus/qe/FormatActivityImpl.java
+++ b/examples/temporal/src/main/java/io/quarkus/qe/FormatActivityImpl.java
@@ -1,0 +1,26 @@
+package io.quarkus.qe;
+
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+import io.temporal.activity.Activity;
+
+public class FormatActivityImpl implements FormatActivity {
+
+    @Override
+    public String composeGreeting(String name) {
+        try {
+            return "Hello " + name.trim() + "!";
+        } catch (Exception e) {
+            throw Activity.wrap(e);
+        }
+    }
+
+    @Singleton
+    @Produces
+    @Named("hello-world-format-activity")
+    FormatActivity getActivity() {
+        return new FormatActivityImpl();
+    }
+}

--- a/examples/temporal/src/main/java/io/quarkus/qe/HelloWorldWorkflow.java
+++ b/examples/temporal/src/main/java/io/quarkus/qe/HelloWorldWorkflow.java
@@ -1,0 +1,10 @@
+package io.quarkus.qe;
+
+import io.temporal.workflow.WorkflowInterface;
+import io.temporal.workflow.WorkflowMethod;
+
+@WorkflowInterface
+public interface HelloWorldWorkflow {
+    @WorkflowMethod
+    String getGreeting(String name);
+}

--- a/examples/temporal/src/main/java/io/quarkus/qe/HelloWorldWorkflowImpl.java
+++ b/examples/temporal/src/main/java/io/quarkus/qe/HelloWorldWorkflowImpl.java
@@ -1,0 +1,19 @@
+package io.quarkus.qe;
+
+import io.temporal.workflow.Workflow;
+
+public class HelloWorldWorkflowImpl implements HelloWorldWorkflow {
+
+    FormatActivity formatActivity;
+
+    public HelloWorldWorkflowImpl() {
+        formatActivity = Workflow.newActivityStub(FormatActivity.class, FormatActivity.FORMAT_ACTIVITY_DEFAULT_OPTS);
+    }
+
+    @Override
+    public String getGreeting(String name) {
+        // This is the entry point to the Workflow.
+        // If there were other Activity methods they would be orchestrated here or from within other Activities.
+        return formatActivity.composeGreeting(name);
+    }
+}

--- a/examples/temporal/src/main/java/io/quarkus/qe/WorkflowResource.java
+++ b/examples/temporal/src/main/java/io/quarkus/qe/WorkflowResource.java
@@ -1,0 +1,44 @@
+package io.quarkus.qe;
+
+import static io.quarkus.qe.producers.TemporalCommons.HELLO_WORLD_TASK_QUEUE;
+import static io.quarkus.qe.producers.TemporalWorker.WORKER_SUFFIX;
+import static io.quarkus.qe.producers.TemporalWorkflow.WORKFLOW_SUFFIX;
+
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.jboss.resteasy.reactive.RestPath;
+
+import io.quarkus.qe.producers.TemporalWorker;
+import io.quarkus.qe.producers.TemporalWorkflow;
+import io.quarkus.runtime.StartupEvent;
+
+@Path("/workflow")
+public class WorkflowResource {
+
+    @Inject
+    @Named(HELLO_WORLD_TASK_QUEUE + WORKER_SUFFIX)
+    TemporalWorker worker;
+
+    @Inject
+    @Named(HELLO_WORLD_TASK_QUEUE + WORKFLOW_SUFFIX)
+    TemporalWorkflow workflow;
+
+    void onStart(@Observes StartupEvent ev) {
+        worker.start();
+    }
+
+    @Path("/hello/{name}")
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String helloWorld(@RestPath String name) {
+        HelloWorldWorkflow helloWorldWorkflow = workflow.getStub(HelloWorldWorkflow.class);
+        String greeting = helloWorldWorkflow.getGreeting(name);
+        return greeting;
+    }
+}

--- a/examples/temporal/src/main/java/io/quarkus/qe/producers/TemporalCommons.java
+++ b/examples/temporal/src/main/java/io/quarkus/qe/producers/TemporalCommons.java
@@ -1,0 +1,45 @@
+package io.quarkus.qe.producers;
+
+import java.util.Objects;
+
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import io.quarkus.runtime.util.StringUtil;
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowClientOptions;
+import io.temporal.serviceclient.WorkflowServiceStubs;
+import io.temporal.serviceclient.WorkflowServiceStubsOptions;
+
+public abstract class TemporalCommons {
+
+    public static final String HELLO_WORLD_TASK_QUEUE = "HELLO_WORLD_TASK_QUEUE";
+    protected WorkflowClientOptions clientOpts;
+    @Inject
+    @ConfigProperty(name = "temporal.host", defaultValue = "127.0.0.1")
+    protected String temporalServerHost;
+    @Inject
+    @ConfigProperty(name = "temporal.port", defaultValue = "7233")
+    protected Integer temporalServerPort;
+
+    @Inject
+    @ConfigProperty(name = "temporal.namespace", defaultValue = "default")
+    protected String namespace;
+
+    protected WorkflowClient createWorkflowClient(WorkflowServiceStubs service) {
+        if (Objects.isNull(this.clientOpts)) {
+            if (StringUtil.isNullOrEmpty(namespace)) {
+                this.clientOpts = WorkflowClientOptions.newBuilder().build();
+            } else {
+                this.clientOpts = WorkflowClientOptions.newBuilder().setNamespace(namespace).build();
+            }
+        }
+        return WorkflowClient.newInstance(service, this.clientOpts);
+    }
+
+    protected WorkflowServiceStubs createDefaultWorkflowServiceStubs() {
+        String endpoint = String.format("%s:%s", temporalServerHost, temporalServerPort);
+        return WorkflowServiceStubs.newServiceStubs(WorkflowServiceStubsOptions.newBuilder().setTarget(endpoint).build());
+    }
+}

--- a/examples/temporal/src/main/java/io/quarkus/qe/producers/TemporalWorker.java
+++ b/examples/temporal/src/main/java/io/quarkus/qe/producers/TemporalWorker.java
@@ -1,0 +1,180 @@
+package io.quarkus.qe.producers;
+
+import java.util.Objects;
+
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+import org.jboss.logging.Logger;
+
+import com.google.common.base.Throwables;
+
+import io.quarkus.qe.FormatActivity;
+import io.quarkus.qe.HelloWorldWorkflowImpl;
+import io.quarkus.runtime.Quarkus;
+import io.quarkus.runtime.util.StringUtil;
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowClientOptions;
+import io.temporal.internal.worker.Startable;
+import io.temporal.serviceclient.WorkflowServiceStubs;
+import io.temporal.worker.Worker;
+import io.temporal.worker.WorkerFactory;
+
+public class TemporalWorker extends TemporalCommons implements Startable {
+
+    public static final String WORKER_SUFFIX = "_WORKER";
+
+    private static final Logger LOG = Logger.getLogger(TemporalWorker.class);
+    private boolean waitForExist = true;
+    private String taskQueueName;
+    private Class<?>[] workflowImplementationClasses;
+    private Object[] activityImplInstances;
+    private boolean running;
+    private Thread innerThread;
+
+    public void start() {
+        this.running = true;
+        innerThread = new Thread(this::run);
+        innerThread.setDaemon(true);
+        innerThread.start();
+    }
+
+    @Override
+    public boolean isStarted() {
+        return running;
+    }
+
+    public void stop() {
+        this.running = false;
+        Quarkus.asyncExit(0);
+    }
+
+    public static Builder newTemporalWorkerBuilder(String taskQueueName) {
+        return new Builder(taskQueueName);
+    }
+
+    private void run() {
+        try {
+            WorkflowServiceStubs service = createDefaultWorkflowServiceStubs();
+            WorkflowClient client = createWorkflowClient(service);
+            WorkerFactory factory = WorkerFactory.newInstance(client);
+
+            Worker worker = factory.newWorker(this.taskQueueName);
+            worker.registerWorkflowImplementationTypes(this.workflowImplementationClasses);
+            worker.registerActivitiesImplementations(this.activityImplInstances);
+            LOG.infof("Listening queue -> %s", this.taskQueueName);
+
+            factory.start();
+        } catch (Exception e) {
+            LOG.errorf("Stack Trace: %s" + Throwables.getStackTraceAsString(e));
+            Throwable cause = Throwables.getRootCause(e);
+            LOG.errorf("Root cause:: %s" + cause.getMessage());
+            stop();
+        }
+    }
+
+    public static class Builder {
+        private String namespace;
+        private String temporalServerHost;
+        private int temporalServerPort;
+        private Boolean waitForExist;
+        private WorkflowClientOptions clientOpts;
+        private final String taskQueueName;
+        private Class<?>[] workflowImplementationClasses;
+        private Object[] activityImplInstances;
+
+        public Builder(String taskQueueName) {
+            if (StringUtil.isNullOrEmpty(taskQueueName)) {
+                throw new IllegalArgumentException("taskQueueName must be not empty");
+            }
+
+            this.taskQueueName = taskQueueName;
+        }
+
+        public Builder withNamespace(String namespace) {
+            if (StringUtil.isNullOrEmpty(namespace)) {
+                throw new IllegalArgumentException("namespace can't be empty or null");
+            }
+            this.namespace = namespace;
+            return this;
+        }
+
+        public Builder withTemporalServerHost(String host) {
+            this.temporalServerHost = host;
+            return this;
+        }
+
+        public Builder withTemporalServerPort(int port) {
+            if (port <= 0) {
+                throw new IllegalArgumentException("port must be an unsigned integer");
+            }
+
+            this.temporalServerPort = port;
+            return this;
+        }
+
+        public Builder withWorkflowClientOptions(WorkflowClientOptions opts) {
+            this.clientOpts = opts;
+            return this;
+        }
+
+        public Builder withWorkflowImplementationClasses(Class<?>... implementationClasses) {
+            this.workflowImplementationClasses = implementationClasses;
+            return this;
+        }
+
+        public Builder withActivityImplInstances(Object... activityImplInstances) {
+            this.activityImplInstances = activityImplInstances;
+            return this;
+        }
+
+        public Builder withWaitForExist(boolean waitForExist) {
+            this.waitForExist = waitForExist;
+            return this;
+        }
+
+        public TemporalWorker build() {
+            TemporalWorker worker = new TemporalWorker();
+            worker.taskQueueName = this.taskQueueName;
+            worker.activityImplInstances = this.activityImplInstances;
+            worker.workflowImplementationClasses = this.workflowImplementationClasses;
+
+            if (Objects.nonNull(waitForExist)) {
+                worker.waitForExist = this.waitForExist;
+            }
+
+            if (!StringUtil.isNullOrEmpty(this.temporalServerHost)) {
+                worker.temporalServerHost = this.temporalServerHost;
+            }
+
+            if (this.temporalServerPort > 0) {
+                worker.temporalServerPort = this.temporalServerPort;
+            }
+
+            worker.clientOpts = this.clientOpts;
+            worker.namespace = this.namespace;
+            if (!StringUtil.isNullOrEmpty(this.namespace) && Objects.nonNull(worker.clientOpts)) {
+                if (worker.clientOpts.getNamespace().equalsIgnoreCase(worker.namespace)) {
+                    throw new IllegalArgumentException("WorkflowClientOptions namespace doesn't match with worker namespace");
+                }
+            }
+
+            return worker;
+        }
+    }
+
+    @Singleton
+    @Produces
+    @Named(HELLO_WORLD_TASK_QUEUE + WORKER_SUFFIX)
+    TemporalWorker getWorker(@Named("hello-world-format-activity") FormatActivity activity) {
+        return newTemporalWorkerBuilder(HELLO_WORLD_TASK_QUEUE)
+                .withTemporalServerHost(temporalServerHost)
+                .withTemporalServerPort(temporalServerPort)
+                .withNamespace(namespace)
+                .withWorkflowImplementationClasses(HelloWorldWorkflowImpl.class)
+                .withActivityImplInstances(activity)
+                .withWaitForExist(waitForExist)
+                .build();
+    }
+}

--- a/examples/temporal/src/main/java/io/quarkus/qe/producers/TemporalWorkflow.java
+++ b/examples/temporal/src/main/java/io/quarkus/qe/producers/TemporalWorkflow.java
@@ -1,0 +1,132 @@
+package io.quarkus.qe.producers;
+
+import java.util.Objects;
+
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+import org.jboss.logging.Logger;
+
+import com.google.common.base.Throwables;
+
+import io.quarkus.runtime.util.StringUtil;
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowClientOptions;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.serviceclient.WorkflowServiceStubs;
+
+public class TemporalWorkflow extends TemporalCommons {
+
+    public static final String WORKFLOW_SUFFIX = "_WORKFLOW";
+    private static final Logger LOG = Logger.getLogger(TemporalWorkflow.class);
+    private String taskQueueName;
+    private WorkflowClientOptions clientOpts;
+    private WorkflowOptions workflowOpts;
+
+    public <T> T getStub(Class<T> stub) {
+        try {
+            WorkflowServiceStubs service = createDefaultWorkflowServiceStubs();
+            WorkflowClient client = createWorkflowClient(service);
+            return client.newWorkflowStub(stub, workflowOpts);
+        } catch (Exception e) {
+            LOG.errorf("Stack Trace: %s" + Throwables.getStackTraceAsString(e));
+            Throwable cause = Throwables.getRootCause(e);
+            LOG.errorf("Root cause:: %s" + cause.getMessage());
+            throw new RuntimeException("Error on Workflow getStub. " + e.getMessage());
+        }
+    }
+
+    public static Builder newTemporalWorkflowBuilder(String taskQueueName) {
+        return new Builder(taskQueueName);
+    }
+
+    public static class Builder {
+        private String namespace;
+        private String temporalServerHost;
+        private int temporalServerPort;
+        private WorkflowClientOptions clientOpts;
+        private WorkflowOptions workflowOpts;
+        private final String taskQueueName;
+
+        public Builder(String taskQueueName) {
+            if (StringUtil.isNullOrEmpty(taskQueueName)) {
+                throw new IllegalArgumentException("taskQueueName must be not empty");
+            }
+
+            this.taskQueueName = taskQueueName;
+        }
+
+        public Builder withNamespace(String namespace) {
+            if (StringUtil.isNullOrEmpty(namespace)) {
+                throw new IllegalArgumentException("namespace can't be empty or null");
+            }
+            this.namespace = namespace;
+            return this;
+        }
+
+        public Builder withTemporalServerHost(String host) {
+            this.temporalServerHost = host;
+            return this;
+        }
+
+        public Builder withTemporalServerPort(int port) {
+            if (port <= 0) {
+                throw new IllegalArgumentException("port must be an unsigned integer");
+            }
+
+            this.temporalServerPort = port;
+            return this;
+        }
+
+        public Builder withWorkflowClientOptions(WorkflowClientOptions opts) {
+            this.clientOpts = opts;
+            return this;
+        }
+
+        public Builder withWorkflowOptions(WorkflowOptions options) {
+            this.workflowOpts = options;
+            return this;
+        }
+
+        public TemporalWorkflow build() {
+            TemporalWorkflow workflow = new TemporalWorkflow();
+            workflow.taskQueueName = this.taskQueueName;
+            if (!StringUtil.isNullOrEmpty(this.temporalServerHost)) {
+                workflow.temporalServerHost = this.temporalServerHost;
+            }
+
+            if (this.temporalServerPort > 0) {
+                workflow.temporalServerPort = this.temporalServerPort;
+            }
+
+            workflow.workflowOpts = this.workflowOpts;
+            if (Objects.isNull(this.workflowOpts)) {
+                workflow.workflowOpts = WorkflowOptions.newBuilder()
+                        .setTaskQueue(workflow.taskQueueName)
+                        .build();
+            }
+
+            workflow.clientOpts = this.clientOpts;
+            workflow.namespace = this.namespace;
+            if (!StringUtil.isNullOrEmpty(this.namespace) && Objects.nonNull(workflow.clientOpts)) {
+                if (workflow.clientOpts.getNamespace().equalsIgnoreCase(workflow.namespace)) {
+                    throw new IllegalArgumentException("WorkflowClientOptions namespace doesn't match with workflow namespace");
+                }
+            }
+
+            return workflow;
+        }
+    }
+
+    @Singleton
+    @Produces
+    @Named(HELLO_WORLD_TASK_QUEUE + WORKFLOW_SUFFIX)
+    TemporalWorkflow getWorkflow() {
+        return newTemporalWorkflowBuilder(HELLO_WORLD_TASK_QUEUE)
+                .withTemporalServerHost(temporalServerHost)
+                .withTemporalServerPort(temporalServerPort)
+                .withNamespace(namespace)
+                .build();
+    }
+}

--- a/examples/temporal/src/main/resources/application.properties
+++ b/examples/temporal/src/main/resources/application.properties
@@ -1,0 +1,3 @@
+temporal.host=127.0.0.1
+temporal.port=7233
+temporal.namespace=default

--- a/examples/temporal/src/test/java/io/quarkus/qe/TemporalHelloWorldIT.java
+++ b/examples/temporal/src/test/java/io/quarkus/qe/TemporalHelloWorldIT.java
@@ -1,0 +1,77 @@
+package io.quarkus.qe;
+
+import static org.hamcrest.Matchers.is;
+
+import java.time.Duration;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.DefaultService;
+import io.quarkus.test.bootstrap.PostgresqlService;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnNative;
+import io.quarkus.test.services.Container;
+import io.quarkus.test.services.QuarkusApplication;
+
+@QuarkusScenario
+@DisabledOnNative(reason = "Not supported by Temporal")
+public class TemporalHelloWorldIT {
+
+    private static final String NETWORK_ALIAS = "postgresql";
+    private static final String TEMPORAL_DB_TYPE = "postgresql";
+    private static final String DEFAULT_POSTGRES_CONFIG = "config/dynamicconfig/development-sql.yaml";
+    private static final String CONTAINER_FILE_DEPLOYMENT_PATH = "/etc/temporal/config/dynamicconfig";
+    private static final String DEPLOYMENT_CASS_FILE = "development-cass.yaml";
+    private static final String DOCKER_FILE = "docker.yaml";
+    private static final String DEPLOYMENT_SQL_FILE = "development-sql.yaml";
+    private static final String CONTAINER_RESOURCE = "resource_with_destination";
+    private static final String NAMESPACE = "default";
+    static final int POSTGRESQL_PORT = 5432;
+    static final int TEMPORAL_PORT = 7233;
+
+    protected static final String POSTGRES_USER = "temporal";
+    protected static final String POSTGRES_PWD = "temporal";
+
+    @Container(image = "docker.io/library/postgres:latest", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address", networkAlias = NETWORK_ALIAS)
+    static PostgresqlService postgres = new PostgresqlService()
+            .with(POSTGRES_USER, POSTGRES_PWD, "temporal");
+
+    @Container(image = "temporalio/auto-setup:1.19.0", port = TEMPORAL_PORT, expectedLog = "Temporal server started", networkAlias = NETWORK_ALIAS)
+    static DefaultService temporal = new DefaultService()
+            .withProperty("POSTGRES_USER", () -> postgres.getUser())
+            .withProperty("POSTGRES_PWD", () -> postgres.getPassword())
+            .withProperty("DB", TEMPORAL_DB_TYPE)
+            .withProperty("DB_PORT", "" + POSTGRESQL_PORT)
+            .withProperty("POSTGRES_SEEDS", TEMPORAL_DB_TYPE)
+            .withProperty("DYNAMIC_CONFIG_FILE_PATH", DEFAULT_POSTGRES_CONFIG)
+            .withProperty("DEFAULT_NAMESPACE", NAMESPACE)
+            .withProperty("DEPLOYMENT_CASS",
+                    String.format("%s::%s|%s", CONTAINER_RESOURCE, CONTAINER_FILE_DEPLOYMENT_PATH, DEPLOYMENT_CASS_FILE))
+            .withProperty("DOCKER_YAML",
+                    String.format("%s::%s|%s", CONTAINER_RESOURCE, CONTAINER_FILE_DEPLOYMENT_PATH, DOCKER_FILE))
+            .withProperty("DEPLOYMENT_SQL",
+                    String.format("%s::%s|%s", CONTAINER_RESOURCE, CONTAINER_FILE_DEPLOYMENT_PATH, DEPLOYMENT_SQL_FILE))
+            .onPostStart(service -> wait(Duration.ofSeconds(10)));
+
+    @QuarkusApplication
+    static final RestService app = new RestService()
+            .withProperty("temporal.host", () -> temporal.getURI().getHost())
+            .withProperty("temporal.port", () -> "" + temporal.getURI().getPort())
+            .withProperty("temporal.namespace", NAMESPACE);
+
+    @Test
+    public void temporalHelloWorld() {
+        app.given().get("/workflow/hello/pablo").then().statusCode(HttpStatus.SC_OK).and().body(is("Hello pablo!"));
+    }
+
+    //TODO https://github.com/temporalio/temporal/issues/1336
+    static final void wait(Duration amount) {
+        try {
+            Thread.sleep(amount.toMillis());
+        } catch (InterruptedException e) {
+
+        }
+    }
+}

--- a/examples/temporal/src/test/resources/development-cass.yaml
+++ b/examples/temporal/src/test/resources/development-cass.yaml
@@ -1,0 +1,3 @@
+system.forceSearchAttributesCacheRefreshOnRead:
+  - value: true # Dev setup only. Please don't turn this on in production.
+    constraints: {}

--- a/examples/temporal/src/test/resources/development-sql.yaml
+++ b/examples/temporal/src/test/resources/development-sql.yaml
@@ -1,0 +1,6 @@
+limit.maxIDLength:
+  - value: 255
+    constraints: {}
+system.forceSearchAttributesCacheRefreshOnRead:
+  - value: true # Dev setup only. Please don't turn this on in production.
+    constraints: {}

--- a/pom.xml
+++ b/pom.xml
@@ -403,6 +403,7 @@
                 <module>examples/database-oracle</module>
                 <module>examples/external-applications</module>
                 <module>examples/funqy-knative-events</module>
+                <module>examples/temporal</module>
             </modules>
         </profile>
         <profile>

--- a/quarkus-test-containers/src/main/java/io/quarkus/test/services/Container.java
+++ b/quarkus-test-containers/src/main/java/io/quarkus/test/services/Container.java
@@ -1,5 +1,7 @@
 package io.quarkus.test.services;
 
+import static io.quarkus.test.services.containers.DockerContainersNetwork.NetworkType;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -11,6 +13,7 @@ import io.quarkus.test.services.containers.ContainerManagedResourceBuilder;
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Container {
+
     String image();
 
     int port();
@@ -18,6 +21,10 @@ public @interface Container {
     String expectedLog() default "";
 
     String[] command() default {};
+
+    String[] networkAlias() default {};
+
+    NetworkType networkType() default NetworkType.NEW;
 
     Class<? extends ManagedResourceBuilder> builder() default ContainerManagedResourceBuilder.class;
 }

--- a/quarkus-test-containers/src/main/java/io/quarkus/test/services/containers/ContainerManagedResourceBuilder.java
+++ b/quarkus-test-containers/src/main/java/io/quarkus/test/services/containers/ContainerManagedResourceBuilder.java
@@ -20,6 +20,8 @@ public class ContainerManagedResourceBuilder implements ManagedResourceBuilder {
     private String expectedLog;
     private String[] command;
     private Integer port;
+    private String[] networkAlias;
+    private DockerContainersNetwork.NetworkType networkType;
 
     protected String getImage() {
         return image;
@@ -41,6 +43,14 @@ public class ContainerManagedResourceBuilder implements ManagedResourceBuilder {
         return context;
     }
 
+    public String[] getNetworkAlias() {
+        return networkAlias;
+    }
+
+    public DockerContainersNetwork.NetworkType getNetworkType() {
+        return networkType;
+    }
+
     @Override
     public void init(Annotation annotation) {
         Container metadata = (Container) annotation;
@@ -48,6 +58,8 @@ public class ContainerManagedResourceBuilder implements ManagedResourceBuilder {
         this.command = metadata.command();
         this.expectedLog = PropertiesUtils.resolveProperty(metadata.expectedLog());
         this.port = metadata.port();
+        this.networkAlias = metadata.networkAlias();
+        this.networkType = metadata.networkType();
     }
 
     @Override

--- a/quarkus-test-containers/src/main/java/io/quarkus/test/services/containers/DockerContainersNetwork.java
+++ b/quarkus-test-containers/src/main/java/io/quarkus/test/services/containers/DockerContainersNetwork.java
@@ -1,0 +1,55 @@
+package io.quarkus.test.services.containers;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.testcontainers.containers.Network;
+
+public final class DockerContainersNetwork {
+    private static volatile DockerContainersNetwork instance;
+    private static Object mutex = new Object();
+    private Map<String, Network> store = new HashMap<>();
+
+    private DockerContainersNetwork() {
+
+    }
+
+    public static DockerContainersNetwork getInstance() {
+        DockerContainersNetwork result = instance;
+        if (result == null) {
+            synchronized (mutex) {
+                result = instance;
+                if (result == null) {
+                    instance = new DockerContainersNetwork();
+                    result = instance;
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
+     * @getNetworkById returns a container network for a given ID, if the network doesn't exist then is created
+     */
+    public Network getNetworkByID(String id, NetworkType type) {
+        String networkID = getFormattedId(id, type);
+        if (!store.containsKey(networkID)) {
+            if (type == NetworkType.SHARED) {
+                store.put(networkID, Network.SHARED);
+            } else {
+                store.put(networkID, Network.newNetwork());
+            }
+        }
+
+        return store.get(networkID);
+    }
+
+    private String getFormattedId(String id, NetworkType type) {
+        return String.format("%s_%s", id, type.name());
+    }
+
+    public enum NetworkType {
+        NEW,
+        SHARED
+    }
+}

--- a/quarkus-test-containers/src/main/java/io/quarkus/test/services/containers/GenericDockerContainerManagedResource.java
+++ b/quarkus-test-containers/src/main/java/io/quarkus/test/services/containers/GenericDockerContainerManagedResource.java
@@ -2,6 +2,7 @@ package io.quarkus.test.services.containers;
 
 import org.apache.commons.lang3.StringUtils;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
 import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 
 import io.quarkus.test.logging.Log;
@@ -53,6 +54,16 @@ public class GenericDockerContainerManagedResource extends DockerContainerManage
                     + " tagged as UnstableAPI, so is a subject to change and SHOULD NOT be considered a stable API");
 
             container.withReuse(true);
+        }
+
+        if (model.getNetworkAlias().length > 0) {
+            String internalId = String.join("_", model.getNetworkAlias());
+            Network network = DockerContainersNetwork
+                    .getInstance()
+                    .getNetworkByID(internalId, model.getNetworkType());
+
+            container.withNetwork(network);
+            container.withNetworkAliases(model.getNetworkAlias());
         }
 
         container.withExposedPorts(model.getPort());


### PR DESCRIPTION
### Summary

 `What's the motivation to introduce shared network for containers?`

If you have a complex scenario with several containers and each container depends on another container you should run all containers into the same network, otherwise, you will get a connection refused error (because there is no visibility between containers). Currently, we have several scenarios as this one, for example with Kafka (Kafka + ZK + Registry), but are hidden by internal Quarkus test framework components as `KafkaContainer`

For example

```
  @KafkaContainer(vendor = KafkaVendor.STRIMZI, withRegistry = true, registryPath = "/apis/registry/v2")
    static final KafkaService kafka = new KafkaService();
```

This commit allows you to create complex scenarios with the current `container` annotation

For example

```
 @Container(image = "docker.io/library/postgres:latest", port = POSTGRESQL_PORT, expectedLog = "listening on IPv4 address", networkAlias = TEMPORAL_DB_TYPE)
    static PostgresqlService postgres = new PostgresqlService()
            .with(POSTGRES_USER, POSTGRES_PWD, "temporal");

    @Container(image = "temporalio/auto-setup:1.19.0", port = TEMPORAL_PORT, expectedLog = "Temporal server started", networkAlias = TEMPORAL_DB_TYPE)
    static DefaultService temporal = new DefaultService()
            .withProperty("POSTGRES_USER", () -> postgres.getUser())
            .withProperty("POSTGRES_PWD", () -> postgres.getPassword())
            .withProperty("DB", TEMPORAL_DB_TYPE)
            .withProperty("DB_PORT", "" + POSTGRESQL_PORT)
            .withProperty("POSTGRES_SEEDS", TEMPORAL_DB_TYPE)
            .withProperty("DYNAMIC_CONFIG_FILE_PATH", DEFAULT_POSTGRES_CONFIG)
            .withProperty("DEFAULT_NAMESPACE", NAMESPACE)
            .withProperty("DEPLOYMENT_CASS",
                    String.format("%s::%s|%s", CONTAINER_RESOURCE, CONTAINER_FILE_DEPLOYMENT_PATH, DEPLOYMENT_CASS_FILE))
            .withProperty("DOCKER_YAML",
                    String.format("%s::%s|%s", CONTAINER_RESOURCE, CONTAINER_FILE_DEPLOYMENT_PATH, DOCKER_FILE))
            .withProperty("DEPLOYMENT_SQL",
                    String.format("%s::%s|%s", CONTAINER_RESOURCE, CONTAINER_FILE_DEPLOYMENT_PATH, DEPLOYMENT_SQL_FILE))
            .onPostStart(service -> wait(Duration.ofSeconds(10)));
```

In this example, you can see that both containers share a Network called "TEMPORAL_DB_TYPE"

The current implementation doesn´t allow you to create complex scenarios. 


Please check the relevant options

- [X] New feature (non-breaking change which adds functionality)

### Checklist:
- [X] Example scenarios has been updated / added
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)