### PR TITLE
Do not manage HTMLUnit and Jaeger client dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,12 +40,10 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <surefire-plugin.version>3.1.0</surefire-plugin.version>
         <jacoco-maven-plugin.version>0.8.10</jacoco-maven-plugin.version>
-        <jaeger.version>1.8.1</jaeger.version>
         <prometheus.simpleclient_pushgateway.version>0.16.0</prometheus.simpleclient_pushgateway.version>
         <maven-checkstyle-plugin.version>3.2.1</maven-checkstyle-plugin.version>
         <formatter-maven-plugin.version>2.22.0</formatter-maven-plugin.version>
         <impsort-maven-plugin.version>1.9.0</impsort-maven-plugin.version>
-        <htmlunit.version>2.70.0</htmlunit.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>3.0.3.Final</quarkus.platform.version>
@@ -171,23 +169,6 @@
                 <groupId>io.quarkus.qe</groupId>
                 <artifactId>quarkus-test-service-infinispan</artifactId>
                 <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.jaegertracing</groupId>
-                <artifactId>jaeger-client</artifactId>
-                <version>${jaeger.version}</version>
-                <exclusions>
-                    <!-- CVE-2020-1938 // https://github.com/jaegertracing/jaeger-client-java/issues/800-->
-                    <exclusion>
-                        <groupId>org.apache.tomcat.embed</groupId>
-                        <artifactId>tomcat-embed-core</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>net.sourceforge.htmlunit</groupId>
-                <artifactId>htmlunit</artifactId>
-                <version>${htmlunit.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.prometheus</groupId>

--- a/quarkus-test-core/src/main/resources/logging.properties
+++ b/quarkus-test-core/src/main/resources/logging.properties
@@ -1,4 +1,3 @@
 # Levels
 okhttp3.level=WARNING
 org.apache.http.level=WARNING
-com.gargoylesoftware.htmlunit.level=OFF


### PR DESCRIPTION
### Summary

We don't use Jaeger client and HTMLUnit in Test Framework and shouldn't waste dependabot runs on them. If anything that depends on our framework actually needs this dependencies, it should manage them itself.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)