### PR TITLE
Remove quarkus-helm module exclusion in Native daily CI runs 

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -234,7 +234,6 @@ jobs:
         shell: bash
         run: tar -xzf maven-repo.tgz -C ~
       - name: Build
-        # TODO: Remove quarkus-helm module exclusion when Quarkus helm extension bumps to 1.0.9
         run: |
           if [[ "${{ matrix.quarkus-version }}" = 1.* ]]; then
              EXCLUDE_MODULES="-pl !examples/grpc"
@@ -242,7 +241,6 @@ jobs:
 
           if [[ "${{ matrix.quarkus-version }}" != current ]]; then
              QUARKUS_VERSION="-Dquarkus.platform.version=${{ matrix.quarkus-version }}"
-             EXCLUDE_MODULES+=" -pl '!examples/quarkus-helm'"
           fi
 
           mvn -B -fae -s .github/mvn-settings.xml clean install -Pframework,examples,native $QUARKUS_VERSION $EXCLUDE_MODULES
@@ -366,9 +364,8 @@ jobs:
         uses: al-cheb/configure-pagefile-action@v1.3
       - name: Build in Native mode
         shell: bash
-        # TODO: Remove quarkus-helm module exclusion when Quarkus helm extension bumps to 1.0.9
         run: |
-          mvn -B -fae -s .github/mvn-settings.xml clean install -Pframework,examples,native,skip-tests-on-windows-in-native -Dquarkus.native.container-build=false -Dquarkus.platform.version="${{ matrix.quarkus-version }}" -pl '!examples/quarkus-helm'
+          mvn -B -fae -s .github/mvn-settings.xml clean install -Pframework,examples,native,skip-tests-on-windows-in-native -Dquarkus.native.container-build=false -Dquarkus.platform.version="${{ matrix.quarkus-version }}"
       - name: Zip Artifacts
         shell: bash
         if: failure()


### PR DESCRIPTION
### Summary

Fixes daily CI fails. Due to helm examples module is disabled on Native, maven can't exclude this module. 

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)