### PR TITLE
Revert "Run `blocking-reactive-model` example on Windows in native mode"

### DIFF
--- a/examples/blocking-reactive-model/pom.xml
+++ b/examples/blocking-reactive-model/pom.xml
@@ -60,5 +60,33 @@
                 </dependency>
             </dependencies>
         </profile>
+        <!-- Skipped on Windows in a native mode due to https://github.com/quarkusio/quarkus/issues/27061 -->
+        <profile>
+            <id>skip-tests-on-windows-in-native</id>
+            <activation>
+                <os>
+                    <family>windows</family>
+                </os>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
Reverts quarkus-qe/quarkus-test-framework#698 as daily runs are still failing https://github.com/quarkus-qe/quarkus-test-framework/actions/runs/4389194630, https://github.com/quarkus-qe/quarkus-test-framework/actions/runs/4394600082. I'll try to investigate when I have time.