### PR TITLE
Enable ping-pong resource tests with Quarkus OpenShift extension

### DIFF
--- a/examples/pingpong/src/test/java/io/quarkus/qe/OpenShiftUsingExtensionAndDockerBuildAndServerlessPingPongResourceIT.java
+++ b/examples/pingpong/src/test/java/io/quarkus/qe/OpenShiftUsingExtensionAndDockerBuildAndServerlessPingPongResourceIT.java
@@ -1,11 +1,8 @@
 package io.quarkus.qe;
 
-import org.junit.jupiter.api.Disabled;
-
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
-@Disabled("https://github.com/quarkusio/quarkus/issues/31787")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtensionAndDockerBuildStrategy)
 public class OpenShiftUsingExtensionAndDockerBuildAndServerlessPingPongResourceIT extends PingPongResourceIT {
 }

--- a/examples/pingpong/src/test/java/io/quarkus/qe/OpenShiftUsingExtensionAndServerlessPingPongResourceIT.java
+++ b/examples/pingpong/src/test/java/io/quarkus/qe/OpenShiftUsingExtensionAndServerlessPingPongResourceIT.java
@@ -1,11 +1,8 @@
 package io.quarkus.qe;
 
-import org.junit.jupiter.api.Disabled;
-
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
-@Disabled("https://github.com/quarkusio/quarkus/issues/31787")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
 public class OpenShiftUsingExtensionAndServerlessPingPongResourceIT extends PingPongResourceIT {
 }


### PR DESCRIPTION
### Summary

Enable tests using Quarkus OpenShift extension as https://github.com/quarkusio/quarkus/issues/31787 is resolved.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)