### PR TITLE
Use Docker official Apache Zookeeper image for OpenShift instead of Debezium version

### DIFF
--- a/quarkus-test-service-kafka/src/main/resources/strimzi-deployment-template.yml
+++ b/quarkus-test-service-kafka/src/main/resources/strimzi-deployment-template.yml
@@ -75,7 +75,7 @@ items:
         spec:
           containers:
             - name: k8s-zookeeper
-              image: quay.io/debezium/zookeeper
+              image: zookeeper
               ports:
                 - containerPort: 2181
                   name: client


### PR DESCRIPTION
### Summary

See https://github.com/quarkus-qe/quarkus-test-suite/pull/1431#issuecomment-1741805959, I'm not sure about versioning at all, but I gave up searching for it after 15 mins. Can't see any compatibility matrix, IIRC some version of Zookeeper used to be shipped with Strimzi and now something. Let's verify it experimentally.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)