### PR TITLE
Bump Quarkus to 3.2.1.Final and remove workarounds for fixed issues

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -18,9 +18,8 @@ jobs:
           check-latest: true
           cache: 'maven'
       - name: Build with Maven
-        # TODO: remove 'quarkus.bootstrap.effective-model-builder' property when issue get fixed: https://github.com/quarkusio/quarkus/issues/34787
         run: |
-          mvn -V -B -s .github/mvn-settings.xml verify -Pframework,examples -Dvalidate-format -DskipTests -DskipITs -Dquarkus.bootstrap.effective-model-builder
+          mvn -V -B -s .github/mvn-settings.xml verify -Pframework,examples -Dvalidate-format -DskipTests -DskipITs
   quarkus-main-build:
     name: Quarkus main build
     runs-on: ubuntu-latest

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <impsort-maven-plugin.version>1.9.0</impsort-maven-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>3.2.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>3.2.1.Final</quarkus.platform.version>
         <exclude.tests.with.tags>quarkus-cli</exclude.tests.with.tags>
         <include.tests>**/*IT.java</include.tests>
         <exclude.openshift.tests>**/OpenShift*IT.java</exclude.openshift.tests>


### PR DESCRIPTION
### Summary

- bumps Quarkus to 3.2.1.Final
- https://github.com/quarkusio/quarkus/issues/34787 got fixed, removing workaround
- https://github.com/quarkusio/quarkus/pull/33767 got fixed, removing workaround

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)