### PR TITLE
Bump Quarkus to 3.2.0.CR1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <impsort-maven-plugin.version>1.9.0</impsort-maven-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>3.1.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>3.2.0.CR1</quarkus.platform.version>
         <exclude.tests.with.tags>quarkus-cli</exclude.tests.with.tags>
         <include.tests>**/*IT.java</include.tests>
         <exclude.openshift.tests>**/OpenShift*IT.java</exclude.openshift.tests>

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
@@ -17,9 +17,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -56,9 +53,7 @@ import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.fabric8.kubernetes.client.dsl.ContainerResource;
-import io.fabric8.kubernetes.client.dsl.NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable;
 import io.fabric8.kubernetes.client.dsl.PodResource;
-import io.fabric8.kubernetes.client.impl.KubernetesClientImpl;
 import io.fabric8.kubernetes.client.utils.Serialization;
 import io.fabric8.openshift.api.model.DeploymentConfig;
 import io.fabric8.openshift.api.model.ImageStream;
@@ -962,26 +957,7 @@ public final class OpenShiftClient {
     }
 
     private List<HasMetadata> loadYaml(String template) {
-        NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata> metadata = loadUsingDarkArtsOfReflection(
-                client, new ByteArrayInputStream(template.getBytes()));
-        return metadata.items();
-    }
-
-    /*
-     * todo replace the only call of this method with client.load(new ByteArrayInputStream(...)
-     * when https://github.com/quarkusio/quarkus/pull/33767 got released (probably 3.2.0)
-     * verification: mvn clean install -Pframework \
-     * && mvn clean verify -Popenshift,examples -pl examples/https/ -Dquarkus.platform.version=999-SNAPSHOT
-     */
-    private NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata> loadUsingDarkArtsOfReflection(
-            OpenShiftClientImpl client, ByteArrayInputStream stream) {
-        try {
-            Method method = KubernetesClientImpl.class.getDeclaredMethod("load", InputStream.class);
-            Object metadata = method.invoke(client, stream);
-            return (NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata>) metadata;
-        } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
-            throw new RuntimeException(e);
-        }
+        return client.load(new ByteArrayInputStream(template.getBytes())).items();
     }
 
     private String generateRandomProjectName() {


### PR DESCRIPTION
### Summary
Bump Quarkus to 3.2.0.CR1
Remove workaround from https://github.com/quarkus-qe/quarkus-test-framework/pull/814

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Dependency update
- [x] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)