### PR TITLE
Remove rollout from deployment and bump Quarkus to 3.5.0.CR1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <impsort-maven-plugin.version>1.9.0</impsort-maven-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>3.2.5.Final</quarkus.platform.version>
+        <quarkus.platform.version>3.5.0.CR1</quarkus.platform.version>
         <exclude.tests.with.tags>quarkus-cli</exclude.tests.with.tags>
         <include.tests>**/*IT.java</include.tests>
         <exclude.openshift.tests>**/OpenShift*IT.java</exclude.openshift.tests>

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
@@ -225,6 +225,7 @@ public final class OpenShiftClient {
      *
      * @param service
      */
+    @Deprecated(forRemoval = true) //This method is not used anymore. Remove this annotation if you need it for some reason
     public void rollout(Service service) {
         Log.info("Rolling out deploymentConfig " + service.getName() + " in namespace " + currentNamespace);
         Log.info("Run this command to replicate: oc rollout latest dc/" + service.getName() + " -n " + currentNamespace);

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/ContainerRegistryOpenShiftQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/ContainerRegistryOpenShiftQuarkusApplicationManagedResource.java
@@ -26,7 +26,6 @@ public class ContainerRegistryOpenShiftQuarkusApplicationManagedResource
     protected void doInit() {
         image = createImageAndPush();
         super.doInit();
-        client.rollout(model.getContext().getOwner());
         exposeServices();
     }
 


### PR DESCRIPTION
### Summary

Rollout is only used for deployment via container registry, but tests are working fine even without it. At the same time, it often causes hard-to-reproduce bugs, with "Failure executing: PATCH at: <...>the object has been modified" exception

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)