### PR TITLE
Fix failing SureFireDebugIT by setting parent project version

### DIFF
--- a/examples/debug/pom.xml
+++ b/examples/debug/pom.xml
@@ -37,6 +37,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
+                <version>${maven-resources-plugin.version}</version>
                 <configuration>
                     <escapeString>\</escapeString>
                 </configuration>

--- a/examples/debug/src/test/resources-filtered/project/classic/pom.xml
+++ b/examples/debug/src/test/resources-filtered/project/classic/pom.xml
@@ -4,11 +4,12 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-examples-parent</artifactId>
-        <version>1.3.1.Beta16-SNAPSHOT</version>
+        <version>@project.version@</version>
         <relativePath>../../../../../</relativePath>
     </parent>
     <artifactId>examples-debug</artifactId>
     <name>Quarkus - Test Framework - Examples - Debug - Classic Test</name>
+    <version>@project.version@</version>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <surefire-plugin.version>3.1.0</surefire-plugin.version>
+        <maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>
         <jacoco-maven-plugin.version>0.8.10</jacoco-maven-plugin.version>
         <prometheus.simpleclient_pushgateway.version>0.16.0</prometheus.simpleclient_pushgateway.version>
         <maven-checkstyle-plugin.version>3.3.0</maven-checkstyle-plugin.version>


### PR DESCRIPTION
### Summary

I hardcoded project version of Maven invoker test, however dependabot doesn't update POMs in resource directories and when we released 1.3.0.Beta16, daily build started to fail.

Also mentioned warning about missing `maven-resources-plugin` version when any fw/example is run (though it works :/), so now we manage this dependency version.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)