### PR TITLE
Remove unavailable skip-tests-on-windows-in-native profile

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -365,7 +365,7 @@ jobs:
       - name: Build in Native mode
         shell: bash
         run: |
-          mvn -B -fae -s .github/mvn-settings.xml clean install -Pframework,examples,native,skip-tests-on-windows-in-native -Dquarkus.native.container-build=false -Dquarkus.platform.version="${{ matrix.quarkus-version }}"
+          mvn -B -fae -s .github/mvn-settings.xml clean install -Pframework,examples,native -Dquarkus.native.container-build=false -Dquarkus.platform.version="${{ matrix.quarkus-version }}"
       - name: Zip Artifacts
         shell: bash
         if: failure()


### PR DESCRIPTION
### Summary

Remove unavailable skip-tests-on-windows-in-native profile

Property was removed in https://github.com/quarkus-qe/quarkus-test-framework/commit/5238f124d7e4e119f31937efddae1b6f6508618e#diff-5f1afddf2b21f65a58e6aa212e01eb16621165ef2a238d221f8a98dc3f4b4f6bL63

https://github.com/quarkusio/quarkus/issues/27061 is still not resolved, so maybe `skip-tests-on-windows-in-native` removal in the mentioned commit was not intentional? @michalvavrik 

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)