### PR TITLE
Fix compilation failure due to removed method

### DIFF
--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
@@ -51,6 +51,7 @@ import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.VolumeMount;
 import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
 import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.fabric8.kubernetes.client.dsl.ContainerResource;
 import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.fabric8.kubernetes.client.utils.Serialization;
@@ -65,7 +66,6 @@ import io.fabric8.openshift.api.model.operatorhub.v1alpha1.SubscriptionSpec;
 import io.fabric8.openshift.client.NamespacedOpenShiftClient;
 import io.fabric8.openshift.client.OpenShiftConfig;
 import io.fabric8.openshift.client.OpenShiftConfigBuilder;
-import io.fabric8.openshift.client.impl.OpenShiftClientImpl;
 import io.quarkus.test.bootstrap.Service;
 import io.quarkus.test.configuration.PropertyLookup;
 import io.quarkus.test.logging.Log;
@@ -108,14 +108,18 @@ public final class OpenShiftClient {
         if (ENABLED_EPHEMERAL_NAMESPACES.getAsBoolean()) {
             currentNamespace = createProject();
             OpenShiftConfig config = new OpenShiftConfigBuilder().withTrustCerts(true).withNamespace(currentNamespace).build();
-            client = new OpenShiftClientImpl(config);
+            client = createClient(config);
         } else {
             OpenShiftConfig config = new OpenShiftConfigBuilder().withTrustCerts(true).build();
-            client = new OpenShiftClientImpl(config);
+            client = createClient(config);
             currentNamespace = client.getNamespace();
         }
         isClientReady = true;
         kn = client.adapt(KnativeClient.class);
+    }
+
+    private static NamespacedOpenShiftClient createClient(OpenShiftConfig config) {
+        return new KubernetesClientBuilder().withConfig(config).build().adapt(NamespacedOpenShiftClient.class);
     }
 
     public static OpenShiftClient create(String scenarioId) {


### PR DESCRIPTION
### Summary
Fabric8 team removed[1][2] constructors, which we were using to create Openshift client
Switched to other methods.
This change was brought to Quarkus with this update[3]

[1] https://github.com/fabric8io/kubernetes-client/commit/6d7db8075ac40e4624d63237ccd4fd7f83058708#diff-92a1266d167b46838301a64f043de2895376ebf7ec810e7769d641d2fed6f511L227-L246
[2] https://github.com/fabric8io/kubernetes-client/pull/4662
[3] https://github.com/quarkusio/quarkus/pull/33767



Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)