### PR TITLE
Print application logs only after start-up

### DIFF
--- a/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/BaseService.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/BaseService.java
@@ -250,6 +250,7 @@ public class BaseService<T extends Service> implements Service {
         this.managedResourceBuilder = managedResourceBuilder;
         this.managedResource = managedResourceBuilder.build(context);
         this.managedResource.validate();
+        this.onPostStart((service) -> this.managedResource.afterStart());
     }
 
     public void restart() {

--- a/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/ManagedResource.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/ManagedResource.java
@@ -56,6 +56,13 @@ public interface ManagedResource {
     default void validate() {
     }
 
+    /*
+     * An action, which should be executed as soon as the resource is started.
+     */
+    default void afterStart() {
+
+    }
+
     default URILike createURI(String scheme, String host, int port) {
         return new URILike(scheme, host, port, null);
     }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusManagedResource.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusManagedResource.java
@@ -10,6 +10,10 @@ import io.quarkus.test.logging.LoggingHandler;
 import io.quarkus.test.services.quarkus.model.LaunchMode;
 import io.quarkus.test.services.quarkus.model.QuarkusProperties;
 
+/**
+ * This class describes a Quarkus application,
+ * children classes define, where and how it is built and run.
+ */
 public abstract class QuarkusManagedResource implements ManagedResource {
 
     private static final String EXPECTED_OUTPUT_DEFAULT = "Installed features";
@@ -38,12 +42,7 @@ public abstract class QuarkusManagedResource implements ManagedResource {
 
     @Override
     public boolean isRunning() {
-        if (getLoggingHandler() != null && getLoggingHandler().logsContains(expectedOutput)) {
-            getLoggingHandler().flush();
-            return true;
-        }
-
-        return false;
+        return getLoggingHandler() != null && getLoggingHandler().logsContains(expectedOutput);
     }
 
     @Override
@@ -62,6 +61,11 @@ public abstract class QuarkusManagedResource implements ManagedResource {
 
     public void onPostBuild() {
 
+    }
+
+    @Override
+    public void afterStart() {
+        getLoggingHandler().flush();
     }
 
     protected ServiceContext getContext() {


### PR DESCRIPTION
### Summary

Previously[1] it was (wrongly) assumed, that method isRunning of class QuarkusManagedResource is run only once right after start, so it is safe to put log output into it. In reality, this method is called several times during test lifecycle, including at the time of teardown.
Logs for OpenShiftQuarkusApplicationManagedResource are retrieved from OCP cluster. Since connection to the cluster may be already closed during teardown, this leads to hard-to-reproduce exceptions. This change addresses this by making sure, that logs are printed only once during start up and not in (supposedly) pure isRunning method.

[1] https://github.com/quarkus-qe/quarkus-test-framework/pull/213

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)