### PR TITLE
Revert snapshot coverage on quarkus-camel

### DIFF
--- a/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftExtensionQuickstartUsingDefaultsIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftExtensionQuickstartUsingDefaultsIT.java
@@ -6,8 +6,10 @@ import org.junit.jupiter.api.Test;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusSnapshot;
 import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 
+@DisabledOnQuarkusSnapshot(reason = "'io.quarkus:quarkus-camel-bom:pom:999-SNAPSHOT' is not available in the Maven repositories")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
 public class OpenShiftExtensionQuickstartUsingDefaultsIT {
 

--- a/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftExtensionUsingDockerBuildStrategyQuickstartUsingDefaultsIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftExtensionUsingDockerBuildStrategyQuickstartUsingDefaultsIT.java
@@ -6,8 +6,10 @@ import org.junit.jupiter.api.Test;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusSnapshot;
 import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 
+@DisabledOnQuarkusSnapshot(reason = "'io.quarkus:quarkus-camel-bom:pom:999-SNAPSHOT' is not available in the Maven repositories")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtensionAndDockerBuildStrategy)
 public class OpenShiftExtensionUsingDockerBuildStrategyQuickstartUsingDefaultsIT {
 


### PR DESCRIPTION
### Summary

'io.quarkus:quarkus-camel-bom:pom:999-SNAPSHOT' is not available in the Maven repositories

This fix nightly OCP builds

Please check the relevant options

- [X] Bug fix (non-breaking change which fixes an issue)
