### PR TITLE
Use short image names for Kafka Confluent

### DIFF
--- a/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/ConfluentKafkaContainerManagedResource.java
+++ b/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/ConfluentKafkaContainerManagedResource.java
@@ -20,11 +20,7 @@ public class ConfluentKafkaContainerManagedResource extends BaseKafkaContainerMa
 
     @Override
     protected GenericContainer<?> initKafkaContainer() {
-        DockerImageName imageName = DockerImageName
-                .parse(getKafkaImage() + ":" + getKafkaVersion())
-                // todo https://github.com/testcontainers/testcontainers-java/issues/5612
-                .asCompatibleSubstituteFor("confluentinc/cp-kafka");
-        return new KafkaContainer(imageName)
+        return new KafkaContainer(DockerImageName.parse(getKafkaImage() + ":" + getKafkaVersion()))
                 .withCreateContainerCmdModifier(cmd -> cmd.withName(DockerUtils.generateDockerContainerName()));
     }
 

--- a/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/model/KafkaRegistry.java
+++ b/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/model/KafkaRegistry.java
@@ -1,7 +1,7 @@
 package io.quarkus.test.services.containers.model;
 
 public enum KafkaRegistry {
-    CONFLUENT("docker.io/confluentinc/cp-schema-registry", "7.3.3", "/", 8081),
+    CONFLUENT("confluentinc/cp-schema-registry", "7.3.3", "/", 8081),
     APICURIO("quay.io/apicurio/apicurio-registry-mem", "2.4.2.Final", "/apis", 8080);
 
     private final String image;

--- a/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/model/KafkaVendor.java
+++ b/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/model/KafkaVendor.java
@@ -1,7 +1,7 @@
 package io.quarkus.test.services.containers.model;
 
 public enum KafkaVendor {
-    CONFLUENT("docker.io/confluentinc/cp-kafka", "7.3.3", 9093, KafkaRegistry.CONFLUENT),
+    CONFLUENT("confluentinc/cp-kafka", "7.3.3", 9093, KafkaRegistry.CONFLUENT),
     STRIMZI("quay.io/strimzi/kafka", "0.34.0-kafka-3.4.0", 9092, KafkaRegistry.APICURIO);
 
     private final String image;


### PR DESCRIPTION
### Summary

Use short image names for Kafka Confluent as problem was solved in Testcontainers 1.18.0

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)