### PR TITLE
Adapt enabling of continuous testing to new DEV UI

### DIFF
--- a/examples/greetings/src/test/java/io/quarkus/qe/DevModeGreetingResourceIT.java
+++ b/examples/greetings/src/test/java/io/quarkus/qe/DevModeGreetingResourceIT.java
@@ -3,7 +3,6 @@ package io.quarkus.qe;
 import static org.hamcrest.Matchers.is;
 
 import org.apache.http.HttpStatus;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -16,11 +15,9 @@ import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
 import io.quarkus.test.services.DevModeQuarkusApplication;
 import io.quarkus.test.utils.AwaitilityUtils;
 
-// TODO: mvavrik enable and adapt to new continuous testing page
-@Disabled("Disabled as DEV UI continuous testing is currently re-worked")
 @QuarkusScenario
 @DisabledOnNative
-@DisabledOnQuarkusVersion(version = "1\\..*", reason = "Continuous Testing was entered in 2.x")
+@DisabledOnQuarkusVersion(version = "3.0.0.CR2", reason = "Continuous Testing page was added to DEV UI in Quarkus 3.0.0.Final")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class DevModeGreetingResourceIT {
 

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
         <checkstyle.version>10.9.2</checkstyle.version>
         <!-- Code Coverage Properties-->
         <jacoco.agent.argLine />
+        <playwright.version>1.32.0</playwright.version>
     </properties>
     <distributionManagement>
         <snapshotRepository>
@@ -190,6 +191,12 @@
                 <groupId>io.prometheus</groupId>
                 <artifactId>simpleclient_pushgateway</artifactId>
                 <version>${prometheus.simpleclient_pushgateway.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.microsoft.playwright</groupId>
+                <artifactId>playwright</artifactId>
+                <!-- TODO: upstream is also considering using of 'playwright', use managed version if that happens -->
+                <version>${playwright.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/QuarkusCliClient.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/QuarkusCliClient.java
@@ -12,8 +12,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.apache.commons.lang3.StringUtils;
-
 import io.quarkus.test.configuration.PropertyLookup;
 import io.quarkus.test.logging.FileLoggingHandler;
 import io.quarkus.test.logging.Log;
@@ -85,11 +83,11 @@ public class QuarkusCliClient {
         List<String> args = new ArrayList<>();
         args.addAll(Arrays.asList("create", "app", name));
         // Platform Bom
-        if (StringUtils.isNotEmpty(request.platformBom)) {
+        if (isNotEmpty(request.platformBom)) {
             args.add("--platform-bom=" + request.platformBom);
         }
         // Stream
-        if (StringUtils.isNotEmpty(request.stream)) {
+        if (isNotEmpty(request.stream)) {
             args.add("--stream=" + request.stream);
         }
         // Extensions
@@ -107,6 +105,10 @@ public class QuarkusCliClient {
         return service;
     }
 
+    private static boolean isNotEmpty(String str) {
+        return str != null && !str.isEmpty();
+    }
+
     public QuarkusCliDefaultService createExtension(String name) {
         return createExtension(name, CreateExtensionRequest.defaults());
     }
@@ -122,11 +124,11 @@ public class QuarkusCliClient {
         List<String> args = new ArrayList<>();
         args.addAll(Arrays.asList("create", "extension", name));
         // Platform Bom
-        if (StringUtils.isNotEmpty(request.platformBom)) {
+        if (isNotEmpty(request.platformBom)) {
             args.add("--platform-bom=" + request.platformBom);
         }
         // Stream
-        if (StringUtils.isNotEmpty(request.stream)) {
+        if (isNotEmpty(request.stream)) {
             args.add("--stream=" + request.stream);
         }
         // Extra args

--- a/quarkus-test-cli/src/main/java/io/quarkus/test/services/quarkus/CliDevModeLocalhostQuarkusApplicationManagedResource.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/services/quarkus/CliDevModeLocalhostQuarkusApplicationManagedResource.java
@@ -7,8 +7,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang3.StringUtils;
-
 import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.QuarkusCliClient;
 import io.quarkus.test.bootstrap.ServiceContext;
@@ -124,7 +122,7 @@ public class CliDevModeLocalhostQuarkusApplicationManagedResource extends Quarku
 
     private int getOrAssignPortByProperty(String property) {
         return serviceContext.getOwner().getProperty(property)
-                .filter(StringUtils::isNotEmpty)
+                .filter(str -> !str.isEmpty())
                 .map(Integer::parseInt)
                 .orElseGet(SocketUtils::findAvailablePort);
     }

--- a/quarkus-test-core/pom.xml
+++ b/quarkus-test-core/pom.xml
@@ -38,8 +38,8 @@
             <type>pom</type>
         </dependency>
         <dependency>
-            <groupId>net.sourceforge.htmlunit</groupId>
-            <artifactId>htmlunit</artifactId>
+            <groupId>com.microsoft.playwright</groupId>
+            <artifactId>playwright</artifactId>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>

--- a/quarkus-test-core/src/main/java/io/quarkus/test/metrics/exporters/FileMetricsExporter.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/metrics/exporters/FileMetricsExporter.java
@@ -7,8 +7,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.apache.commons.text.TextStringBuilder;
-
 import io.quarkus.test.configuration.PropertyLookup;
 
 public class FileMetricsExporter implements MetricsExporter {
@@ -34,11 +32,13 @@ public class FileMetricsExporter implements MetricsExporter {
         allMetrics.putAll(labels);
         allMetrics.putAll(metrics);
 
-        TextStringBuilder sw = new TextStringBuilder();
+        StringBuilder sb = new StringBuilder();
         allMetrics.keySet().stream()
                 .sorted()
-                .forEach(metricId -> sw.appendln(String.format("%s=%s", metricId, allMetrics.get(metricId))));
+                .forEach(metricId -> sb
+                        .append(String.format("%s=%s", metricId, allMetrics.get(metricId)))
+                        .append(System.lineSeparator()));
 
-        Files.write(Path.of(METRICS_EXPORT_FILE_OUTPUT.get()), sw.toString().getBytes());
+        Files.write(Path.of(METRICS_EXPORT_FILE_OUTPUT.get()), sb.toString().getBytes());
     }
 }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/utils/LogsVerifier.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/utils/LogsVerifier.java
@@ -1,6 +1,8 @@
 package io.quarkus.test.utils;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Assertions;
 
@@ -18,12 +20,23 @@ public class LogsVerifier {
         return new QuarkusLogsVerifier(service);
     }
 
-    public void assertContains(String expectedLog) {
+    /**
+     * Asserts log contains any of {@code expectedLogs}.
+     */
+    public void assertContains(String... expectedLogs) {
+        Predicate<String> containsExpectedLog = createExpectedLogPredicate(expectedLogs);
         AwaitilityUtils.untilAsserted(() -> {
             List<String> actualLogs = service.getLogs();
-            Assertions.assertTrue(actualLogs.stream().anyMatch(line -> line.contains(expectedLog)),
-                    "Log does not contain " + expectedLog + ". Full logs: " + actualLogs);
+            Assertions.assertTrue(actualLogs.stream().anyMatch(containsExpectedLog),
+                    "Log does not contain any of '" + Arrays.toString(expectedLogs) + "'. Full logs: " + actualLogs);
         });
+    }
+
+    private Predicate<String> createExpectedLogPredicate(String[] expectedLogs) {
+        if (expectedLogs.length == 1) {
+            return log -> log.contains(expectedLogs[0]);
+        }
+        return log -> Arrays.stream(expectedLogs).anyMatch(log::contains);
     }
 
     public void assertDoesNotContain(String unexpectedLog) {

--- a/quarkus-test-knative-events/root/src/main/java/io/quarkus/test/services/knative/eventing/FunqyKnativeEventsService.java
+++ b/quarkus-test-knative-events/root/src/main/java/io/quarkus/test/services/knative/eventing/FunqyKnativeEventsService.java
@@ -1,6 +1,7 @@
 package io.quarkus.test.services.knative.eventing;
 
 import static java.util.Objects.requireNonNull;
+import static org.apache.http.HttpStatus.SC_NOT_FOUND;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -9,7 +10,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.eclipse.jetty.http.HttpStatus;
 import org.hamcrest.Matcher;
 
 import io.fabric8.knative.client.KnativeClient;
@@ -289,7 +289,7 @@ public class FunqyKnativeEventsService extends BaseService<FunqyKnativeEventsSer
         }
 
         private ForwardResponseValidator<T> validate(Response response) {
-            if (response.statusCode() == HttpStatus.NOT_FOUND_404) {
+            if (response.statusCode() == SC_NOT_FOUND) {
                 // We need Funqy function that forward cloud events to the broker. Brokers are internal by design.
                 // We need a way to send events to the broker. We could expose another service, or use 'DomainMapping', but
                 // that's less efficient than using existing app. 'clusterEndpoint' is a Funqy function that we call directly.

--- a/quarkus-test-service-consul/src/main/java/io/quarkus/test/bootstrap/ConsulService.java
+++ b/quarkus-test-service-consul/src/main/java/io/quarkus/test/bootstrap/ConsulService.java
@@ -4,8 +4,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-
-import org.apache.commons.io.IOUtils;
+import java.util.Objects;
 
 import com.google.common.net.HostAndPort;
 import com.orbitz.consul.Consul;
@@ -21,9 +20,11 @@ public class ConsulService extends BaseService<ConsulService> {
     public void loadPropertiesFromFile(String key, String file) {
         KeyValueClient kvClient = consulClient().keyValueClient();
         try {
-            String properties = IOUtils.toString(
-                    ConsulService.class.getClassLoader().getResourceAsStream(file),
-                    StandardCharsets.UTF_8);
+            String properties;
+            try (var is = ConsulService.class.getClassLoader().getResourceAsStream(file)) {
+                Objects.requireNonNull(is, "Failed to find file " + file);
+                properties = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+            }
             kvClient.putValue(key, properties);
         } catch (IOException e) {
             fail("Failed to load properties. Caused by " + e.getMessage());

--- a/quarkus-test-service-infinispan/src/main/java/io/quarkus/test/bootstrap/InfinispanService.java
+++ b/quarkus-test-service-infinispan/src/main/java/io/quarkus/test/bootstrap/InfinispanService.java
@@ -7,8 +7,6 @@ import static io.quarkus.test.utils.PropertiesUtils.SLASH;
 import java.util.Arrays;
 import java.util.List;
 
-import org.apache.commons.lang3.StringUtils;
-
 public class InfinispanService extends BaseService<InfinispanService> {
 
     public static final String USERNAME_DEFAULT = "my_username";
@@ -63,7 +61,7 @@ public class InfinispanService extends BaseService<InfinispanService> {
         withProperty("USER", getUsername());
         withProperty("PASS", getPassword());
 
-        if (StringUtils.isNotEmpty(configFile)) {
+        if (configFile != null && !configFile.isEmpty()) {
             // legacy -> Infinispan previous to version 14
             withProperty("CONFIG_PATH", RESOURCE_PREFIX + SLASH + configFile);
             // Infinispan 14+ configuration setup


### PR DESCRIPTION
### Summary

Adapts enabling of continuous testing to new DEV UI added by https://github.com/quarkusio/quarkus/pull/32491.
HtmlUnit doesn't handle Vaadin correctly (likely because of `importmaps`), I decided to use PlayWright as Phillip Krüger suggested that's what he eventually plans to use and Aleš Justin also experiments with it: https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/Testing.20in.20Dev.20UI

It turned out that HtmlUnit dependency brought in also Apache Commons utils we used in past, however I could easily avoid using this dependency (they are just simple util methods), so I dropped it from here. If anyone needs this in the future (e.g. in TS etc.), they should add it directly and only the dependency they really need.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Dependency update
- [x] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)