### PR TITLE
Fix Picocli test failures in native mode by passing args to executable

### DIFF
--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/ProdLocalhostQuarkusApplicationManagedResource.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/ProdLocalhostQuarkusApplicationManagedResource.java
@@ -21,17 +21,18 @@ public class ProdLocalhostQuarkusApplicationManagedResource extends LocalhostQua
 
     protected List<String> prepareCommand(List<String> systemProperties) {
         List<String> command = new LinkedList<>();
+        // extract 'quarkus.args' and remove the args from system properties
         String[] cmdArgs = extractQuarkusArgs(systemProperties);
         if (model.getArtifact().getFileName().toString().endsWith(".jar")) {
             command.add(JAVA);
             command.addAll(systemProperties);
             command.add("-jar");
             command.add(model.getArtifact().toAbsolutePath().toString());
-            command.addAll(Arrays.asList(cmdArgs));
         } else {
             command.add(model.getArtifact().toAbsolutePath().toString());
             command.addAll(systemProperties);
         }
+        command.addAll(Arrays.asList(cmdArgs));
 
         return command;
     }


### PR DESCRIPTION
### Summary

Daily runs are failing in native mode over Picocli examples ever since https://github.com/quarkus-qe/quarkus-test-framework/pull/702 was merged. We need to pass 'quarkus.args' to native executable too.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)