### PR TITLE
Fix Quarkus Platform group id used for external applications as default Quickstarts group id changed

### DIFF
--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/GitRepositoryLocalhostQuarkusApplicationManagedResource.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/GitRepositoryLocalhostQuarkusApplicationManagedResource.java
@@ -2,6 +2,8 @@ package io.quarkus.test.services.quarkus;
 
 import static io.quarkus.test.services.quarkus.GitRepositoryResourceBuilderUtils.cloneRepository;
 import static io.quarkus.test.services.quarkus.GitRepositoryResourceBuilderUtils.mavenBuild;
+import static io.quarkus.test.services.quarkus.model.QuarkusProperties.PLATFORM_GROUP_ID;
+import static io.quarkus.test.utils.MavenUtils.withProperty;
 
 import java.nio.file.Path;
 import java.util.List;
@@ -43,13 +45,20 @@ public class GitRepositoryLocalhostQuarkusApplicationManagedResource
 
     @Override
     protected List<String> prepareCommand(List<String> systemProperties) {
-        // Dev mode
+        final List<String> commands;
+
         if (model.isDevMode()) {
-            return MavenUtils.devModeMavenCommand(model.getContext(), systemProperties);
+            // Dev mode
+            commands = MavenUtils.devModeMavenCommand(model.getContext(), systemProperties);
+        } else {
+            // JVM or Native
+            commands = super.prepareCommand(systemProperties);
         }
 
-        // JVM or Native
-        return super.prepareCommand(systemProperties);
+        // set quarkus.platform.group-id
+        commands.add(withProperty(PLATFORM_GROUP_ID.getPropertyKey(), PLATFORM_GROUP_ID.get()));
+
+        return List.copyOf(commands);
     }
 
     @Override


### PR DESCRIPTION
### Summary

Quarkus Quickstarts platform group id has changed https://github.com/quarkusio/quarkus-quickstarts/commit/cef1faf1eab248c85a34462c9c68bfd9c3dd910a. We do set explicitly group id for build https://github.com/quarkus-qe/quarkus-test-framework/blob/main/quarkus-test-core/src/main/java/io/quarkus/test/services/GitRepositoryQuarkusApplication.java#L20, but not for dev mode (or JVM and native) https://github.com/quarkus-qe/quarkus-test-framework/blob/main/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/GitRepositoryLocalhostQuarkusApplicationManagedResource.java#L45 https://github.com/quarkus-qe/quarkus-test-framework/blob/main/quarkus-test-core/src/main/java/io/quarkus/test/utils/MavenUtils.java#L70. That seems like a bug to me and now, we always set group id explicitly.

Daily build fails because of this.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)