### PR TITLE
Enable to use java preview while executing built jar file.

### DIFF
--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/ProdLocalhostQuarkusApplicationManagedResource.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/ProdLocalhostQuarkusApplicationManagedResource.java
@@ -7,10 +7,14 @@ import java.util.List;
 
 import org.apache.commons.lang3.ArrayUtils;
 
+import io.quarkus.test.configuration.PropertyLookup;
+
 public class ProdLocalhostQuarkusApplicationManagedResource extends LocalhostQuarkusApplicationManagedResource {
 
     private static final String JAVA = "java";
     private static final String QUARKUS_ARGS_PROPERTY_NAME = "quarkus.args";
+    private static final String ENABLE_PREVIEW = "--enable-preview";
+    private static final PropertyLookup JAVA_ENABLE_PREVIEW = new PropertyLookup("ts.enable-java-preview", "false");
 
     private final ProdQuarkusApplicationManagedResourceBuilder model;
 
@@ -25,6 +29,9 @@ public class ProdLocalhostQuarkusApplicationManagedResource extends LocalhostQua
         String[] cmdArgs = extractQuarkusArgs(systemProperties);
         if (model.getArtifact().getFileName().toString().endsWith(".jar")) {
             command.add(JAVA);
+            if (JAVA_ENABLE_PREVIEW.getAsBoolean()) {
+                command.add(ENABLE_PREVIEW);
+            }
             command.addAll(systemProperties);
             command.add("-jar");
             command.add(model.getArtifact().toAbsolutePath().toString());


### PR DESCRIPTION
### Summary

Hi, this PR adding option run built jar with preview argument. This can be useful when someone trying the JEPs which are marked as preview. What I tried when using framework with quarkus dev mode it pass the property `-D--enable-preview` but when using standard mode the property is not picked so jar failing to execute.

Running `mvn -B -fae clean install -Pframework,examples -Dvalidate-format -Dquarkus.platform.version="999-SNAPSHOT" -pl examples/database-mysql -D--enable-preview `

Before this PR result in produced command `java -D<some Quarkus properties> -jar quarkus-test-framework/examples/database-mysql/target/quarkus-app/quarkus-run.jar`

After this PR result in produced command `java --enable-preview -D<some Quarkus properties> -jar quarkus-test-framework/examples/database-mysql/target/quarkus-app/quarkus-run.jar`

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)