### PR TITLE
Enable quickstart tests with Quarkus OpenShift extension

### DIFF
--- a/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftExtensionQuickstartUsingDefaultsIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftExtensionQuickstartUsingDefaultsIT.java
@@ -1,18 +1,13 @@
 package io.quarkus.qe;
 
 import org.apache.http.HttpStatus;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusSnapshot;
 import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 
-// TODO: enable when Quarkus QuickStarts migrates to Quarkus 3
-@Disabled("Disabled until Quarkus QuickStarts migrates to Quarkus 3")
-@DisabledOnQuarkusSnapshot(reason = "999-SNAPSHOT is not available in the Maven repositories in OpenShift")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
 public class OpenShiftExtensionQuickstartUsingDefaultsIT {
 

--- a/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftExtensionUsingDockerBuildStrategyQuickstartUsingDefaultsIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftExtensionUsingDockerBuildStrategyQuickstartUsingDefaultsIT.java
@@ -1,18 +1,13 @@
 package io.quarkus.qe;
 
 import org.apache.http.HttpStatus;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusSnapshot;
 import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 
-// TODO: enable when Quarkus QuickStarts migrates to Quarkus 3
-@Disabled("Disabled until Quarkus QuickStarts migrates to Quarkus 3")
-@DisabledOnQuarkusSnapshot(reason = "999-SNAPSHOT is not available in the Maven repositories in OpenShift")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtensionAndDockerBuildStrategy)
 public class OpenShiftExtensionUsingDockerBuildStrategyQuickstartUsingDefaultsIT {
 


### PR DESCRIPTION
### Summary

Enable quickstart tests using Quarkus OpenShift extension that has been fixed on Quarkus 3.0.0.Alpha6


Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)