### PR TITLE
Revert "Enable database native tests"

### DIFF
--- a/examples/database-mysql/src/test/java/io/quarkus/qe/database/mysql/DevModeMySqlDatabaseIT.java
+++ b/examples/database-mysql/src/test/java/io/quarkus/qe/database/mysql/DevModeMySqlDatabaseIT.java
@@ -3,12 +3,14 @@ package io.quarkus.qe.database.mysql;
 import io.quarkus.test.bootstrap.DefaultService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.DevModeQuarkusApplication;
 
 /**
  * This test verifies that resources in test can be used in DevMode.
  */
+@DisabledOnNative // Don't run DEV mode tests in native: https://github.com/quarkus-qe/quarkus-test-framework/issues/720
 @QuarkusScenario
 public class DevModeMySqlDatabaseIT extends AbstractSqlDatabaseIT {
 

--- a/examples/database-mysql/src/test/java/io/quarkus/qe/database/mysql/DevModeMySqlDevServicesDatabaseIT.java
+++ b/examples/database-mysql/src/test/java/io/quarkus/qe/database/mysql/DevModeMySqlDevServicesDatabaseIT.java
@@ -4,11 +4,13 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 import io.quarkus.test.services.DevModeQuarkusApplication;
 
 /**
  * Running Quarkus on DEV mode will spin up a Database instance automatically.
  */
+@DisabledOnNative // Don't run DEV mode tests in native: https://github.com/quarkus-qe/quarkus-test-framework/issues/720
 @QuarkusScenario
 public class DevModeMySqlDevServicesDatabaseIT extends AbstractSqlDatabaseIT {
 

--- a/examples/database-oracle/src/test/java/io/quarkus/qe/database/oracle/DevModeOracleDatabaseIT.java
+++ b/examples/database-oracle/src/test/java/io/quarkus/qe/database/oracle/DevModeOracleDatabaseIT.java
@@ -3,12 +3,14 @@ package io.quarkus.qe.database.oracle;
 import io.quarkus.test.bootstrap.DefaultService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.DevModeQuarkusApplication;
 
 /**
  * This test verifies that resources in test can be used in DevMode.
  */
+@DisabledOnNative // Don't run DEV mode tests in native: https://github.com/quarkus-qe/quarkus-test-framework/issues/720
 @QuarkusScenario
 public class DevModeOracleDatabaseIT extends AbstractSqlDatabaseIT {
 

--- a/examples/database-oracle/src/test/java/io/quarkus/qe/database/oracle/DevModeOracleDevServiceDatabaseIT.java
+++ b/examples/database-oracle/src/test/java/io/quarkus/qe/database/oracle/DevModeOracleDevServiceDatabaseIT.java
@@ -4,11 +4,13 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 import io.quarkus.test.services.DevModeQuarkusApplication;
 
 /**
  * Running Quarkus on DEV mode will spin up a Database instance automatically.
  */
+@DisabledOnNative // Don't run DEV mode tests in native: https://github.com/quarkus-qe/quarkus-test-framework/issues/720
 @QuarkusScenario
 public class DevModeOracleDevServiceDatabaseIT extends AbstractSqlDatabaseIT {
 


### PR DESCRIPTION
Reverts quarkus-qe/quarkus-test-framework#714

We are building native executable and then running DEV mode test. The tests we are running has absolutely nothing to do with a native mode, the PR doesn't actually run database tests in native mode as it claims (**doesn't use native executable**) and we should revert it as it waste running time and resources.