### PR TITLE
Enable Quarkus Quickstart tests

### DIFF
--- a/examples/external-applications/src/test/java/io/quarkus/qe/DevModeQuickstartUsingDefaultsIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/DevModeQuickstartUsingDefaultsIT.java
@@ -1,7 +1,6 @@
 package io.quarkus.qe;
 
 import org.apache.http.HttpStatus;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -9,16 +8,18 @@ import org.junit.jupiter.api.condition.OS;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnNative;
+import io.quarkus.test.scenarios.annotations.EnabledOnQuarkusVersion;
 import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 
-// TODO: enable when Quarkus QuickStarts migrates to Quarkus 3
-@Disabled("Disabled until Quarkus QuickStarts migrates to Quarkus 3")
 @QuarkusScenario
+// TODO: remove when Quarkus QuickStarts migrates to Quarkus 3
+@EnabledOnQuarkusVersion(version = "999-SNAPSHOT", reason = "QuickStarts on development branch uses 999-SNAPSHOT")
 @DisabledOnNative
 @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Windows does not support long file paths")
 public class DevModeQuickstartUsingDefaultsIT {
 
-    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", contextDir = "getting-started", devMode = true)
+    // TODO: switch to main branch when Quarkus QuickStarts migrates to Quarkus 3
+    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", branch = "development", contextDir = "getting-started", devMode = true)
     static final RestService app = new RestService();
 
     @Test

--- a/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftContainerRegistryQuickstartUsingDefaultsIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftContainerRegistryQuickstartUsingDefaultsIT.java
@@ -1,13 +1,9 @@
 package io.quarkus.qe;
 
-import org.junit.jupiter.api.Disabled;
-
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusSnapshot;
 
-// TODO: enable when Quarkus QuickStarts migrates to Quarkus 3
-@Disabled("Disabled until Quarkus QuickStarts migrates to Quarkus 3")
 @DisabledOnQuarkusSnapshot(reason = "999-SNAPSHOT is not available in the Maven repositories in OpenShift")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingContainerRegistry)
 public class OpenShiftContainerRegistryQuickstartUsingDefaultsIT extends QuickstartUsingDefaultsIT {

--- a/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftS2iQuickstartUsingDefaultsIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftS2iQuickstartUsingDefaultsIT.java
@@ -1,12 +1,8 @@
 package io.quarkus.qe;
 
-import org.junit.jupiter.api.Disabled;
-
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusSnapshot;
 
-// TODO: enable when Quarkus QuickStarts migrates to Quarkus 3
-@Disabled("Disabled until Quarkus QuickStarts migrates to Quarkus 3")
 @DisabledOnQuarkusSnapshot(reason = "999-SNAPSHOT is not available in the Maven repositories in OpenShift")
 @OpenShiftScenario
 public class OpenShiftS2iQuickstartUsingDefaultsIT extends QuickstartUsingDefaultsIT {

--- a/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftS2iQuickstartUsingUberJarIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftS2iQuickstartUsingUberJarIT.java
@@ -1,7 +1,6 @@
 package io.quarkus.qe;
 
 import org.apache.http.HttpStatus;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
@@ -10,8 +9,6 @@ import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusSnapshot;
 import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 
-// TODO: enable when Quarkus QuickStarts migrates to Quarkus 3
-@Disabled("Disabled until Quarkus QuickStarts migrates to Quarkus 3")
 @DisabledOnNative(reason = "This is to verify uber-jar, so it does not make sense on Native")
 @DisabledOnQuarkusSnapshot(reason = "999-SNAPSHOT is not available in the Maven repositories in OpenShift")
 @OpenShiftScenario
@@ -20,7 +17,8 @@ public class OpenShiftS2iQuickstartUsingUberJarIT {
     /**
      * Package type is set in the custom template.
      */
-    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", contextDir = "getting-started")
+    // TODO: switch to main branch when Quarkus QuickStarts migrates to Quarkus 3
+    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", branch = "development", contextDir = "getting-started")
     static final RestService appuberjar = new RestService();
 
     @Test

--- a/examples/external-applications/src/test/java/io/quarkus/qe/QuickstartUsingDefaultsIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/QuickstartUsingDefaultsIT.java
@@ -1,22 +1,23 @@
 package io.quarkus.qe;
 
 import org.apache.http.HttpStatus;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.annotations.EnabledOnQuarkusVersion;
 import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 
-// TODO: enable when Quarkus QuickStarts migrates to Quarkus 3
-@Disabled("Disabled until Quarkus QuickStarts migrates to Quarkus 3")
 @QuarkusScenario
+// TODO: remove when Quarkus QuickStarts migrates to Quarkus 3
+@EnabledOnQuarkusVersion(version = "999-SNAPSHOT", reason = "QuickStarts on development branch uses 999-SNAPSHOT")
 @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Windows does not support long file paths")
 public class QuickstartUsingDefaultsIT {
 
-    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", contextDir = "getting-started")
+    // TODO: switch to main branch when Quarkus QuickStarts migrates to Quarkus 3
+    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", branch = "development", contextDir = "getting-started")
     static final RestService app = new RestService();
 
     @Test

--- a/examples/external-applications/src/test/java/io/quarkus/qe/QuickstartUsingUsingUberJarIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/QuickstartUsingUsingUberJarIT.java
@@ -1,7 +1,6 @@
 package io.quarkus.qe;
 
 import org.apache.http.HttpStatus;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -9,16 +8,18 @@ import org.junit.jupiter.api.condition.OS;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnNative;
+import io.quarkus.test.scenarios.annotations.EnabledOnQuarkusVersion;
 import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 
-// TODO: enable when Quarkus QuickStarts migrates to Quarkus 3
-@Disabled("Disabled until Quarkus QuickStarts migrates to Quarkus 3")
 @QuarkusScenario
+// TODO: remove when Quarkus QuickStarts migrates to Quarkus 3
+@EnabledOnQuarkusVersion(version = "999-SNAPSHOT", reason = "QuickStarts on development branch use 999-SNAPSHOT")
 @DisabledOnNative(reason = "This is to verify uber-jar, so it does not make sense on Native")
 @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Windows does not support long file paths")
 public class QuickstartUsingUsingUberJarIT {
 
-    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", contextDir = "getting-started", mavenArgs = "-Dquarkus.package.type=uber-jar -DskipTests=true -Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus.platform.version=${QUARKUS_PLATFORM_VERSION}")
+    // TODO: switch to main branch when Quarkus QuickStarts migrates to Quarkus 3
+    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", branch = "development", contextDir = "getting-started", mavenArgs = "-Dquarkus.package.type=uber-jar -DskipTests=true -Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus.platform.version=${QUARKUS_PLATFORM_VERSION}")
     static final RestService app = new RestService();
 
     @Test


### PR DESCRIPTION
### Summary

Enable Quarkus Quickstart tests. 
Make quarkus app from development branch that uses Quarkus 3 so we can test it before Quarkus Quickstarts main starts using Quarkus 3.0.0.Final

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)