### PR TITLE
Another attempt to solve broken compatibility in fabric8 6.7.1

### DIFF
--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
@@ -53,6 +53,7 @@ import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.fabric8.kubernetes.client.dsl.ContainerResource;
+import io.fabric8.kubernetes.client.dsl.NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable;
 import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.fabric8.kubernetes.client.utils.Serialization;
 import io.fabric8.openshift.api.model.DeploymentConfig;
@@ -957,7 +958,9 @@ public final class OpenShiftClient {
     }
 
     private List<HasMetadata> loadYaml(String template) {
-        return client.load(new ByteArrayInputStream(template.getBytes())).items();
+        NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata> load = client
+                .load(new ByteArrayInputStream(template.getBytes()));
+        return load.items();
     }
 
     private String generateRandomProjectName() {


### PR DESCRIPTION
See [1] and [2] for details.
[1] https://github.com/quarkus-qe/quarkus-test-framework/pull/803
[2] https://github.com/fabric8io/kubernetes-client/pull/4662

### Summary

(Summarize the problem solved by this PR, and how to verify it manually)

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)