### PR TITLE
Update kafka version in template for strimzi operator.

### DIFF
--- a/quarkus-test-service-kafka/src/main/resources/strimzi-operator-kafka-instance.yaml
+++ b/quarkus-test-service-kafka/src/main/resources/strimzi-operator-kafka-instance.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kafka-instance
 spec:
   kafka:
-    version: 3.3.1
+    version: 3.4.0
     replicas: 1
     listeners:
       - name: plain


### PR DESCRIPTION
### Summary

Hi, this PR fixing `OpenShiftStrimziOperatorKafkaWithoutRegistryMessagingIT` which was failing because the 3.3.1 was not supported version. See this log:
```
Unsupported Kafka.spec.kafka.version: 3.3.1. Supported versions are: [3.4.0, 3.4.1, 3.5.0, 3.5.1]
```

So it's never started and timed out.

Maybe the update of version [here](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/model/KafkaVendor.java#L5) should be done as well but tests are not failing so there is probably no need for that.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)