### PR TITLE
Fix properties not escape " on windows

### DIFF
--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/LocalhostQuarkusApplicationManagedResource.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/LocalhostQuarkusApplicationManagedResource.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.condition.OS;
 
 import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.logging.FileServiceLoggingHandler;
@@ -178,7 +179,8 @@ public abstract class LocalhostQuarkusApplicationManagedResource extends Quarkus
         }
 
         return runtimeProperties.entrySet().stream()
-                .map(e -> "-D" + e.getKey() + "=" + getComputedValue(e.getValue()))
+                .map(e -> "-D" + (OS.WINDOWS.isCurrentOs() ? e.getKey().replace("\"", "\\\"") : e.getKey())
+                        + "=" + getComputedValue(e.getValue()))
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
### Summary

Hi, this PR resolve #584 which not escaped char `"`caused fail some tests on windows machine.

Testing it on windows with  tests from Quarkus TS (with [LargeFileHandlingIT](https://github.com/quarkus-qe/quarkus-test-suite/blob/34d7d8b286a706239da1e305b8bf21c6072e9a3e/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/LargeFileHandlingIT.java) and [ReactiveRestClientIT](https://github.com/jedla97/quarkus-test-suite/blob/main/http/rest-client-reactive/src/test/java/io/quarkus/ts/http/restclient/reactive/ReactiveRestClientIT.java) tests). After this change tests are passing without problem on Windows and Linux. 


Before:
```
[INFO] Running io.quarkus.ts.http.restclient.reactive.LargeFileHandlingIT
08:56:18,857 INFO  [app] Initialize service (Quarkus JVM mode)
08:56:18,889 INFO  Running command: java -Dquarkus.vertx.warning-exception-time=5s -Dquarkus.rest-client."io.quarkus.ts.http.restclient.reactive.ResourceAndSubResourcesClient".url=http://localhost:${quarkus.http.port} -Dquarkus.rest-client.logging.scope=request-response -Dclient.filepath=C:\Users\RUNNER~1\AppData\Local\Temp\large_files11198165765889963790 -Dquarkus.rest-client.read-timeout=120000 -Dquarkus.rest-client."io.quarkus.ts.http.restclient.reactive.files.FileClient".url=http://localhost:${quarkus.http.port} -Dquarkus.http.limits.max-body-size=3G -Dquarkus.log.category."org.jboss.resteasy.reactive.client.logging".level=DEBUG -Dquarkus.rest-client."io.quarkus.ts.http.restclient.reactive.BookClient".url=http://localhost:${quarkus.http.port} -Dquarkus.rest-client."io.quarkus.ts.http.restclient.reactive.BookClient.AuthorClient".url=http://localhost:${quarkus.http.port} -Dquarkus.rest-client."io.quarkus.ts.http.restclient.reactive.json.JsonRestInterface".url=http://localhost:${quarkus.http.port} -Dquarkus.log.console.format=%d{HH:mm:ss,SSS} %s%e%n -Dquarkus.http.port=1101 -jar D:\a\quarkus-test-suite\quarkus-test-suite\http\rest-client-reactive\target\quarkus-app\quarkus-run.jar

...
08:56:34,974 INFO  [app] 08:56:33,895 HTTP Request to /file-client/hash failed, error id: 12b0bc13-414c-40a9-9fdf-cb722a2d0aff-1: java.lang.IllegalArgumentException: Unable to determine the proper baseUrl/baseUri. Consider registering using @RegisterRestClient(baseUri="someuri"), @RegisterRestClient(configKey="orkey"), or by adding 'quarkus.rest-client."io.quarkus.ts.http.restclient.reactive.files.FileClient".url' or 'quarkus.rest-client."io.quarkus.ts.http.restclient.reactive.files.FileClient".uri' to your Quarkus configuration
...

Error:  Tests run: 9, Failures: 6, Errors: 0, Skipped: 1, Time elapsed: 218.824 s <<< FAILURE! - in io.quarkus.ts.http.restclient.reactive.LargeFileHandlingIT
```

After fix:
```
[INFO] Running io.quarkus.ts.http.restclient.reactive.LargeFileHandlingIT
08:34:22,741 INFO  [app] Initialize service (Quarkus JVM mode)
08:34:22,772 INFO  Running command: java -Dquarkus.vertx.warning-exception-time=5s -Dquarkus.rest-client.\"io.quarkus.ts.http.restclient.reactive.ResourceAndSubResourcesClient\".url=http://localhost:${quarkus.http.port} -Dquarkus.rest-client.logging.scope=request-response -Dclient.filepath=C:\Users\RUNNER~1\AppData\Local\Temp\large_files5316569886669347137 -Dquarkus.rest-client.read-timeout=120000 -Dquarkus.rest-client.\"io.quarkus.ts.http.restclient.reactive.files.FileClient\".url=http://localhost:${quarkus.http.port} -Dquarkus.http.limits.max-body-size=3G -Dquarkus.log.category.\"org.jboss.resteasy.reactive.client.logging\".level=DEBUG -Dquarkus.rest-client.\"io.quarkus.ts.http.restclient.reactive.BookClient\".url=http://localhost:${quarkus.http.port} -Dquarkus.rest-client.\"io.quarkus.ts.http.restclient.reactive.BookClient.AuthorClient\".url=http://localhost:${quarkus.http.port} -Dquarkus.rest-client.\"io.quarkus.ts.http.restclient.reactive.json.JsonRestInterface\".url=http://localhost:${quarkus.http.port} -Dquarkus.log.console.format=%d{HH:mm:ss,SSS} %s%e%n -Dquarkus.http.port=1101 -jar D:\a\quarkus-test-suite\quarkus-test-suite\http\rest-client-reactive\target\quarkus-app\quarkus-run.jar

...
Warning:  Tests run: 9, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 425.528 s - in io.quarkus.ts.http.restclient.reactive.LargeFileHandlingIT
```

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)