### PR TITLE
Support deployment of applications with management interface via openshift extension

### DIFF
--- a/examples/management/pom.xml
+++ b/examples/management/pom.xml
@@ -29,6 +29,17 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <profiles>
+        <profile>
+            <id>deploy-to-openshift-using-extension</id>
+            <dependencies>
+                <dependency>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-openshift</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
     <build>
         <plugins>
             <plugin>

--- a/examples/management/src/test/java/io/quarkus/qe/LocalIT.java
+++ b/examples/management/src/test/java/io/quarkus/qe/LocalIT.java
@@ -23,18 +23,12 @@ public class LocalIT {
             .withProperty("quarkus.management.port", "9002");
 
     @QuarkusApplication
-    static final RestService tls = new RestService()
-            .withProperty("quarkus.management.port", "9003")
-            .withProperty("quarkus.management.ssl.certificate.key-store-file", "META-INF/resources/server.keystore")
-            .withProperty("quarkus.management.ssl.certificate.key-store-password", "password");
-
-    @QuarkusApplication
     static final RestService unmanaged = new RestService()
             .withProperty("quarkus.management.enabled", "false");
 
     @Test
     public void greeting() {
-        for (RestService service : Arrays.asList(app, custom, tls, unmanaged)) {
+        for (RestService service : Arrays.asList(app, custom, unmanaged)) {
             Response response = service.given().get("/ping");
             assertEquals(200, response.statusCode());
             assertEquals("pong", response.body().asString());
@@ -54,13 +48,6 @@ public class LocalIT {
     @Test
     public void customPort() {
         custom.management()
-                .get("q/health").then().statusCode(HttpStatus.SC_OK);
-    }
-
-    @Test
-    public void tls() {
-        tls.management()
-                .relaxedHTTPSValidation()
                 .get("q/health").then().statusCode(HttpStatus.SC_OK);
     }
 }

--- a/examples/management/src/test/java/io/quarkus/qe/LocalTLSIT.java
+++ b/examples/management/src/test/java/io/quarkus/qe/LocalTLSIT.java
@@ -1,0 +1,36 @@
+package io.quarkus.qe;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.QuarkusApplication;
+import io.restassured.response.Response;
+
+@QuarkusScenario
+// todo Merge with LocalIT when https://github.com/quarkusio/quarkus/issues/32225 is fixed
+public class LocalTLSIT {
+
+    @QuarkusApplication
+    static final RestService service = new RestService()
+            .withProperty("quarkus.management.port", "9003")
+            .withProperty("quarkus.management.ssl.certificate.key-store-file", "META-INF/resources/server.keystore")
+            .withProperty("quarkus.management.ssl.certificate.key-store-password", "password");
+
+    @Test
+    public void greeting() {
+        Response response = service.given().get("/ping");
+        assertEquals(200, response.statusCode());
+        assertEquals("pong", response.body().asString());
+    }
+
+    @Test
+    public void tls() {
+        service.management()
+                .relaxedHTTPSValidation()
+                .get("q/health").then().statusCode(HttpStatus.SC_OK);
+    }
+}

--- a/examples/management/src/test/java/io/quarkus/qe/OpenShiftBuildIT.java
+++ b/examples/management/src/test/java/io/quarkus/qe/OpenShiftBuildIT.java
@@ -1,0 +1,8 @@
+package io.quarkus.qe;
+
+import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
+import io.quarkus.test.scenarios.OpenShiftScenario;
+
+@OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.Build)
+public class OpenShiftBuildIT extends LocalIT {
+}

--- a/examples/management/src/test/java/io/quarkus/qe/OpenShiftContainerIT.java
+++ b/examples/management/src/test/java/io/quarkus/qe/OpenShiftContainerIT.java
@@ -1,0 +1,8 @@
+package io.quarkus.qe;
+
+import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
+import io.quarkus.test.scenarios.OpenShiftScenario;
+
+@OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingContainerRegistry)
+public class OpenShiftContainerIT extends LocalIT {
+}

--- a/examples/management/src/test/java/io/quarkus/qe/OpenShiftDockerBuildIT.java
+++ b/examples/management/src/test/java/io/quarkus/qe/OpenShiftDockerBuildIT.java
@@ -1,0 +1,8 @@
+package io.quarkus.qe;
+
+import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
+import io.quarkus.test.scenarios.OpenShiftScenario;
+
+@OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtensionAndDockerBuildStrategy)
+public class OpenShiftDockerBuildIT extends LocalIT {
+}

--- a/examples/management/src/test/java/io/quarkus/qe/OpenShiftExtensionIT.java
+++ b/examples/management/src/test/java/io/quarkus/qe/OpenShiftExtensionIT.java
@@ -1,0 +1,8 @@
+package io.quarkus.qe;
+
+import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
+import io.quarkus.test.scenarios.OpenShiftScenario;
+
+@OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
+public class OpenShiftExtensionIT extends LocalIT {
+}

--- a/examples/management/src/test/java/io/quarkus/qe/OpenShiftIT.java
+++ b/examples/management/src/test/java/io/quarkus/qe/OpenShiftIT.java
@@ -1,14 +1,7 @@
 package io.quarkus.qe;
 
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
-
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
 @OpenShiftScenario
 public class OpenShiftIT extends LocalIT {
-    @Test
-    @Disabled("SSL on openshift is not supported by the FW (yet)")
-    public void tls() {
-    }
 }

--- a/examples/management/src/test/java/io/quarkus/qe/OpenShiftTLSIT.java
+++ b/examples/management/src/test/java/io/quarkus/qe/OpenShiftTLSIT.java
@@ -1,0 +1,11 @@
+package io.quarkus.qe;
+
+import org.junit.jupiter.api.Disabled;
+
+import io.quarkus.test.scenarios.OpenShiftScenario;
+
+@OpenShiftScenario
+@Disabled
+// todo delete when https://github.com/quarkusio/quarkus/issues/32225 is fixed
+public class OpenShiftTLSIT extends LocalTLSIT {
+}

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusApplicationManagedResourceBuilder.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusApplicationManagedResourceBuilder.java
@@ -38,6 +38,7 @@ public abstract class QuarkusApplicationManagedResourceBuilder implements Manage
     public static final String QUARKUS_GRPC_SERVER_PORT_PROPERTY = "quarkus.grpc.server.port";
     public static final String QUARKUS_HTTP_SSL_PORT_PROPERTY = "quarkus.http.ssl-port";
     public static final int HTTP_PORT_DEFAULT = 8080;
+    public static final int MANAGEMENT_PORT_DEFAULT = 9000;
 
     protected static final Path RESOURCES_FOLDER = Paths.get("src", "main", "resources");
 
@@ -48,7 +49,6 @@ public abstract class QuarkusApplicationManagedResourceBuilder implements Manage
     private static final String DEPENDENCY_SCOPE_DEFAULT = "compile";
     private static final String QUARKUS_GROUP_ID_DEFAULT = "io.quarkus";
     private static final int DEPENDENCY_DIRECT_FLAG = 0b000010;
-    private static final int DEFAULT_MANAGEMENT_PORT = 9000;
 
     private Class<?>[] appClasses;
     private List<AppDependency> forcedDependencies = Collections.emptyList();
@@ -254,7 +254,7 @@ public abstract class QuarkusApplicationManagedResourceBuilder implements Manage
 
     public int getManagementPort() {
         if (useSeparateManagementInterface()) {
-            return getPort("quarkus.management.port").orElse(DEFAULT_MANAGEMENT_PORT);
+            return getPort("quarkus.management.port").orElse(MANAGEMENT_PORT_DEFAULT);
         }
         return getHttpPort();
     }

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/ContainerRegistryOpenShiftQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/ContainerRegistryOpenShiftQuarkusApplicationManagedResource.java
@@ -3,6 +3,7 @@ package io.quarkus.test.services.quarkus;
 import static io.quarkus.test.services.quarkus.QuarkusApplicationManagedResourceBuilder.HTTP_PORT_DEFAULT;
 import static java.util.regex.Pattern.quote;
 
+import io.quarkus.test.bootstrap.Service;
 import io.quarkus.test.utils.DockerUtils;
 
 public class ContainerRegistryOpenShiftQuarkusApplicationManagedResource
@@ -35,7 +36,11 @@ public class ContainerRegistryOpenShiftQuarkusApplicationManagedResource
     }
 
     private void exposeServices() {
-        client.expose(model.getContext().getOwner(), HTTP_PORT_DEFAULT);
+        Service service = model.getContext().getOwner();
+        client.expose(service, HTTP_PORT_DEFAULT);
+        if (model.useSeparateManagementInterface()) {
+            client.expose(model.getContext().getOwner().getName() + "-management", model.getManagementPort());
+        }
     }
 
     private String createImageAndPush() {

--- a/quarkus-test-openshift/src/main/resources/quarkus-build-openshift-template.yml
+++ b/quarkus-test-openshift/src/main/resources/quarkus-build-openshift-template.yml
@@ -97,10 +97,6 @@ items:
               image: "${SERVICE_NAME}:0.0.1-SNAPSHOT"
               imagePullPolicy: "IfNotPresent"
               name: "${SERVICE_NAME}"
-              ports:
-                - containerPort: ${INTERNAL_PORT}
-                  name: "http"
-                  protocol: "TCP"
       triggers:
         - imageChangeParams:
             automatic: true

--- a/quarkus-test-openshift/src/main/resources/quarkus-registry-openshift-template.yml
+++ b/quarkus-test-openshift/src/main/resources/quarkus-registry-openshift-template.yml
@@ -14,6 +14,18 @@ items:
     selector:
       app.kubernetes.io/name: "${SERVICE_NAME}"
     type: "ClusterIP"
+- apiVersion: "v1"
+  kind: "Service"
+  metadata:
+    name: "${SERVICE_NAME}-management"
+  spec:
+    ports:
+      - name: "management"
+        port: 9000
+        targetPort: ${MANAGEMENT_PORT}
+    selector:
+      app.kubernetes.io/name: "${SERVICE_NAME}"
+    type: "ClusterIP"
 - apiVersion: "apps.openshift.io/v1"
   kind: "DeploymentConfig"
   metadata:
@@ -40,7 +52,10 @@ items:
           image: "${IMAGE}"
           name: "${SERVICE_NAME}"
           ports:
-          - containerPort: ${INTERNAL_PORT}
-            name: "http"
-            protocol: "TCP"
-      
+            - containerPort: ${INTERNAL_PORT}
+              name: "http"
+              protocol: "TCP"
+              ports:
+            - containerPort: ${MANAGEMENT_PORT}
+              name: "management"
+              protocol: "TCP"


### PR DESCRIPTION
### Summary
Applications, which use separate network interface for management can now be deployed by openshift extension
Be aware, that https connection for the interface is not enabled upstream, so it is disabled in tests.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)