### PR TITLE
Fix CI by using single Oracle image as image pull timeouts and other Oracle test fails over insufficient free space

### DIFF
--- a/examples/database-oracle/src/test/java/io/quarkus/qe/database/oracle/DevModeOracleDatabaseIT.java
+++ b/examples/database-oracle/src/test/java/io/quarkus/qe/database/oracle/DevModeOracleDatabaseIT.java
@@ -17,7 +17,7 @@ public class DevModeOracleDatabaseIT extends AbstractSqlDatabaseIT {
     static final String ORACLE_DATABASE = "mydb";
     static final int ORACLE_PORT = 1521;
 
-    @Container(image = "docker.io/gvenzl/oracle-xe:21-slim-faststart", port = ORACLE_PORT, expectedLog = "DATABASE IS READY TO USE!")
+    @Container(image = "${oracle.image}", port = ORACLE_PORT, expectedLog = "DATABASE IS READY TO USE!")
     static DefaultService database = new DefaultService()
             .withProperty("APP_USER", ORACLE_USER)
             .withProperty("APP_USER_PASSWORD", ORACLE_PASSWORD)

--- a/examples/database-oracle/src/test/java/io/quarkus/qe/database/oracle/OracleDatabaseIT.java
+++ b/examples/database-oracle/src/test/java/io/quarkus/qe/database/oracle/OracleDatabaseIT.java
@@ -11,7 +11,7 @@ import io.quarkus.test.services.QuarkusApplication;
 @QuarkusScenario
 public class OracleDatabaseIT extends AbstractSqlDatabaseIT {
 
-    @Container(image = "docker.io/gvenzl/oracle-xe:21-slim-faststart", port = ORACLE_PORT, expectedLog = "DATABASE IS READY TO USE!")
+    @Container(image = "${oracle.image}", port = ORACLE_PORT, expectedLog = "DATABASE IS READY TO USE!")
     static OracleService database = new OracleService();
 
     @QuarkusApplication

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,8 @@
         <playwright.version>1.36.0</playwright.version>
         <!-- Faster build when using -DskipTests -->
         <quarkus.build.skip>${skipTests}</quarkus.build.skip>
+        <!-- Oracle image - we aim to use same version as Dev Services for Oracle so that we only download one image -->
+        <oracle.image>docker.io/gvenzl/oracle-free:23-slim-faststart</oracle.image>
     </properties>
     <distributionManagement>
         <snapshotRepository>
@@ -341,6 +343,9 @@
                             <goal>verify</goal>
                         </goals>
                         <configuration>
+                            <systemProperties>
+                                <oracle.image>${oracle.image}</oracle.image>
+                            </systemProperties>
                             <argLine>${jacoco.agent.argLine}</argLine>
                             <excludedGroups>${exclude.tests.with.tags}</excludedGroups>
                             <includes>


### PR DESCRIPTION
### Summary

We should use same Oracle image as is default image for Dev Services for Database (Oracle) https://github.com/quarkusio/quarkus/pull/32489/files. You can see that daily build fails over Oracle example for 6 days in row. In fact, right after Quarkus bump to 3.2.1.Final https://github.com/quarkus-qe/quarkus-test-framework/pull/839 where we saw this failure for the first time. I hope that is just a strange coincidence though, for Oracle Docker image didn't change between Quarkus versions and Docker image itself is same 2 months for now https://hub.docker.com/r/gvenzl/oracle-free/tags?page=1&name=23-slim-faststart https://github.com/gvenzl/oci-oracle-free/blob/main/Dockerfile.faststart.

However:

- it only fails on `999-SNAPSHOT`, so I can't see relation to bump
- I can't see related changes in upstream, I checked dev svcs changes, jdbc changes, hibernate-orm changes, there is nothing that I can link to this fialure.

Failure:
- there is a warning over free space and we know that docker images takes a lot of space ```2023-07-27T00:08:52.0038349Z 00:08:51,965 INFO  Running command: mvn -e -Dquarkus.profile=DevModeOracleDevServiceDatabaseIT -Dquarkus.platform.version=999-SNAPSHOT -Drun-cli-tests=true -Dts.container.registry-url=*** -Dvalidate-format=true -Dts.quarkus.cli.cmd=/home/runner/work/quarkus-test-framework/quarkus-test-framework/quarkus-dev-cli -DlocalRepository=/home/runner/.m2/repository -Dnative.encoding=UTF-8 -Dcheckstyle.skip -DskipITs=true -Dquarkus.log.console.format=%d{HH:mm:ss,SSS} %s%e%n -Dquarkus.analytics.disabled=true -Dquarkus.http.port=1102 -Ddebug=false quarkus:dev
2023-07-27T00:10:28.4940362Z ##[warning]You are running out of disk space. The runner will stop working when the machine runs out of disk space. Free space left: 75 MB```
- free space I think later affects `OracleDatabaseIT` that I can't reproduce ```2023-07-27T00:18:53.7749938Z ERROR at line 1:
2023-07-27T00:18:53.7750412Z ORA-65169: error encountered while attempting to copy file
2023-07-27T00:18:53.7750759Z /opt/oracle/oradata/XE/pdbseed/system01.dbf
2023-07-27T00:18:53.7751214Z ORA-19502: write error on file "/opt/oracle/oradata/XE/mydb/system01.dbf",
2023-07-27T00:18:53.7751554Z block number 28416 (block size=8192)
2023-07-27T00:18:53.7751846Z ORA-27072: File I/O error
2023-07-27T00:18:53.7752105Z Additional information: 4
2023-07-27T00:18:53.7752380Z Additional information: 28416
2023-07-27T00:18:53.7752657Z Additional information: 331776```
- I can reproduce `DevModeOracleDevServiceDatabaseIT` which for me timeouts because Docker pull is too slow on my network connection (even with `3.2.0`). I think same happens in CI `Condition with io.quarkus.test.bootstrap.BaseService was not fulfilled within 5 minutes.`

For I can't find why it started now, I suggest we treat symptoms: we don't really need to use different Oracle image than Dev Svc does considering this is FW (not TS) and there is no such requirement. When we use same image, we don't download 2 (space) and won't timeout as `DevModeOracleDevServiceDatabaseIT` runs after test that already downloads it via `@Container` annotation, which is not included in timeout for starting Quarkus app (it has it's own timeout of course).

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)