### PR TITLE
Fix corrupted channel trouble with native binary build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -220,6 +220,10 @@
                 <plugin>
                     <artifactId>maven-failsafe-plugin</artifactId>
                     <version>${surefire-plugin.version}</version>
+                    <configuration>
+                        <!-- fixes unavailable native binary build logs, https://github.com/quarkus-qe/quarkus-test-framework/issues/785 -->
+                        <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Fix corrupted channel trouble with native binary build.

Fixes https://github.com/quarkus-qe/quarkus-test-framework/issues/785 issue, before this change there was no native build log.
Details also in ^^^, I tried to adjust bootstrap with my own customizer but that didn't work well (classloader issue in FW).

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)

Example of the log with native build details:
```
[INFO] Running io.quarkus.qe.GreetingResourceIT
15:43:52,010 INFO  JBoss Threads version 3.5.0.Final
15:43:52,545 INFO  Building native image source jar: target/GreetingResourceIT/blocking/blocking-native-image-source-jar/blocking-runner.jar
15:43:54,270 INFO  Building native image from target/GreetingResourceIT/blocking/blocking-native-image-source-jar/blocking-runner.jar
15:43:54,741 INFO  Running Quarkus native-image plugin on GraalVM 22.3.1 Java 17 CE (Java Version 17.0.6+10-jvmci-22.3-b13)
15:43:54,746 INFO  /Users/rsvoboda/.sdkman/candidates/java/22.3.1.r17-grl/bin/native-image -J-Djava.util.logging.manager=org.jboss.logmanager.LogManager -J-Dsun.nio.ch.maxUpdateArraySize=100 -J-Dlogging.initial-configurator.min-level=500 -J-Dio.netty.leakDetection.level=DISABLED -J-Dio.netty.allocator.maxOrder=3 -J-Dvertx.logger-delegate-factory-class-name=io.quarkus.vertx.core.runtime.VertxLogDelegateFactory -J-Dvertx.disableDnsResolver=true -J-Duser.language=en -J-Duser.country=GB -J-Dfile.encoding=UTF-8 --features=io.quarkus.runner.Feature,io.quarkus.runtime.graal.DisableLoggingFeature -J--add-exports=java.security.jgss/sun.security.krb5=ALL-UNNAMED -J--add-opens=java.base/java.text=ALL-UNNAMED -J--add-opens=java.base/java.io=ALL-UNNAMED -J--add-opens=java.base/java.lang.invoke=ALL-UNNAMED -J--add-opens=java.base/java.util=ALL-UNNAMED -H:+CollectImageBuildStatistics -H:ImageBuildStatisticsFile=blocking-runner-timing-stats.json -H:BuildOutputJSONFile=blocking-runner-build-output-stats.json -H:+AllowFoldMethods -J-Djava.awt.headless=true --no-fallback --link-at-build-time -H:+ReportExceptionStackTraces -J-Xmx5g -H:-AddAllCharsets --enable-url-protocols=http -H:-UseServiceLoaderFeature -H:+StackTrace -J--add-exports=org.graalvm.sdk/org.graalvm.nativeimage.impl=ALL-UNNAMED --exclude-config io\.netty\.netty-codec /META-INF/native-image/io\.netty/netty-codec/generated/handlers/reflect-config\.json --exclude-config io\.netty\.netty-handler /META-INF/native-image/io\.netty/netty-handler/generated/handlers/reflect-config\.json blocking-runner -jar blocking-runner.jar
========================================================================================================================
GraalVM Native Image: Generating 'blocking-runner' (executable)...
========================================================================================================================
[1/7] Initializing...                                                                                    (7.5s @ 0.17GB)
 Version info: 'GraalVM 22.3.1 Java 17 CE'
 Java version info: '17.0.6+10-jvmci-22.3-b13'
 C compiler: cc (apple, x86_64, 14.0.3)
 Garbage collector: Serial GC
 3 user-specific feature(s)
 - io.quarkus.runner.Feature: Auto-generated class by Quarkus from the existing extensions
 - io.quarkus.runtime.graal.DisableLoggingFeature: Disables INFO logging during the analysis phase
 - org.eclipse.angus.activation.nativeimage.AngusActivationFeature
15:44:17,556 WARN  [io.net.res.dns.DnsServerAddressStreamProviders] Can not find io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider in the classpath, fallback to system defaults. This may result in incorrect DNS resolutions on MacOS. Check whether you have a dependency on 'io.netty:netty-resolver-dns-native-macos'
[2/7] Performing analysis...  [*******]                                                                 (34.9s @ 1.93GB)
  10,736 (88.82%) of 12,087 classes reachable
  15,412 (58.15%) of 26,506 fields reachable
  52,816 (55.05%) of 95,947 methods reachable
     539 classes,   123 fields, and 2,417 methods registered for reflection
      63 classes,    69 fields, and    55 methods registered for JNI access
       5 native libraries: -framework CoreServices, -framework Foundation, dl, pthread, z
[3/7] Building universe...                                                                               (3.8s @ 1.20GB)
[4/7] Parsing methods...      [**]                                                                       (3.4s @ 1.57GB)
[5/7] Inlining methods...     [***]                                                                      (1.4s @ 1.80GB)
[6/7] Compiling methods...    [*****]                                                                   (26.0s @ 1.59GB)
[7/7] Creating image...                                                                                  (4.8s @ 2.19GB)
  20.07MB (49.04%) for code area:    33,741 compilation units
  20.57MB (50.26%) for image heap:  265,100 objects and 9 resources
 291.62KB ( 0.70%) for other data
  40.92MB in total
------------------------------------------------------------------------------------------------------------------------
Top 10 packages in code area:                               Top 10 object types in image heap:
   1.62MB sun.security.ssl                                     4.45MB byte[] for code metadata
 976.74KB java.util                                            2.55MB java.lang.Class
 733.90KB java.lang.invoke                                     2.44MB java.lang.String
 717.68KB com.sun.crypto.provider                              2.16MB byte[] for general heap data
 450.59KB sun.security.x509                                    1.94MB byte[] for java.lang.String
 450.10KB java.lang                                          922.63KB com.oracle.svm.core.hub.DynamicHubCompanion
 402.18KB io.netty.buffer                                    599.91KB java.util.HashMap$Node
 400.84KB java.util.concurrent                               562.55KB byte[] for reflection metadata
 399.85KB java.io                                            478.77KB java.lang.String[]
 339.98KB io.quarkus.runtime.generated                       380.86KB c.o.svm.core.hub.DynamicHub$ReflectionMetadata
  13.44MB for 394 more packages                                3.94MB for 2587 more object types
------------------------------------------------------------------------------------------------------------------------
                        3.7s (4.3% of total time) in 52 GCs | Peak RSS: 3.15GB | CPU load: 7.10
------------------------------------------------------------------------------------------------------------------------
Produced artifacts:
 /Users/rsvoboda/git/quarkus-test-framework/examples/blocking-reactive-model/target/GreetingResourceIT/blocking/blocking-native-image-source-jar/blocking-runner (executable)
 /Users/rsvoboda/git/quarkus-test-framework/examples/blocking-reactive-model/target/GreetingResourceIT/blocking/blocking-native-image-source-jar/blocking-runner-build-output-stats.json (json)
 /Users/rsvoboda/git/quarkus-test-framework/examples/blocking-reactive-model/target/GreetingResourceIT/blocking/blocking-native-image-source-jar/blocking-runner-timing-stats.json (raw)
 /Users/rsvoboda/git/quarkus-test-framework/examples/blocking-reactive-model/target/GreetingResourceIT/blocking/blocking-native-image-source-jar/blocking-runner.build_artifacts.txt (txt)
========================================================================================================================
Finished generating 'blocking-runner' in 1m 26s.
15:45:23,181 INFO  Quarkus augmentation completed in 91592ms
15:45:24,767 INFO  JBoss Threads version 3.5.0.Final
15:45:25,285 INFO  Building native image source jar: target/GreetingResourceIT/reactive/reactive-native-image-source-jar/reactive-runner.jar
15:45:26,960 INFO  Building native image from target/GreetingResourceIT/reactive/reactive-native-image-source-jar/reactive-runner.jar
15:45:27,188 INFO  Running Quarkus native-image plugin on GraalVM 22.3.1 Java 17 CE (Java Version 17.0.6+10-jvmci-22.3-b13)
15:45:27,190 INFO  /Users/rsvoboda/.sdkman/candidates/java/22.3.1.r17-grl/bin/native-image -J-Djava.util.logging.manager=org.jboss.logmanager.LogManager -J-Dsun.nio.ch.maxUpdateArraySize=100 -J-Dlogging.initial-configurator.min-level=500 -J-Dvertx.logger-delegate-factory-class-name=io.quarkus.vertx.core.runtime.VertxLogDelegateFactory -J-Dvertx.disableDnsResolver=true -J-Dio.netty.leakDetection.level=DISABLED -J-Dio.netty.allocator.maxOrder=3 -J-Duser.language=en -J-Duser.country=GB -J-Dfile.encoding=UTF-8 --features=io.quarkus.runner.Feature,io.quarkus.runtime.graal.DisableLoggingFeature -J--add-exports=java.security.jgss/sun.security.krb5=ALL-UNNAMED -J--add-opens=java.base/java.text=ALL-UNNAMED -J--add-opens=java.base/java.io=ALL-UNNAMED -J--add-opens=java.base/java.lang.invoke=ALL-UNNAMED -J--add-opens=java.base/java.util=ALL-UNNAMED -H:+CollectImageBuildStatistics -H:ImageBuildStatisticsFile=reactive-runner-timing-stats.json -H:BuildOutputJSONFile=reactive-runner-build-output-stats.json -H:+AllowFoldMethods -J-Djava.awt.headless=true --no-fallback --link-at-build-time -H:+ReportExceptionStackTraces -J-Xmx5g -H:-AddAllCharsets --enable-url-protocols=http -H:-UseServiceLoaderFeature -H:+StackTrace -J--add-exports=org.graalvm.sdk/org.graalvm.nativeimage.impl=ALL-UNNAMED --exclude-config io\.netty\.netty-codec /META-INF/native-image/io\.netty/netty-codec/generated/handlers/reflect-config\.json --exclude-config io\.netty\.netty-handler /META-INF/native-image/io\.netty/netty-handler/generated/handlers/reflect-config\.json reactive-runner -jar reactive-runner.jar
========================================================================================================================
GraalVM Native Image: Generating 'reactive-runner' (executable)...
========================================================================================================================
[1/7] Initializing...                                                                                    (8.0s @ 0.15GB)
 Version info: 'GraalVM 22.3.1 Java 17 CE'
 Java version info: '17.0.6+10-jvmci-22.3-b13'
 C compiler: cc (apple, x86_64, 14.0.3)
 Garbage collector: Serial GC
 2 user-specific feature(s)
 - io.quarkus.runner.Feature: Auto-generated class by Quarkus from the existing extensions
 - io.quarkus.runtime.graal.DisableLoggingFeature: Disables INFO logging during the analysis phase
15:45:50,929 WARN  [io.net.res.dns.DnsServerAddressStreamProviders] Can not find io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider in the classpath, fallback to system defaults. This may result in incorrect DNS resolutions on MacOS. Check whether you have a dependency on 'io.netty:netty-resolver-dns-native-macos'
[2/7] Performing analysis...  [******]                                                                  (33.9s @ 0.91GB)
  10,407 (88.59%) of 11,748 classes reachable
  14,789 (57.37%) of 25,780 fields reachable
  51,251 (55.30%) of 92,671 methods reachable
     543 classes,   113 fields, and 2,637 methods registered for reflection
      63 classes,    69 fields, and    55 methods registered for JNI access
       5 native libraries: -framework CoreServices, -framework Foundation, dl, pthread, z
[3/7] Building universe...                                                                               (3.3s @ 1.44GB)
[4/7] Parsing methods...      [**]                                                                       (2.8s @ 1.68GB)
[5/7] Inlining methods...     [***]                                                                      (1.6s @ 1.78GB)
[6/7] Compiling methods...    [*****]                                                                   (23.0s @ 1.18GB)
[7/7] Creating image...                                                                                  (4.6s @ 1.85GB)
  19.25MB (48.23%) for code area:    32,687 compilation units
  20.37MB (51.02%) for image heap:  261,273 objects and 7 resources
 306.66KB ( 0.75%) for other data
  39.92MB in total
------------------------------------------------------------------------------------------------------------------------
Top 10 packages in code area:                               Top 10 object types in image heap:
   1.62MB sun.security.ssl                                     4.26MB byte[] for code metadata
 974.07KB java.util                                            2.46MB java.lang.Class
 733.10KB java.lang.invoke                                     2.42MB java.lang.String
 717.65KB com.sun.crypto.provider                              2.14MB byte[] for general heap data
 474.88KB java.lang                                            1.91MB byte[] for java.lang.String
 450.56KB sun.security.x509                                  894.35KB com.oracle.svm.core.hub.DynamicHubCompanion
 404.98KB io.netty.buffer                                    557.91KB byte[] for reflection metadata
 385.96KB java.io                                            524.02KB java.util.HashMap$Node
 381.19KB java.util.concurrent                               473.43KB java.lang.String[]
 337.81KB io.netty.handler.codec.http2                       370.51KB c.o.svm.core.hub.DynamicHub$ReflectionMetadata
  12.64MB for 388 more packages                                3.92MB for 2538 more object types
------------------------------------------------------------------------------------------------------------------------
                        3.2s (3.9% of total time) in 48 GCs | Peak RSS: 3.10GB | CPU load: 7.28
------------------------------------------------------------------------------------------------------------------------
Produced artifacts:
 /Users/rsvoboda/git/quarkus-test-framework/examples/blocking-reactive-model/target/GreetingResourceIT/reactive/reactive-native-image-source-jar/reactive-runner (executable)
 /Users/rsvoboda/git/quarkus-test-framework/examples/blocking-reactive-model/target/GreetingResourceIT/reactive/reactive-native-image-source-jar/reactive-runner-build-output-stats.json (json)
 /Users/rsvoboda/git/quarkus-test-framework/examples/blocking-reactive-model/target/GreetingResourceIT/reactive/reactive-native-image-source-jar/reactive-runner-timing-stats.json (raw)
 /Users/rsvoboda/git/quarkus-test-framework/examples/blocking-reactive-model/target/GreetingResourceIT/reactive/reactive-native-image-source-jar/reactive-runner.build_artifacts.txt (txt)
========================================================================================================================
Finished generating 'reactive-runner' in 1m 22s.
15:46:50,830 INFO  Quarkus augmentation completed in 86529ms
15:46:50,857 INFO  [blocking] Initialize service (Quarkus NATIVE mode)
...
```