### PR TITLE
Replacing oc rollout usage with fabric8

### DIFF
--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
@@ -226,11 +226,10 @@ public final class OpenShiftClient {
      * @param service
      */
     public void rollout(Service service) {
-        try {
-            new Command(OC, "rollout", "latest", "dc/" + service.getName(), "-n", currentNamespace).runAndWait();
-        } catch (Exception e) {
-            fail("Deployment failed to be started. Caused by " + e.getMessage());
-        }
+        Log.info("Rolling out deploymentConfig " + service.getName() + " in namespace " + currentNamespace);
+        Log.info("Run this command to replicate: oc rollout latest dc/" + service.getName() + " -n " + currentNamespace);
+        DeploymentConfig dc = client.deploymentConfigs().withName(service.getName()).deployLatest(true);
+        Log.info("dc/" + service.getName() + " rolled out.");
     }
 
     /**


### PR DESCRIPTION
### Summary

* Replacing usage of 'oc rollout' in OpenShiftClient with fabric8 client's deployable resource's 'deployLatest'. This seems to be reducing the racy failures in some tests.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)