### PR TITLE
Fix Infinispan service resource loading on Windows

### DIFF
--- a/examples/infinispan/src/test/java/io/quarkus/qe/books/LegacyUsingJksInfinispanBookCacheIT.java
+++ b/examples/infinispan/src/test/java/io/quarkus/qe/books/LegacyUsingJksInfinispanBookCacheIT.java
@@ -11,8 +11,8 @@ public class LegacyUsingJksInfinispanBookCacheIT extends BaseBookCacheIT {
 
     @Container(image = "docker.io/infinispan/server:13.0", expectedLog = "Infinispan Server.*started in", port = 11222)
     static final InfinispanService infinispan = new InfinispanService()
-            .withConfigFile("jks-config.yaml")
-            .withSecretFiles("jks/server.jks");
+            .withConfigFile("/jks-config.yaml")
+            .withSecretFiles("/jks/server.jks");
 
     @QuarkusApplication
     static final RestService app = new RestService()

--- a/examples/infinispan/src/test/java/io/quarkus/qe/books/UsingJksInfinispanBookCacheIT.java
+++ b/examples/infinispan/src/test/java/io/quarkus/qe/books/UsingJksInfinispanBookCacheIT.java
@@ -12,7 +12,7 @@ public class UsingJksInfinispanBookCacheIT extends BaseBookCacheIT {
     @Container(image = "docker.io/infinispan/server:14.0", expectedLog = "Infinispan Server.*started in", port = 11222)
     static final InfinispanService infinispan = new InfinispanService()
             .withConfigFile("infinispan.xml")
-            .withSecretFiles("jks/keystore.jks");
+            .withSecretFiles("/jks/keystore.jks");
 
     @QuarkusApplication
     static final RestService app = new RestService()

--- a/quarkus-test-service-infinispan/src/main/java/io/quarkus/test/bootstrap/InfinispanService.java
+++ b/quarkus-test-service-infinispan/src/main/java/io/quarkus/test/bootstrap/InfinispanService.java
@@ -2,7 +2,6 @@ package io.quarkus.test.bootstrap;
 
 import static io.quarkus.test.utils.PropertiesUtils.RESOURCE_PREFIX;
 import static io.quarkus.test.utils.PropertiesUtils.SECRET_PREFIX;
-import static io.quarkus.test.utils.PropertiesUtils.SLASH;
 
 import java.util.Arrays;
 import java.util.List;
@@ -63,20 +62,20 @@ public class InfinispanService extends BaseService<InfinispanService> {
 
         if (configFile != null && !configFile.isEmpty()) {
             // legacy -> Infinispan previous to version 14
-            withProperty("CONFIG_PATH", RESOURCE_PREFIX + SLASH + configFile);
+            withProperty("CONFIG_PATH", RESOURCE_PREFIX + configFile);
             // Infinispan 14+ configuration setup
             withProperty("INFINISPAN_CONFIG_PATH", "resource_with_destination::/opt/infinispan/server/conf|" + configFile);
         }
 
         if (userConfigFiles != null) {
             for (int index = 0; index < userConfigFiles.size(); index++) {
-                withProperty("USER_CONFIG_" + index, RESOURCE_PREFIX + SLASH + userConfigFiles.get(index));
+                withProperty("USER_CONFIG_" + index, RESOURCE_PREFIX + userConfigFiles.get(index));
             }
         }
 
         if (secretFiles != null) {
             for (int index = 0; index < secretFiles.size(); index++) {
-                withProperty("SECRET_" + index, SECRET_PREFIX + SLASH + secretFiles.get(index));
+                withProperty("SECRET_" + index, SECRET_PREFIX + secretFiles.get(index));
             }
         }
 


### PR DESCRIPTION
### Summary

On Windows, class resources prefixed with file separator are not found (see respective Jenkins jobs messaging module and failures of `io.quarkus.ts.messaging.infinispan.grpc.kafka.InfinispanKafkaIT` and `io.quarkus.ts.messaging.infinispan.grpc.kafka.InfinispanKafkaSaslIT`). without file separator prefix, loading works both on Windows and Linux except for when resources are in subfolder. This way, we allow to add file separator only when needed and resources will be resolved on Windows a well. For example, in `messaging-infinispan-grpc-kafka` it won't be necessary to add file separators for either OS.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)