### PR TITLE
Maven invoker test should create Quarkus with the same version we are testing

### DIFF
--- a/examples/debug/src/test/resources-filtered/project/classic/pom.xml
+++ b/examples/debug/src/test/resources-filtered/project/classic/pom.xml
@@ -10,6 +10,17 @@
     <artifactId>examples-debug</artifactId>
     <name>Quarkus - Test Framework - Examples - Debug - Classic Test</name>
     <version>@project.version@</version>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>${quarkus.platform.group-id}</groupId>
+                <artifactId>${quarkus.platform.artifact-id}</artifactId>
+                <version>${quarkus.platform.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
### Summary

Fixes daily build and CI.

Problem was that we were creating Quarks application with Quarkus version hardoced in parent pom (right now 3.1.0.Final) but testing with 999-SNAPSHOT. So Quarkus maven plugin could sometimes be incompatible with created application. Quarkus dependency management wasn't updated with `quarkus.platform.version` due to how invoker test works (my best guess!), so now we override it.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)