### PR TITLE
Update Strimzi Kafka, Confluentinc CP Kafka, CP schema registry docker images

### DIFF
--- a/examples/kafka/pom.xml
+++ b/examples/kafka/pom.xml
@@ -48,7 +48,7 @@
                         <configuration>
                             <systemProperties>
                                 <custom.kafka.image>quay.io/strimzi/kafka</custom.kafka.image>
-                                <custom.kafka.version>0.28.0-kafka-3.1.0</custom.kafka.version>
+                                <custom.kafka.version>0.34.0-kafka-3.3.2</custom.kafka.version>
                             </systemProperties>
                         </configuration>
                     </execution>

--- a/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/model/KafkaRegistry.java
+++ b/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/model/KafkaRegistry.java
@@ -1,7 +1,7 @@
 package io.quarkus.test.services.containers.model;
 
 public enum KafkaRegistry {
-    CONFLUENT("docker.io/confluentinc/cp-schema-registry", "6.1.1", "/", 8081),
+    CONFLUENT("docker.io/confluentinc/cp-schema-registry", "7.3.3", "/", 8081),
     APICURIO("quay.io/apicurio/apicurio-registry-mem", "2.2.5.Final", "/apis", 8080);
 
     private final String image;

--- a/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/model/KafkaVendor.java
+++ b/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/model/KafkaVendor.java
@@ -1,8 +1,8 @@
 package io.quarkus.test.services.containers.model;
 
 public enum KafkaVendor {
-    CONFLUENT("docker.io/confluentinc/cp-kafka", "7.2.2", 9093, KafkaRegistry.CONFLUENT),
-    STRIMZI("quay.io/strimzi/kafka", "0.31.1-kafka-3.1.2", 9092, KafkaRegistry.APICURIO);
+    CONFLUENT("docker.io/confluentinc/cp-kafka", "7.3.3", 9093, KafkaRegistry.CONFLUENT),
+    STRIMZI("quay.io/strimzi/kafka", "0.34.0-kafka-3.4.0", 9092, KafkaRegistry.APICURIO);
 
     private final String image;
     private final String defaultVersion;


### PR DESCRIPTION
### Summary

Updates used Docker images of Strimzi Kafka, Confluentinc CP schema registry  and CP Kafka. Custom Kafka is one minor version lesser than the latest in order for custom/non-custom images to actually differ.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)