### PR TITLE
Fix calls to methods broken by fabric8 update

### DIFF
--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
@@ -17,6 +17,9 @@ import static org.junit.jupiter.api.Assertions.fail;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -55,6 +58,7 @@ import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.fabric8.kubernetes.client.dsl.ContainerResource;
 import io.fabric8.kubernetes.client.dsl.NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable;
 import io.fabric8.kubernetes.client.dsl.PodResource;
+import io.fabric8.kubernetes.client.impl.KubernetesClientImpl;
 import io.fabric8.kubernetes.client.utils.Serialization;
 import io.fabric8.openshift.api.model.DeploymentConfig;
 import io.fabric8.openshift.api.model.ImageStream;
@@ -958,9 +962,26 @@ public final class OpenShiftClient {
     }
 
     private List<HasMetadata> loadYaml(String template) {
-        NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata> load = client
-                .load(new ByteArrayInputStream(template.getBytes()));
-        return load.items();
+        NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata> metadata = loadUsingDarkArtsOfReflection(
+                client, new ByteArrayInputStream(template.getBytes()));
+        return metadata.items();
+    }
+
+    /*
+     * todo replace the only call of this method with client.load(new ByteArrayInputStream(...)
+     * when https://github.com/quarkusio/quarkus/pull/33767 got released (probably 3.2.0)
+     * verification: mvn clean install -Pframework \
+     * && mvn clean verify -Popenshift,examples -pl examples/https/ -Dquarkus.platform.version=999-SNAPSHOT
+     */
+    private NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata> loadUsingDarkArtsOfReflection(
+            OpenShiftClientImpl client, ByteArrayInputStream stream) {
+        try {
+            Method method = KubernetesClientImpl.class.getDeclaredMethod("load", InputStream.class);
+            Object metadata = method.invoke(client, stream);
+            return (NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata>) metadata;
+        } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private String generateRandomProjectName() {


### PR DESCRIPTION
### Summary

Class KubernetesClientImpl changed between fabric8 versions 6.6.2 and 6.7.2
* in 6.6.2 method `load` returns ParameterNamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata>
* in 6.7.2 the same method returns NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata> our FW is built using stable Quarkus (ie fabric8 6.6.2) but often run with the latest (ie fabric8 6.7.2) The only way Java can handle change of returned value after compilation, is through reflection

Follow up to:
* https://github.com/quarkus-qe/quarkus-test-framework/pull/803
* https://github.com/quarkus-qe/quarkus-test-framework/pull/808
* https://github.com/quarkus-qe/quarkus-test-framework/pull/811
all due to https://github.com/fabric8io/kubernetes-client/pull/4662

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)