### PR TITLE
Revert "Bump io.confluent:kafka-avro-serializer from 7.3.4 to 7.5.0"

### DIFF
--- a/examples/kafka-registry/pom.xml
+++ b/examples/kafka-registry/pom.xml
@@ -10,7 +10,7 @@
     <artifactId>examples-kafka-registry</artifactId>
     <name>Quarkus - Test Framework - Examples - Kafka with Registry</name>
     <properties>
-        <confluent.kafka-avro-serializer.version>7.5.0</confluent.kafka-avro-serializer.version>
+        <confluent.kafka-avro-serializer.version>7.3.4</confluent.kafka-avro-serializer.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Reverts quarkus-qe/quarkus-test-framework#862

I made mistake, see https://github.com/quarkus-qe/quarkus-test-framework/pull/862#issuecomment-1729318761.