### PR TITLE
Disable DevMode tests for native and update files name.

### DIFF
--- a/examples/database-mysql/src/test/java/io/quarkus/qe/database/mysql/DevModeMySqlDatabaseIT.java
+++ b/examples/database-mysql/src/test/java/io/quarkus/qe/database/mysql/DevModeMySqlDatabaseIT.java
@@ -3,14 +3,12 @@ package io.quarkus.qe.database.mysql;
 import io.quarkus.test.bootstrap.DefaultService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.DevModeQuarkusApplication;
 
 /**
  * This test verifies that resources in test can be used in DevMode.
  */
-@DisabledOnNative // Don't run DEV mode tests in native: https://github.com/quarkus-qe/quarkus-test-framework/issues/720
 @QuarkusScenario
 public class DevModeMySqlDatabaseIT extends AbstractSqlDatabaseIT {
 

--- a/examples/database-mysql/src/test/java/io/quarkus/qe/database/mysql/DevModeMySqlDevServicesDatabaseIT.java
+++ b/examples/database-mysql/src/test/java/io/quarkus/qe/database/mysql/DevModeMySqlDevServicesDatabaseIT.java
@@ -4,13 +4,11 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 import io.quarkus.test.services.DevModeQuarkusApplication;
 
 /**
  * Running Quarkus on DEV mode will spin up a Database instance automatically.
  */
-@DisabledOnNative // Don't run DEV mode tests in native: https://github.com/quarkus-qe/quarkus-test-framework/issues/720
 @QuarkusScenario
 public class DevModeMySqlDevServicesDatabaseIT extends AbstractSqlDatabaseIT {
 

--- a/examples/database-oracle/src/test/java/io/quarkus/qe/database/oracle/DevModeOracleDatabaseIT.java
+++ b/examples/database-oracle/src/test/java/io/quarkus/qe/database/oracle/DevModeOracleDatabaseIT.java
@@ -3,14 +3,12 @@ package io.quarkus.qe.database.oracle;
 import io.quarkus.test.bootstrap.DefaultService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 import io.quarkus.test.services.Container;
 import io.quarkus.test.services.DevModeQuarkusApplication;
 
 /**
  * This test verifies that resources in test can be used in DevMode.
  */
-@DisabledOnNative // Don't run DEV mode tests in native: https://github.com/quarkus-qe/quarkus-test-framework/issues/720
 @QuarkusScenario
 public class DevModeOracleDatabaseIT extends AbstractSqlDatabaseIT {
 

--- a/examples/database-oracle/src/test/java/io/quarkus/qe/database/oracle/DevModeOracleDevServiceDatabaseIT.java
+++ b/examples/database-oracle/src/test/java/io/quarkus/qe/database/oracle/DevModeOracleDevServiceDatabaseIT.java
@@ -4,13 +4,11 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 import io.quarkus.test.services.DevModeQuarkusApplication;
 
 /**
  * Running Quarkus on DEV mode will spin up a Database instance automatically.
  */
-@DisabledOnNative // Don't run DEV mode tests in native: https://github.com/quarkus-qe/quarkus-test-framework/issues/720
 @QuarkusScenario
 public class DevModeOracleDevServiceDatabaseIT extends AbstractSqlDatabaseIT {
 

--- a/examples/external-applications/src/test/java/io/quarkus/qe/DevModeQuickstartUsingDefaultsIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/DevModeQuickstartUsingDefaultsIT.java
@@ -7,11 +7,9 @@ import org.junit.jupiter.api.condition.OS;
 
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 
 @QuarkusScenario
-@DisabledOnNative
 @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Windows does not support long file paths")
 public class DevModeQuickstartUsingDefaultsIT {
 

--- a/examples/greetings/src/test/java/io/quarkus/qe/DevModeGreetingResourceIT.java
+++ b/examples/greetings/src/test/java/io/quarkus/qe/DevModeGreetingResourceIT.java
@@ -10,13 +10,11 @@ import org.junit.jupiter.api.TestMethodOrder;
 
 import io.quarkus.test.bootstrap.DevModeQuarkusService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
 import io.quarkus.test.services.DevModeQuarkusApplication;
 import io.quarkus.test.utils.AwaitilityUtils;
 
 @QuarkusScenario
-@DisabledOnNative
 @DisabledOnQuarkusVersion(version = "3.0.0.CR2", reason = "Continuous Testing page was added to DEV UI in Quarkus 3.0.0.Final")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class DevModeGreetingResourceIT {

--- a/examples/greetings/src/test/java/io/quarkus/qe/KubernetesRemoteDevGreetingResourceIT.java
+++ b/examples/greetings/src/test/java/io/quarkus/qe/KubernetesRemoteDevGreetingResourceIT.java
@@ -1,9 +1,0 @@
-package io.quarkus.qe;
-
-import io.quarkus.test.scenarios.KubernetesScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnNative;
-
-@KubernetesScenario
-@DisabledOnNative
-public class KubernetesRemoteDevGreetingResourceIT extends RemoteDevGreetingResourceIT {
-}

--- a/examples/greetings/src/test/java/io/quarkus/qe/KubernetesRemoteDevModeGreetingResourceIT.java
+++ b/examples/greetings/src/test/java/io/quarkus/qe/KubernetesRemoteDevModeGreetingResourceIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.qe;
+
+import io.quarkus.test.scenarios.KubernetesScenario;
+
+@KubernetesScenario
+public class KubernetesRemoteDevModeGreetingResourceIT extends RemoteDevModeGreetingResourceIT {
+}

--- a/examples/greetings/src/test/java/io/quarkus/qe/OpenShiftRemoteDevGreetingResourceIT.java
+++ b/examples/greetings/src/test/java/io/quarkus/qe/OpenShiftRemoteDevGreetingResourceIT.java
@@ -1,9 +1,0 @@
-package io.quarkus.qe;
-
-import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnNative;
-
-@OpenShiftScenario
-@DisabledOnNative
-public class OpenShiftRemoteDevGreetingResourceIT extends RemoteDevGreetingResourceIT {
-}

--- a/examples/greetings/src/test/java/io/quarkus/qe/OpenShiftRemoteDevModeGreetingResourceIT.java
+++ b/examples/greetings/src/test/java/io/quarkus/qe/OpenShiftRemoteDevModeGreetingResourceIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.qe;
+
+import io.quarkus.test.scenarios.OpenShiftScenario;
+
+@OpenShiftScenario
+public class OpenShiftRemoteDevModeGreetingResourceIT extends RemoteDevModeGreetingResourceIT {
+}

--- a/examples/greetings/src/test/java/io/quarkus/qe/RemoteDevModeGreetingResourceIT.java
+++ b/examples/greetings/src/test/java/io/quarkus/qe/RemoteDevModeGreetingResourceIT.java
@@ -7,13 +7,11 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.DevModeQuarkusService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 import io.quarkus.test.services.RemoteDevModeQuarkusApplication;
 import io.quarkus.test.utils.AwaitilityUtils;
 
 @QuarkusScenario
-@DisabledOnNative
-public class RemoteDevGreetingResourceIT {
+public class RemoteDevModeGreetingResourceIT {
 
     static final String VICTOR_NAME = "victor";
 

--- a/examples/grpc/src/test/java/io/quarkus/qe/grpc/DevModeGrpcServiceIT.java
+++ b/examples/grpc/src/test/java/io/quarkus/qe/grpc/DevModeGrpcServiceIT.java
@@ -6,11 +6,9 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.GrpcService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 import io.quarkus.test.services.DevModeQuarkusApplication;
 
 @QuarkusScenario
-@DisabledOnNative
 public class DevModeGrpcServiceIT {
 
     static final String NAME = "Victor";

--- a/examples/https/src/test/java/io/quarkus/qe/DevModeGreetingResourceIT.java
+++ b/examples/https/src/test/java/io/quarkus/qe/DevModeGreetingResourceIT.java
@@ -5,11 +5,9 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.DevModeQuarkusService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 import io.quarkus.test.services.DevModeQuarkusApplication;
 
 @QuarkusScenario
-@DisabledOnNative
 public class DevModeGreetingResourceIT {
     @DevModeQuarkusApplication(ssl = true)
     static DevModeQuarkusService app = new DevModeQuarkusService();

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
         <include.tests>**/*IT.java</include.tests>
         <exclude.openshift.tests>**/OpenShift*IT.java</exclude.openshift.tests>
         <exclude.kubernetes.tests>**/Kubernetes*IT.java</exclude.kubernetes.tests>
+        <exclude.quarkus.devmode.tests>no</exclude.quarkus.devmode.tests>
         <!-- Format Settings -->
         <src.format.goal>format</src.format.goal>
         <src.sort.goal>sort</src.sort.goal>
@@ -348,6 +349,7 @@
                             <excludes>
                                 <exclude>${exclude.openshift.tests}</exclude>
                                 <exclude>${exclude.kubernetes.tests}</exclude>
+                                <exclude>${exclude.quarkus.devmode.tests}</exclude>
                             </excludes>
                         </configuration>
                     </execution>
@@ -432,6 +434,7 @@
                 <quarkus.package.type>native</quarkus.package.type>
                 <quarkus.native.container-build>true</quarkus.native.container-build>
                 <quarkus.native.native-image-xmx>5g</quarkus.native.native-image-xmx>
+                <exclude.quarkus.devmode.tests>**/*DevMode*IT.java</exclude.quarkus.devmode.tests>
             </properties>
         </profile>
         <profile>


### PR DESCRIPTION
### Summary

Hi, this PR should resolve #720 . Removing the `DisabledOnNative` annotation in DevMode tests as now are these tests excluded by native profile. Also change the names of `*RemoteDevGreetingResourceIT` to`*RemoteDevModeGreetingResourceIT` to catch these remote DevMode tests by regex used to exclude DevMode tests in native profile. This also align the naming.

You can run `mvn -B -fae -s .github/mvn-settings.xml clean install -Pframework,examples,native -Dquarkus.platform.version=3.2.0.Final` and see that there are no DevMode tests started.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)