### PR TITLE
Give tests access to inner Docker container if truly necessary

### DIFF
--- a/quarkus-test-containers/src/main/java/io/quarkus/test/services/containers/DockerContainerManagedResource.java
+++ b/quarkus-test-containers/src/main/java/io/quarkus/test/services/containers/DockerContainerManagedResource.java
@@ -31,6 +31,7 @@ import io.quarkus.test.utils.DockerUtils;
 
 public abstract class DockerContainerManagedResource implements ManagedResource {
 
+    public static final String DOCKER_INNER_CONTAINER = DockerContainerManagedResource.class.getName() + "_inner";
     private static final String DELETE_IMAGE_ON_STOP_PROPERTY = "container.delete.image.on.stop";
     private static final String TARGET = "target";
 
@@ -66,6 +67,8 @@ public abstract class DockerContainerManagedResource implements ManagedResource 
         loggingHandler.startWatching();
 
         doStart();
+
+        context.put(DOCKER_INNER_CONTAINER, innerContainer);
     }
 
     private boolean isDockerImageDeletedOnStop() {

--- a/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/BaseService.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/BaseService.java
@@ -271,7 +271,7 @@ public class BaseService<T extends Service> implements Service {
         return context.getServiceFolder();
     }
 
-    protected <U> U getPropertyFromContext(String key) {
+    public <U> U getPropertyFromContext(String key) {
         if (context == null) {
             fail("Service has not been initialized yet. Make sure you invoke this method in the right order.");
         }


### PR DESCRIPTION
### Summary

I need to execute some actions on container post start (see here https://github.com/quarkusio/quarkus/issues/35336#issuecomment-1676682950, btw it didn't in fact solve my problems :-( so far) and I'd like bare metals to have access to Docker container if really necessary. It is not great option for it's bare metal Docker specific, but this option is available for only very rare cases. The way I use it, I use `io.quarkus.test.bootstrap.BaseService#onPostStart` and do `org.testcontainers.containers.ContainerState#execInContainer(java.lang.String...)`.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)