### PR TITLE
Enable quarkus-helm module execution on Quarkus snapshot in CI pipelines

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -145,9 +145,8 @@ jobs:
           chmod +x ./quarkus-dev-cli
           ./quarkus-dev-cli version
       - name: Build
-        # TODO: Remove quarkus-helm module exclusion when Quarkus helm extension bumps to 1.0.9
         run: |
-          mvn -B -fae -s .github/mvn-settings.xml clean install -Pframework,examples,extensions,coverage -Dvalidate-format -Drun-cli-tests -Dts.container.registry-url=${{ secrets.CI_REGISTRY }} -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli" -Dquarkus.platform.version="${{ matrix.quarkus-version }}" -pl '!examples/quarkus-helm'
+          mvn -B -fae -s .github/mvn-settings.xml clean install -Pframework,examples,extensions,coverage -Dvalidate-format -Drun-cli-tests -Dts.container.registry-url=${{ secrets.CI_REGISTRY }} -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli" -Dquarkus.platform.version="${{ matrix.quarkus-version }}"
       - name: Generate Jacoco Report
         run: |
           cd coverage-report
@@ -292,9 +291,8 @@ jobs:
         run: tar -xzf maven-repo.tgz -C ~
       - name: Build in JVM mode
         shell: bash
-        # TODO: Remove quarkus-helm module exclusion when Quarkus helm extension bumps to 1.0.9
         run: |
-          mvn -B -fae -s .github/mvn-settings.xml clean install -Pframework,examples -Dquarkus.platform.version="${{ matrix.quarkus-version }}" -pl '!examples/quarkus-helm'
+          mvn -B -fae -s .github/mvn-settings.xml clean install -Pframework,examples -Dquarkus.platform.version="${{ matrix.quarkus-version }}"
       - name: Zip Artifacts
         shell: bash
         if: failure()

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -146,9 +146,8 @@ jobs:
           chmod +x ./quarkus-dev-cli
           ./quarkus-dev-cli version
       - name: Build in JVM mode
-        # TODO: Remove quarkus-helm module exclusion when Quarkus helm extension bumps to 1.0.9
         run: |
-          mvn -B -fae -s .github/mvn-settings.xml clean install -Pframework,examples,extensions -Drun-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli" -Dquarkus.platform.version="${{ matrix.quarkus-version }}" -pl '!examples/quarkus-helm'
+          mvn -B -fae -s .github/mvn-settings.xml clean install -Pframework,examples,extensions -Drun-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli" -Dquarkus.platform.version="${{ matrix.quarkus-version }}"
       - name: Zip Artifacts
         run: |
           zip -R artifacts-latest-linux-jvm${{ matrix.java }}.zip '*-reports/*'
@@ -195,9 +194,8 @@ jobs:
         run: tar -xzf maven-repo.tgz -C ~
       - name: Build in JVM mode
         shell: bash
-        # TODO: Remove quarkus-helm module exclusion when Quarkus helm extension bumps to 1.0.9
         run: |
-          mvn -B -fae -s .github/mvn-settings.xml clean install -Pframework,examples -Dquarkus.platform.version="${{ matrix.quarkus-version }}" -pl '!examples/quarkus-helm'
+          mvn -B -fae -s .github/mvn-settings.xml clean install -Pframework,examples -Dquarkus.platform.version="${{ matrix.quarkus-version }}"
       - name: Zip Artifacts
         shell: bash
         if: failure()


### PR DESCRIPTION
### Summary

Helm was bumped to 1.0.9 so we can re-enable Helm tests execution in CI

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)