### PR TITLE
Disable DEV mode continuous testing scenarios due to upstream re-working

### DIFF
--- a/examples/greetings/src/test/java/io/quarkus/qe/DevModeGreetingResourceIT.java
+++ b/examples/greetings/src/test/java/io/quarkus/qe/DevModeGreetingResourceIT.java
@@ -3,6 +3,7 @@ package io.quarkus.qe;
 import static org.hamcrest.Matchers.is;
 
 import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -15,6 +16,8 @@ import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
 import io.quarkus.test.services.DevModeQuarkusApplication;
 import io.quarkus.test.utils.AwaitilityUtils;
 
+// TODO: mvavrik enable and adapt to new continuous testing page
+@Disabled("Disabled as DEV UI continuous testing is currently re-worked")
 @QuarkusScenario
 @DisabledOnNative
 @DisabledOnQuarkusVersion(version = "1\\..*", reason = "Continuous Testing was entered in 2.x")


### PR DESCRIPTION
### Summary

Currently tests with 999-SNAPSHOT are failing as the button for enabling continuous testing is gone. Philip is currently working on this and there will be PR with next page for it in next days (maybe tomorrow), then we need to adapt changes as there will be different buttons based on what is happening (re-run failed tests, stop running tests, run all tests). We should consider this for testing too.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)