### PR TITLE
Improve detection of Native mode

### DIFF
--- a/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/annotations/DisabledOnNativeCondition.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/annotations/DisabledOnNativeCondition.java
@@ -1,5 +1,10 @@
 package io.quarkus.test.scenarios.annotations;
 
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.disabled;
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled;
+
+import java.util.Objects;
+
 import org.junit.jupiter.api.extension.ConditionEvaluationResult;
 import org.junit.jupiter.api.extension.ExecutionCondition;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -10,10 +15,13 @@ public class DisabledOnNativeCondition implements ExecutionCondition {
 
     @Override
     public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
-        if (!QuarkusProperties.isNativePackageType()) {
-            return ConditionEvaluationResult.enabled("It's not running the test on Native");
+        if (QuarkusProperties.isNativePackageType()) {
+            return disabled("It's running the test on Native, detected through package type");
         }
-
-        return ConditionEvaluationResult.disabled("It's running the test on Native");
+        String property = System.getProperty("profile.id");
+        if (Objects.equals(property, "native")) {
+            return disabled("It's running the test on Native, detected through build profile");
+        }
+        return enabled("It's not running the test on Native");
     }
 }


### PR DESCRIPTION
Previously, @DisabledOnNative annotations used package type to detect whether the test is executed in Native mode. Unfortunately, this doesn't work for modules, which have their native mode disabled (e.g. quarkus-cli[1]). This changes uses Maven profiles to detect Native mode, the same way it worked[1] for quarkus-cli

[1] https://github.com/Sgitario/quarkus-test-suite/blob/afebdd2e187c2c3edcc53fc6ce2cff4b8c629a17/quarkus-cli/pom.xml#L20-L29
[2] https://github.com/quarkus-qe/quarkus-test-suite/pull/1230

### Summary

(Summarize the problem solved by this PR, and how to verify it manually)

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)