### PR TITLE
Disable build analytics in DEV mode and CLI tests

### DIFF
--- a/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/QuarkusCliClient.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/QuarkusCliClient.java
@@ -1,5 +1,7 @@
 package io.quarkus.test.bootstrap;
 
+import static io.quarkus.test.services.quarkus.model.QuarkusProperties.QUARKUS_ANALYTICS_DISABLED_LOCAL_PROP_KEY;
+import static java.lang.String.format;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
@@ -16,6 +18,7 @@ import io.quarkus.test.configuration.PropertyLookup;
 import io.quarkus.test.logging.FileLoggingHandler;
 import io.quarkus.test.logging.Log;
 import io.quarkus.test.services.quarkus.CliDevModeLocalhostQuarkusApplicationManagedResource;
+import io.quarkus.test.services.quarkus.model.QuarkusProperties;
 import io.quarkus.test.utils.FileUtils;
 import io.quarkus.test.utils.ProcessBuilderProvider;
 
@@ -169,6 +172,10 @@ public class QuarkusCliClient {
         List<String> cmd = new ArrayList<>();
         cmd.addAll(Arrays.asList(COMMAND.get().split(" ")));
         cmd.addAll(Arrays.asList(args));
+
+        if (QuarkusProperties.disableBuildAnalytics()) {
+            cmd.add(format("-D%s=%s", QUARKUS_ANALYTICS_DISABLED_LOCAL_PROP_KEY, Boolean.TRUE));
+        }
 
         Log.info(cmd.stream().collect(Collectors.joining(" ")));
         try {

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/DevModeQuarkusApplicationManagedResourceBuilder.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/DevModeQuarkusApplicationManagedResourceBuilder.java
@@ -1,5 +1,6 @@
 package io.quarkus.test.services.quarkus;
 
+import static io.quarkus.test.services.quarkus.model.QuarkusProperties.QUARKUS_ANALYTICS_DISABLED_LOCAL_PROP_KEY;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.annotation.Annotation;
@@ -8,6 +9,7 @@ import java.nio.file.Path;
 import io.quarkus.test.bootstrap.ManagedResource;
 import io.quarkus.test.bootstrap.ServiceContext;
 import io.quarkus.test.services.DevModeQuarkusApplication;
+import io.quarkus.test.services.quarkus.model.QuarkusProperties;
 import io.quarkus.test.utils.FileUtils;
 
 public class DevModeQuarkusApplicationManagedResourceBuilder extends QuarkusApplicationManagedResourceBuilder {
@@ -30,6 +32,11 @@ public class DevModeQuarkusApplicationManagedResourceBuilder extends QuarkusAppl
     public ManagedResource build(ServiceContext context) {
         setContext(context);
         configureLogging();
+        if (QuarkusProperties.disableBuildAnalytics()) {
+            getContext()
+                    .getOwner()
+                    .withProperty(QUARKUS_ANALYTICS_DISABLED_LOCAL_PROP_KEY, Boolean.TRUE.toString());
+        }
         build();
         return new DevModeLocalhostQuarkusApplicationManagedResource(this);
     }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/model/QuarkusProperties.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/model/QuarkusProperties.java
@@ -14,6 +14,9 @@ public final class QuarkusProperties {
     public static final PropertyLookup PLATFORM_GROUP_ID = new PropertyLookup("quarkus.platform.group-id", "io.quarkus");
     public static final PropertyLookup PLATFORM_VERSION = new PropertyLookup("quarkus.platform.version");
     public static final PropertyLookup PLUGIN_VERSION = new PropertyLookup("quarkus-plugin.version");
+    public static final String QUARKUS_ANALYTICS_DISABLED_LOCAL_PROP_KEY = "quarkus.analytics.disabled";
+    public static final PropertyLookup QUARKUS_ANALYTICS_DISABLED_LOCAL_PROP = new PropertyLookup(
+            QUARKUS_ANALYTICS_DISABLED_LOCAL_PROP_KEY, "true");
     public static final String PACKAGE_TYPE_NAME = "quarkus.package.type";
     public static final String MUTABLE_JAR = "mutable-jar";
     public static final PropertyLookup PACKAGE_TYPE = new PropertyLookup(PACKAGE_TYPE_NAME);
@@ -35,6 +38,10 @@ public final class QuarkusProperties {
 
     public static String getPluginVersion() {
         return defaultVersionIfEmpty(PLUGIN_VERSION.get());
+    }
+
+    public static boolean disableBuildAnalytics() {
+        return QUARKUS_ANALYTICS_DISABLED_LOCAL_PROP.getAsBoolean();
     }
 
     public static boolean isNativePackageType() {


### PR DESCRIPTION
### Summary

We are prompted to use build analytics in our DEV mode tests and CLI tests, and as we don't answer, we are waiting out 10s timeout (please see TS daily  build). Providing our build analytics would not improve Quarkus as they target actual users.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)