### PR TITLE
Allow bootstrap without Junit extension context

### DIFF
--- a/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/ServiceContext.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/ServiceContext.java
@@ -4,8 +4,6 @@ import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.jupiter.api.extension.ExtensionContext;
-
 public final class ServiceContext {
 
     private final Service owner;
@@ -13,7 +11,7 @@ public final class ServiceContext {
     private final Path serviceFolder;
     private final Map<String, Object> store = new HashMap<>();
 
-    protected ServiceContext(Service owner, ScenarioContext scenarioContext) {
+    ServiceContext(Service owner, ScenarioContext scenarioContext) {
         this.owner = owner;
         this.scenarioContext = scenarioContext;
         if (getName().contains(":")) {
@@ -39,7 +37,7 @@ public final class ServiceContext {
         return scenarioContext;
     }
 
-    public ExtensionContext getTestContext() {
+    public TestContext getTestContext() {
         return scenarioContext.getTestContext();
     }
 

--- a/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/TestContext.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/TestContext.java
@@ -1,0 +1,101 @@
+package io.quarkus.test.bootstrap;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public interface TestContext {
+
+    Class<?> getRequiredTestClass();
+
+    Set<String> getTags();
+
+    TestStore getTestStore();
+
+    Optional<String> getRunningTestMethodName();
+
+    interface TestStore {
+
+        Object get(Object key);
+
+        void put(Object key, Object val);
+
+    }
+
+    final class TestContextImpl implements TestContext {
+
+        private final TestStore testStore;
+        private final Class<?> requiredTestClass;
+        private final Set<String> tags;
+        private final String runningTestMethodName;
+
+        public TestContextImpl(Class<?> requiredTestClass, Set<String> tags) {
+            this.testStore = new MapBackedTestStore();
+            this.requiredTestClass = requiredTestClass;
+            this.tags = tags;
+            this.runningTestMethodName = null;
+        }
+
+        TestContextImpl(Class<?> requiredTestClass, Set<String> tags, ExtensionContext.Store store) {
+            this.testStore = new TestStore() {
+                @Override
+                public Object get(Object key) {
+                    return store.get(key);
+                }
+
+                @Override
+                public void put(Object key, Object val) {
+                    store.put(key, val);
+                }
+            };
+            this.requiredTestClass = requiredTestClass;
+            this.tags = tags;
+            this.runningTestMethodName = null;
+        }
+
+        TestContextImpl(TestContext testContext, String runningTestMethodName) {
+            this.testStore = testContext.getTestStore();
+            this.requiredTestClass = testContext.getRequiredTestClass();
+            this.tags = testContext.getTags();
+            this.runningTestMethodName = runningTestMethodName;
+        }
+
+        @Override
+        public Class<?> getRequiredTestClass() {
+            return requiredTestClass;
+        }
+
+        @Override
+        public Set<String> getTags() {
+            return tags;
+        }
+
+        @Override
+        public TestStore getTestStore() {
+            return testStore;
+        }
+
+        @Override
+        public Optional<String> getRunningTestMethodName() {
+            return runningTestMethodName == null ? Optional.empty() : Optional.of(runningTestMethodName);
+        }
+    }
+
+    class MapBackedTestStore implements TestStore {
+
+        private final Map<Object, Object> keyToVal = new ConcurrentHashMap<>();
+
+        @Override
+        public Object get(Object key) {
+            return keyToVal.get(key);
+        }
+
+        @Override
+        public void put(Object key, Object val) {
+            keyToVal.put(key, val);
+        }
+    }
+}


### PR DESCRIPTION
### Summary

I am working on https://github.com/quarkus-qe/quarkus-test-suite/issues/145 and https://github.com/quarkus-qe/quarkus-test-framework/issues/345 and I need to be able to use bootstrap without JUnit ExtensionContext as it has package private constructors and many methods we don't actually use.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)