### PR TITLE
Disable QuarkusScenario tests automatically when Linux containers are not available but the test requires them

### DIFF
--- a/examples/amq-amqp/pom.xml
+++ b/examples/amq-amqp/pom.xml
@@ -34,31 +34,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/examples/amq-tcp/pom.xml
+++ b/examples/amq-tcp/pom.xml
@@ -35,31 +35,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/examples/blocking-reactive-model/pom.xml
+++ b/examples/blocking-reactive-model/pom.xml
@@ -60,33 +60,5 @@
                 </dependency>
             </dependencies>
         </profile>
-        <!-- Skipped on Windows in a native mode due to https://github.com/quarkusio/quarkus/issues/27061 -->
-        <profile>
-            <id>skip-tests-on-windows-in-native</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-                <property>
-                    <name>native</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
     </profiles>
 </project>

--- a/examples/consul/pom.xml
+++ b/examples/consul/pom.xml
@@ -66,30 +66,5 @@
                 </dependency>
             </dependencies>
         </profile>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
     </profiles>
 </project>

--- a/examples/database-mysql/pom.xml
+++ b/examples/database-mysql/pom.xml
@@ -63,31 +63,4 @@
             </plugin>
         </plugins>
     </build>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/examples/database-oracle/pom.xml
+++ b/examples/database-oracle/pom.xml
@@ -59,31 +59,4 @@
             </plugin>
         </plugins>
     </build>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/examples/database-postgresql/pom.xml
+++ b/examples/database-postgresql/pom.xml
@@ -63,31 +63,4 @@
             </plugin>
         </plugins>
     </build>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/examples/infinispan/pom.xml
+++ b/examples/infinispan/pom.xml
@@ -65,30 +65,5 @@
                 </dependency>
             </dependencies>
         </profile>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
     </profiles>
 </project>

--- a/examples/jaeger/pom.xml
+++ b/examples/jaeger/pom.xml
@@ -45,31 +45,4 @@
             </plugin>
         </plugins>
     </build>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/examples/kafka-registry/pom.xml
+++ b/examples/kafka-registry/pom.xml
@@ -90,31 +90,4 @@
             </snapshots>
         </repository>
     </repositories>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/examples/kafka-streams/pom.xml
+++ b/examples/kafka-streams/pom.xml
@@ -64,30 +64,5 @@
                 </dependency>
             </dependencies>
         </profile>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
     </profiles>
 </project>

--- a/examples/kafka/pom.xml
+++ b/examples/kafka/pom.xml
@@ -68,31 +68,4 @@
             </plugin>
         </plugins>
     </build>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/examples/keycloak/pom.xml
+++ b/examples/keycloak/pom.xml
@@ -65,30 +65,5 @@
                 </dependency>
             </dependencies>
         </profile>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
     </profiles>
 </project>

--- a/extensions/metrics/pom.xml
+++ b/extensions/metrics/pom.xml
@@ -30,31 +30,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/extensions/tracing/pom.xml
+++ b/extensions/tracing/pom.xml
@@ -35,31 +35,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <profiles>
-        <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
-        <profile>
-            <id>skip-tests-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/quarkus-test-cli/src/main/java/io/quarkus/test/execution/condition/CliQuarkusScenarioContainerExecutionCondition.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/execution/condition/CliQuarkusScenarioContainerExecutionCondition.java
@@ -1,0 +1,22 @@
+package io.quarkus.test.execution.condition;
+
+import io.quarkus.test.scenarios.execution.condition.AbstractQuarkusScenarioContainerExecutionCondition;
+
+/**
+ * Disables Quarkus CLI tests when Linux containers are not available as for now, we are not able to recognize
+ * whether unit test invokes DEV mode or not.
+ */
+public class CliQuarkusScenarioContainerExecutionCondition
+        extends AbstractQuarkusScenarioContainerExecutionCondition {
+
+    private static final String QUARKUS_CLI_TEST_CLASS_PREFIX = "QuarkusCli";
+
+    @Override
+    protected boolean areContainersRequired(Class<?> testClass) {
+        // TODO: we can run cli tests that are not DEV mode tests on Windows, but first we need to revise
+        //   io.quarkus.test.bootstrap.QuarkusCliClient.createApplication that launches app in a DEV mode
+        //   and then find a mechanism that detects whether app is run in a DEV mode (like Assumption or tag)
+        return testClass.getSimpleName().startsWith(QUARKUS_CLI_TEST_CLASS_PREFIX);
+    }
+
+}

--- a/quarkus-test-cli/src/main/resources/META-INF/services/io.quarkus.test.scenarios.execution.condition.QuarkusScenarioExecutionCondition
+++ b/quarkus-test-cli/src/main/resources/META-INF/services/io.quarkus.test.scenarios.execution.condition.QuarkusScenarioExecutionCondition
@@ -1,0 +1,1 @@
+io.quarkus.test.execution.condition.CliQuarkusScenarioContainerExecutionCondition

--- a/quarkus-test-cli/src/test/java/io/quarkus/test/QuarkusCliClientIT.java
+++ b/quarkus-test-cli/src/test/java/io/quarkus/test/QuarkusCliClientIT.java
@@ -16,8 +16,6 @@ import jakarta.inject.Inject;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 
 import io.quarkus.test.bootstrap.QuarkusCliClient;
 import io.quarkus.test.bootstrap.QuarkusCliRestService;
@@ -67,7 +65,6 @@ public class QuarkusCliClientIT {
 
     @Test
     @EnabledOnNative
-    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Windows does not support Linux containers yet")
     public void shouldBuildApplicationOnNativeUsingDocker() {
         // Create application
         QuarkusCliRestService app = cliClient.createApplication("app", defaults().withStream(STREAM_VERSION));

--- a/quarkus-test-containers/src/main/java/io/quarkus/test/services/containers/ContainerAnnotationBinding.java
+++ b/quarkus-test-containers/src/main/java/io/quarkus/test/services/containers/ContainerAnnotationBinding.java
@@ -22,4 +22,9 @@ public class ContainerAnnotationBinding implements AnnotationBinding {
         return builder;
     }
 
+    @Override
+    public boolean requiresLinuxContainersOnBareMetal() {
+        return true;
+    }
+
 }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/AnnotationBinding.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/AnnotationBinding.java
@@ -6,4 +6,11 @@ public interface AnnotationBinding {
     boolean isFor(Field field);
 
     ManagedResourceBuilder createBuilder(Field field) throws Exception;
+
+    /**
+     * Whether associated managed resource requires Linux containers when run on bare metal instances.
+     *
+     * @return true if there is possibility Linux containers are going to be started
+     */
+    boolean requiresLinuxContainersOnBareMetal();
 }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/QuarkusScenario.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/QuarkusScenario.java
@@ -9,10 +9,12 @@ import java.lang.annotation.Target;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import io.quarkus.test.bootstrap.QuarkusScenarioBootstrap;
+import io.quarkus.test.scenarios.execution.condition.QuarkusScenarioExecutionConditions;
 
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @ExtendWith(QuarkusScenarioBootstrap.class)
+@ExtendWith(QuarkusScenarioExecutionConditions.class)
 @Inherited
 public @interface QuarkusScenario {
 }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/execution/condition/AbstractQuarkusScenarioContainerExecutionCondition.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/execution/condition/AbstractQuarkusScenarioContainerExecutionCondition.java
@@ -1,0 +1,121 @@
+package io.quarkus.test.scenarios.execution.condition;
+
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
+import static java.lang.String.format;
+import static java.lang.String.join;
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.disabled;
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled;
+
+import java.lang.reflect.AnnotatedElement;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.jboss.logging.Logger;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.utils.Command;
+
+public abstract class AbstractQuarkusScenarioContainerExecutionCondition implements QuarkusScenarioExecutionCondition {
+
+    private static final Logger LOG = Logger.getLogger(AbstractQuarkusScenarioContainerExecutionCondition.class.getName());
+    private static final ConditionEvaluationResult CONDITION_NOT_MATCHED = enabled("This condition should "
+            + "only be applied on test classes annotated with the '@QuarkusScenario' annotation");
+    private static final ConditionEvaluationResult ENV_SUPPORTS_LINUX_CONTAINERS = enabled("Environment supports"
+            + " Linux containers");
+    private static final String ENV_DOES_NOT_SUPPORT_LINUX_CONTAINERS = "Test class '%s' requires Linux containers, "
+            + "but the environment does not support them";
+    private static final String LINUX_CONTAINERS_NOT_REQUIRED = "Test class '%s' does not require containers";
+    private static final String LINUX_CONTAINER_OS_TYPE = "linux";
+    private static final String PODMAN = "podman";
+    private static final String DOCKER_HOST = "DOCKER_HOST";
+    private static Boolean areLinuxContainersSupported = null;
+
+    @Override
+    public final ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+        if (TRUE.equals(areLinuxContainersSupported)) {
+            // optimization - don't evaluate condition if we know Linux containers are available
+            return ENV_SUPPORTS_LINUX_CONTAINERS;
+        }
+
+        return context
+                .getElement()
+                .filter(AbstractQuarkusScenarioContainerExecutionCondition::isQuarkusScenario)
+                .map(clazz -> (Class<?>) clazz)
+                .map(this::evaluateExecutionCondition)
+                .orElse(CONDITION_NOT_MATCHED);
+    }
+
+    private ConditionEvaluationResult evaluateExecutionCondition(Class<?> testClass) {
+        if (areContainersRequired(testClass)) {
+            if (areLinuxContainersSupported()) {
+                return ENV_SUPPORTS_LINUX_CONTAINERS;
+            }
+            return disabled(format(ENV_DOES_NOT_SUPPORT_LINUX_CONTAINERS, testClass));
+        }
+        return enabled(format(LINUX_CONTAINERS_NOT_REQUIRED, testClass));
+    }
+
+    protected abstract boolean areContainersRequired(Class<?> testClass);
+
+    private static synchronized boolean areLinuxContainersSupported() {
+        if (areLinuxContainersSupported == null) {
+            areLinuxContainersSupported = checkLinuxContainersSupported();
+        }
+        return areLinuxContainersSupported;
+    }
+
+    private static boolean checkLinuxContainersSupported() {
+        return isPodman() || dockerIsUsingLinuxContainers();
+    }
+
+    private static boolean dockerIsUsingLinuxContainers() {
+        final var osType = runDockerOsTypeInfoCommand();
+        return osType
+                .stream()
+                .filter(str -> str.contains(LINUX_CONTAINER_OS_TYPE))
+                .findAny()
+                .map(str -> TRUE)
+                .orElseGet(() -> {
+                    LOG.debugf("Linux containers are required, but container type is: '%s'", join(" ", osType));
+                    return FALSE;
+                });
+    }
+
+    private static boolean isPodman() {
+        final String dockerHostEnvVar = System.getenv(DOCKER_HOST);
+        if (dockerHostEnvVar != null && dockerHostEnvVar.contains(PODMAN)) {
+            return true;
+        }
+
+        try {
+            var output = new ArrayList<String>();
+            new Command("docker", "--version").outputToLines(output).runAndWait();
+            return output.stream().anyMatch(line -> line.contains(PODMAN));
+        } catch (Exception e) {
+            LOG.error("Failed to check whether Podman is used: ", e);
+            return false;
+        }
+    }
+
+    private static boolean isQuarkusScenario(AnnotatedElement annotatedElement) {
+        return annotatedElement.isAnnotationPresent(QuarkusScenario.class);
+    }
+
+    private static Collection<String> runDockerOsTypeInfoCommand() {
+        try {
+            var output = new ArrayList<String>();
+            new Command("docker", "info", "--format", "'{{.OSType}}'")
+                    .outputToLines(output)
+                    .runAndWait();
+            return output;
+        } catch (Exception e) {
+            LOG.error("Failed to check whether Linux containers are supported: ", e);
+            return List.of();
+        }
+    }
+
+}

--- a/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/execution/condition/AnnotationBindingQuarkusScenarioContainerExecutionCondition.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/execution/condition/AnnotationBindingQuarkusScenarioContainerExecutionCondition.java
@@ -1,0 +1,31 @@
+package io.quarkus.test.scenarios.execution.condition;
+
+import java.util.Arrays;
+import java.util.ServiceLoader;
+
+import io.quarkus.test.bootstrap.AnnotationBinding;
+
+/**
+ * Recognizes whether {@link AnnotationBinding} is associated to the resource that requires Linux containers and
+ * disables tests when not available.
+ */
+public class AnnotationBindingQuarkusScenarioContainerExecutionCondition
+        extends AbstractQuarkusScenarioContainerExecutionCondition {
+
+    private final ServiceLoader<AnnotationBinding> bindingsRegistry = ServiceLoader.load(AnnotationBinding.class);
+
+    @Override
+    protected boolean areContainersRequired(Class<?> testClass) {
+        return bindingsRegistry
+                .stream()
+                .map(ServiceLoader.Provider::get)
+                .filter(AnnotationBinding::requiresLinuxContainersOnBareMetal)
+                .anyMatch(binding -> testClassHasFieldsAnnotatedWith(testClass, binding));
+    }
+
+    private static boolean testClassHasFieldsAnnotatedWith(Class<?> testClass, AnnotationBinding binding) {
+        return testClass != null
+                && (Arrays.stream(testClass.getDeclaredFields()).anyMatch(binding::isFor)
+                        || testClassHasFieldsAnnotatedWith(testClass.getSuperclass(), binding));
+    }
+}

--- a/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/execution/condition/QuarkusScenarioExecutionCondition.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/execution/condition/QuarkusScenarioExecutionCondition.java
@@ -1,0 +1,11 @@
+package io.quarkus.test.scenarios.execution.condition;
+
+import org.junit.jupiter.api.extension.ExecutionCondition;
+
+/**
+ * Services that provides required {@link ExecutionCondition} applied on every test class
+ * annotated with the QuarkusScenario annotation.
+ */
+public interface QuarkusScenarioExecutionCondition extends ExecutionCondition {
+
+}

--- a/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/execution/condition/QuarkusScenarioExecutionConditions.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/execution/condition/QuarkusScenarioExecutionConditions.java
@@ -1,0 +1,28 @@
+package io.quarkus.test.scenarios.execution.condition;
+
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled;
+
+import java.util.ServiceLoader;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class QuarkusScenarioExecutionConditions implements ExecutionCondition {
+
+    private static final ConditionEvaluationResult SUCCESS = enabled("All QuarkusScenario execution condition passed");
+    private final ServiceLoader<QuarkusScenarioExecutionCondition> delegates = ServiceLoader
+            .load(QuarkusScenarioExecutionCondition.class);
+
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext extensionContext) {
+        for (ExecutionCondition delegate : delegates) {
+            var result = delegate.evaluateExecutionCondition(extensionContext);
+            if (result.isDisabled()) {
+                return result;
+            }
+        }
+        return SUCCESS;
+    }
+
+}

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/DevModeQuarkusApplicationAnnotationBinding.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/DevModeQuarkusApplicationAnnotationBinding.java
@@ -22,4 +22,9 @@ public class DevModeQuarkusApplicationAnnotationBinding implements AnnotationBin
         return builder;
     }
 
+    @Override
+    public boolean requiresLinuxContainersOnBareMetal() {
+        return true;
+    }
+
 }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/GitRepositoryQuarkusApplicationAnnotationBinding.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/GitRepositoryQuarkusApplicationAnnotationBinding.java
@@ -22,4 +22,9 @@ public class GitRepositoryQuarkusApplicationAnnotationBinding implements Annotat
         return builder;
     }
 
+    @Override
+    public boolean requiresLinuxContainersOnBareMetal() {
+        return false;
+    }
+
 }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusApplicationAnnotationBinding.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusApplicationAnnotationBinding.java
@@ -22,4 +22,9 @@ public class QuarkusApplicationAnnotationBinding implements AnnotationBinding {
         return builder;
     }
 
+    @Override
+    public boolean requiresLinuxContainersOnBareMetal() {
+        return false;
+    }
+
 }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/RemoteDevModeQuarkusApplicationAnnotationBinding.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/RemoteDevModeQuarkusApplicationAnnotationBinding.java
@@ -22,4 +22,9 @@ public class RemoteDevModeQuarkusApplicationAnnotationBinding implements Annotat
         return builder;
     }
 
+    @Override
+    public boolean requiresLinuxContainersOnBareMetal() {
+        return true;
+    }
+
 }

--- a/quarkus-test-core/src/main/resources/META-INF/services/io.quarkus.test.scenarios.execution.condition.QuarkusScenarioExecutionCondition
+++ b/quarkus-test-core/src/main/resources/META-INF/services/io.quarkus.test.scenarios.execution.condition.QuarkusScenarioExecutionCondition
@@ -1,0 +1,1 @@
+io.quarkus.test.scenarios.execution.condition.AnnotationBindingQuarkusScenarioContainerExecutionCondition

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/operator/OperatorAnnotationBinding.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/operator/OperatorAnnotationBinding.java
@@ -20,4 +20,9 @@ public class OperatorAnnotationBinding implements AnnotationBinding {
         builder.init(metadata);
         return builder;
     }
+
+    @Override
+    public boolean requiresLinuxContainersOnBareMetal() {
+        return false;
+    }
 }

--- a/quarkus-test-service-amq/src/main/java/io/quarkus/test/services/containers/AmqContainerAnnotationBinding.java
+++ b/quarkus-test-service-amq/src/main/java/io/quarkus/test/services/containers/AmqContainerAnnotationBinding.java
@@ -22,4 +22,9 @@ public class AmqContainerAnnotationBinding implements AnnotationBinding {
         return builder;
     }
 
+    @Override
+    public boolean requiresLinuxContainersOnBareMetal() {
+        return true;
+    }
+
 }

--- a/quarkus-test-service-jaeger/src/main/java/io/quarkus/test/services/containers/JaegerContainerAnnotationBinding.java
+++ b/quarkus-test-service-jaeger/src/main/java/io/quarkus/test/services/containers/JaegerContainerAnnotationBinding.java
@@ -20,4 +20,9 @@ public class JaegerContainerAnnotationBinding implements AnnotationBinding {
         builder.init(metadata);
         return builder;
     }
+
+    @Override
+    public boolean requiresLinuxContainersOnBareMetal() {
+        return true;
+    }
 }

--- a/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/KafkaContainerAnnotationBinding.java
+++ b/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/KafkaContainerAnnotationBinding.java
@@ -22,4 +22,9 @@ public class KafkaContainerAnnotationBinding implements AnnotationBinding {
         return builder;
     }
 
+    @Override
+    public boolean requiresLinuxContainersOnBareMetal() {
+        return true;
+    }
+
 }

--- a/quarkus-test-service-keycloak/src/main/java/io/quarkus/test/services/containers/KeycloakContainerAnnotationBinding.java
+++ b/quarkus-test-service-keycloak/src/main/java/io/quarkus/test/services/containers/KeycloakContainerAnnotationBinding.java
@@ -20,4 +20,9 @@ public class KeycloakContainerAnnotationBinding implements AnnotationBinding {
         builder.init(metadata);
         return builder;
     }
+
+    @Override
+    public boolean requiresLinuxContainersOnBareMetal() {
+        return true;
+    }
 }


### PR DESCRIPTION
### Summary

Tests are automatically disabled when Linux containers are not available,  but the test has managing resource that requires Linux containers. Detecting when Quarkus CLI starts in DEV mode will require additional effort.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)