### PR TITLE
Provide a way to disable QuarkusTests without Docker

### DIFF
--- a/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/annotations/EnabledWhenLinuxContainersAvailable.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/annotations/EnabledWhenLinuxContainersAvailable.java
@@ -1,0 +1,26 @@
+package io.quarkus.test.scenarios.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Provides option to explicitly enable test only when Linux containers are available.
+ * The framework automatically detects when Linux containers are needed and only run tests
+ * when environment supports them. However, you may need to annotate tests with this annotation
+ * when our framework is not used (like when the QuarkusTest annotation is used).
+ */
+@Inherited
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(EnabledWhenLinuxContainersAvailableCondition.class)
+public @interface EnabledWhenLinuxContainersAvailable {
+    /**
+     * Why is the annotated test class or test method disabled.
+     */
+    String reason() default "";
+}

--- a/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/annotations/EnabledWhenLinuxContainersAvailableCondition.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/annotations/EnabledWhenLinuxContainersAvailableCondition.java
@@ -1,0 +1,25 @@
+package io.quarkus.test.scenarios.annotations;
+
+import static io.quarkus.test.scenarios.execution.condition.AbstractQuarkusScenarioContainerExecutionCondition.ENV_DOES_NOT_SUPPORT_LINUX_CONTAINERS;
+import static io.quarkus.test.scenarios.execution.condition.AbstractQuarkusScenarioContainerExecutionCondition.ENV_SUPPORTS_LINUX_CONTAINERS;
+import static java.lang.String.format;
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.disabled;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import io.quarkus.test.scenarios.execution.condition.AbstractQuarkusScenarioContainerExecutionCondition;
+
+public class EnabledWhenLinuxContainersAvailableCondition implements ExecutionCondition {
+
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext extensionContext) {
+        if (AbstractQuarkusScenarioContainerExecutionCondition.areLinuxContainersSupported()) {
+            return ENV_SUPPORTS_LINUX_CONTAINERS;
+        } else {
+            String testName = extensionContext.getDisplayName();
+            return disabled(format(ENV_DOES_NOT_SUPPORT_LINUX_CONTAINERS, testName));
+        }
+    }
+}

--- a/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/execution/condition/AbstractQuarkusScenarioContainerExecutionCondition.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/execution/condition/AbstractQuarkusScenarioContainerExecutionCondition.java
@@ -21,13 +21,13 @@ import io.quarkus.test.utils.Command;
 
 public abstract class AbstractQuarkusScenarioContainerExecutionCondition implements QuarkusScenarioExecutionCondition {
 
+    public static final ConditionEvaluationResult ENV_SUPPORTS_LINUX_CONTAINERS = enabled("Environment supports"
+            + " Linux containers");
+    public static final String ENV_DOES_NOT_SUPPORT_LINUX_CONTAINERS = "Test class '%s' requires Linux containers, "
+            + "but the environment does not support them";
     private static final Logger LOG = Logger.getLogger(AbstractQuarkusScenarioContainerExecutionCondition.class.getName());
     private static final ConditionEvaluationResult CONDITION_NOT_MATCHED = enabled("This condition should "
             + "only be applied on test classes annotated with the '@QuarkusScenario' annotation");
-    private static final ConditionEvaluationResult ENV_SUPPORTS_LINUX_CONTAINERS = enabled("Environment supports"
-            + " Linux containers");
-    private static final String ENV_DOES_NOT_SUPPORT_LINUX_CONTAINERS = "Test class '%s' requires Linux containers, "
-            + "but the environment does not support them";
     private static final String LINUX_CONTAINERS_NOT_REQUIRED = "Test class '%s' does not require containers";
     private static final String LINUX_CONTAINER_OS_TYPE = "linux";
     private static final String PODMAN = "podman";
@@ -61,7 +61,7 @@ public abstract class AbstractQuarkusScenarioContainerExecutionCondition impleme
 
     protected abstract boolean areContainersRequired(Class<?> testClass);
 
-    private static synchronized boolean areLinuxContainersSupported() {
+    public static synchronized boolean areLinuxContainersSupported() {
         if (areLinuxContainersSupported == null) {
             areLinuxContainersSupported = checkLinuxContainersSupported();
         }


### PR DESCRIPTION
### Summary

We have tests annotated with `@QuarkusTest` that we want to run on Windows when Docker is available, but right now we don't have a tool and I don't want to implement it more than once, let's have it in FW.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)