### PR TITLE
Refactor external apps with Quarkus snapshot

### DIFF
--- a/examples/external-applications/src/test/java/io/quarkus/qe/DevModeQuickstartUsingDefaultsIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/DevModeQuickstartUsingDefaultsIT.java
@@ -8,18 +8,14 @@ import org.junit.jupiter.api.condition.OS;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnNative;
-import io.quarkus.test.scenarios.annotations.EnabledOnQuarkusVersion;
 import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 
 @QuarkusScenario
-// TODO: remove when Quarkus QuickStarts migrates to Quarkus 3
-@EnabledOnQuarkusVersion(version = "999-SNAPSHOT", reason = "QuickStarts on development branch uses 999-SNAPSHOT")
 @DisabledOnNative
 @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Windows does not support long file paths")
 public class DevModeQuickstartUsingDefaultsIT {
 
-    // TODO: switch to main branch when Quarkus QuickStarts migrates to Quarkus 3
-    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", branch = "development", contextDir = "getting-started", devMode = true)
+    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", contextDir = "getting-started", devMode = true)
     static final RestService app = new RestService();
 
     @Test

--- a/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftContainerRegistryQuickstartUsingDefaultsIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftContainerRegistryQuickstartUsingDefaultsIT.java
@@ -2,9 +2,7 @@ package io.quarkus.qe;
 
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusSnapshot;
 
-@DisabledOnQuarkusSnapshot(reason = "999-SNAPSHOT is not available in the Maven repositories in OpenShift")
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingContainerRegistry)
 public class OpenShiftContainerRegistryQuickstartUsingDefaultsIT extends QuickstartUsingDefaultsIT {
 

--- a/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftExtensionCamelFileBindyFtpIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftExtensionCamelFileBindyFtpIT.java
@@ -7,11 +7,14 @@ import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusSnapshot;
+import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
 import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 
-@DisabledOnQuarkusSnapshot(reason = "'io.quarkus:quarkus-camel-bom:pom:999-SNAPSHOT' is not available in the Maven repositories")
-@OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtensionAndDockerBuildStrategy)
-public class OpenShiftExtensionUsingDockerBuildStrategyQuickstartUsingDefaultsIT {
+// TODO: enable test when Camel Quarkus Examples migrate to Quarkus 3.0
+@DisabledOnQuarkusVersion(version = "(3\\.[0-9]\\..*)", reason = "Camel Quarkus Examples is using Quarkus 2.16")
+@DisabledOnQuarkusSnapshot(reason = "Camel Quarkus 999-SNAPSHOT is not available in maven repository") // f.e. 'quarkus-camel-bom:pom:999-SNAPSHOT' is not available
+@OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
+public class OpenShiftExtensionCamelFileBindyFtpIT {
 
     @GitRepositoryQuarkusApplication(repo = "https://github.com/apache/camel-quarkus-examples.git", contextDir = "file-bindy-ftp", mavenArgs = "-Dopenshift")
     static final RestService app = new RestService();

--- a/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftExtensionUsingDockerBuildStrategyCamelFileBindyFtpIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftExtensionUsingDockerBuildStrategyCamelFileBindyFtpIT.java
@@ -7,11 +7,14 @@ import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusSnapshot;
+import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
 import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 
-@DisabledOnQuarkusSnapshot(reason = "'io.quarkus:quarkus-camel-bom:pom:999-SNAPSHOT' is not available in the Maven repositories")
-@OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
-public class OpenShiftExtensionQuickstartUsingDefaultsIT {
+// TODO: enable test when Camel Quarkus Examples migrate to Quarkus 3.0
+@DisabledOnQuarkusVersion(version = "(3\\.[0-9]\\..*)", reason = "Camel Quarkus Examples is using Quarkus 2.16")
+@DisabledOnQuarkusSnapshot(reason = "Camel Quarkus 999-SNAPSHOT is not available in maven repository") // f.e. 'quarkus-camel-bom:pom:999-SNAPSHOT' is not available
+@OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtensionAndDockerBuildStrategy)
+public class OpenShiftExtensionUsingDockerBuildStrategyCamelFileBindyFtpIT {
 
     @GitRepositoryQuarkusApplication(repo = "https://github.com/apache/camel-quarkus-examples.git", contextDir = "file-bindy-ftp", mavenArgs = "-Dopenshift")
     static final RestService app = new RestService();

--- a/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftS2iQuickstartUsingDefaultsIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftS2iQuickstartUsingDefaultsIT.java
@@ -1,9 +1,7 @@
 package io.quarkus.qe;
 
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusSnapshot;
 
-@DisabledOnQuarkusSnapshot(reason = "999-SNAPSHOT is not available in the Maven repositories in OpenShift")
 @OpenShiftScenario
 public class OpenShiftS2iQuickstartUsingDefaultsIT extends QuickstartUsingDefaultsIT {
 

--- a/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftS2iQuickstartUsingUberJarIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftS2iQuickstartUsingUberJarIT.java
@@ -6,19 +6,16 @@ import org.junit.jupiter.api.Test;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnNative;
-import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusSnapshot;
 import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 
 @DisabledOnNative(reason = "This is to verify uber-jar, so it does not make sense on Native")
-@DisabledOnQuarkusSnapshot(reason = "999-SNAPSHOT is not available in the Maven repositories in OpenShift")
 @OpenShiftScenario
 public class OpenShiftS2iQuickstartUsingUberJarIT {
 
     /**
      * Package type is set in the custom template.
      */
-    // TODO: switch to main branch when Quarkus QuickStarts migrates to Quarkus 3
-    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", branch = "development", contextDir = "getting-started")
+    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", contextDir = "getting-started")
     static final RestService appuberjar = new RestService();
 
     @Test

--- a/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftTodoDemoIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftTodoDemoIT.java
@@ -4,11 +4,9 @@ import org.junit.jupiter.api.Disabled;
 
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnNative;
-import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusSnapshot;
 
-// TODO: enable when Quarkus QuickStarts migrates to Quarkus 3
-@Disabled("Disabled until Quarkus QuickStarts migrates to Quarkus 3")
-@DisabledOnQuarkusSnapshot(reason = "999-SNAPSHOT is not available in the Maven repositories in OpenShift")
+// TODO: enable when Quarkus TODO app migrates to Quarkus 3
+@Disabled("Disabled until Quarkus TODO app migrates to Quarkus 3")
 @DisabledOnNative(reason = "Native + s2i not supported")
 @OpenShiftScenario
 public class OpenShiftTodoDemoIT extends TodoDemoIT {

--- a/examples/external-applications/src/test/java/io/quarkus/qe/QuickstartUsingDefaultsIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/QuickstartUsingDefaultsIT.java
@@ -7,17 +7,13 @@ import org.junit.jupiter.api.condition.OS;
 
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.scenarios.annotations.EnabledOnQuarkusVersion;
 import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 
 @QuarkusScenario
-// TODO: remove when Quarkus QuickStarts migrates to Quarkus 3
-@EnabledOnQuarkusVersion(version = "999-SNAPSHOT", reason = "QuickStarts on development branch uses 999-SNAPSHOT")
 @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Windows does not support long file paths")
 public class QuickstartUsingDefaultsIT {
 
-    // TODO: switch to main branch when Quarkus QuickStarts migrates to Quarkus 3
-    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", branch = "development", contextDir = "getting-started")
+    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", contextDir = "getting-started")
     static final RestService app = new RestService();
 
     @Test

--- a/examples/external-applications/src/test/java/io/quarkus/qe/QuickstartUsingUsingUberJarIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/QuickstartUsingUsingUberJarIT.java
@@ -8,18 +8,14 @@ import org.junit.jupiter.api.condition.OS;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnNative;
-import io.quarkus.test.scenarios.annotations.EnabledOnQuarkusVersion;
 import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 
 @QuarkusScenario
-// TODO: remove when Quarkus QuickStarts migrates to Quarkus 3
-@EnabledOnQuarkusVersion(version = "999-SNAPSHOT", reason = "QuickStarts on development branch use 999-SNAPSHOT")
 @DisabledOnNative(reason = "This is to verify uber-jar, so it does not make sense on Native")
 @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Windows does not support long file paths")
 public class QuickstartUsingUsingUberJarIT {
 
-    // TODO: switch to main branch when Quarkus QuickStarts migrates to Quarkus 3
-    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", branch = "development", contextDir = "getting-started", mavenArgs = "-Dquarkus.package.type=uber-jar -DskipTests=true -Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus.platform.version=${QUARKUS_PLATFORM_VERSION}")
+    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", contextDir = "getting-started", mavenArgs = "-Dquarkus.package.type=uber-jar -DskipTests=true -Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus.platform.version=${QUARKUS_PLATFORM_VERSION}")
     static final RestService app = new RestService();
 
     @Test

--- a/quarkus-test-openshift/src/main/resources/settings-mvn.yml
+++ b/quarkus-test-openshift/src/main/resources/settings-mvn.yml
@@ -33,7 +33,7 @@ data:
                         <id>internal.s2i.maven.remote.repository</id>
                         <url>${internal.s2i.maven.remote.repository}</url>
                         <snapshots>
-                            <enabled>false</enabled>
+                            <enabled>true</enabled>
                         </snapshots>
                     </repository>
                 </repositories>
@@ -42,7 +42,7 @@ data:
                         <id>internal.s2i.maven.remote.repository</id>
                         <url>${internal.s2i.maven.remote.repository}</url>
                         <snapshots>
-                            <enabled>false</enabled>
+                            <enabled>true</enabled>
                         </snapshots>
                     </pluginRepository>
                 </pluginRepositories>


### PR DESCRIPTION
### Summary

- enables QuickStart tests running with Quarkus 999-SNAPSHOT on OpenShift as our CI supports that now
- renames OC tests using Camel Quarkus Examples as I think it is confusing calling them QuickStarts (they are not called like that in Camel repo either)
- switches QS branch back to main as it is already migrated to Quarkus 3. I was thinking whether we should support conditional setting of branch based on Quarkus version (e.g. use development for 999-SNAPSHOT), but it is probably not worth it as we only use basic QS here like getting started and it barely changes

`quarkus-main-rhel8-jdk17-openshift-tf-native-githubci` run 34 and quarkus-main-rhel8-jdk11-openshift-tf-jvm-githubci 38 were triggered manually with 999-SNAPSHOT and they are both green

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)