### PR TITLE
[1.2.z] Allowing HTTP mirrors in S2I Maven config

### DIFF
--- a/quarkus-test-openshift/src/main/resources/settings-mvn.yml
+++ b/quarkus-test-openshift/src/main/resources/settings-mvn.yml
@@ -8,6 +8,15 @@ data:
     <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+        <mirrors>
+            <mirror>
+                <id>internal.s2i.maven.remote.repository.mirror</id>
+                <mirrorOf>internal.s2i.maven.remote.repository</mirrorOf>
+                <name>internal.s2i.maven.remote.repository</name>
+                <url>${internal.s2i.maven.remote.repository}</url>
+                <blocked>false</blocked>
+            </mirror>
+        </mirrors>
         <profiles>
             <profile>
                 <id>redhat</id>


### PR DESCRIPTION
### Summary

* With Maven 3.8.1, non-local http repos were disabled. This commit adds Maven settings into S2I build that allows for the http mirror to be used.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)