### PR TITLE
Add native released run to PR workflow

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -66,10 +66,6 @@ jobs:
       - name: Build
         run: |
           MAVEN_PROFILES="-Pframework,examples"
-          if [[ "${{ matrix.quarkus-version }}" = 1.* ]]; then
-             EXCLUDE_MODULES="-pl !examples/grpc"
-             MAVEN_PROFILES=$MAVEN_PROFILES
-          fi
 
           if [[ "${{ matrix.quarkus-version }}" != current ]]; then
              QUARKUS_VERSION="-Dquarkus.platform.version=${{ matrix.quarkus-version }}"
@@ -236,10 +232,6 @@ jobs:
         run: tar -xzf maven-repo.tgz -C ~
       - name: Build
         run: |
-          if [[ "${{ matrix.quarkus-version }}" = 1.* ]]; then
-             EXCLUDE_MODULES="-pl !examples/grpc"
-          fi
-
           if [[ "${{ matrix.quarkus-version }}" != current ]]; then
              QUARKUS_VERSION="-Dquarkus.platform.version=${{ matrix.quarkus-version }}"
           fi

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -10,6 +10,10 @@ jobs:
         java: [ 11 ]
     steps:
       - uses: actions/checkout@v4
+      - name: Reclaim Disk Space
+        run: .github/ci-prerequisites.sh
+      - name: Install required tools
+        run: sudo apt update && sudo apt install pigz
       - name: Install JDK {{ matrix.java }}
         uses: actions/setup-java@v3
         with:
@@ -19,7 +23,16 @@ jobs:
           cache: 'maven'
       - name: Build with Maven
         run: |
-          mvn -V -B -s .github/mvn-settings.xml verify -Pframework,examples -Dvalidate-format -DskipTests -DskipITs
+          mvn -V -B -s .github/mvn-settings.xml clean install -Pframework,examples -Dvalidate-format -DskipTests -DskipITs
+      - name: Tar Maven Repo
+        shell: bash
+        run: tar -I 'pigz -9' -cf maven-repo-current-fw.tgz -C ~ .m2/repository
+      - name: Persist Maven Repo
+        uses: actions/upload-artifact@v3
+        with:
+          name: maven-repo-current-fw
+          path: maven-repo-current-fw.tgz
+          retention-days: 1
   quarkus-main-build:
     name: Quarkus main build
     runs-on: ubuntu-latest
@@ -81,16 +94,17 @@ jobs:
         with:
           helmfile-version: "v0.145.2"
           install-helm: no
+      - name: Download Maven Repo
+        uses: actions/download-artifact@v3
+        with:
+          name: maven-repo-current-fw
+          path: .
+      - name: Extract Maven Repo
+        shell: bash
+        run: tar -xzf maven-repo-current-fw.tgz -C ~
       - name: Build in JVM mode
         run: |
-          if [[ "${{ matrix.quarkus-version }}" = 1.* ]]; then
-             EXCLUDE_MODULES="-pl !examples/grpc"
-          fi
-
-          if [[ "${{ matrix.quarkus-version }}" != current ]]; then
-             QUARKUS_VERSION="-Dquarkus.platform.version=${{ matrix.quarkus-version }}"
-          fi
-          mvn -B -fae -s .github/mvn-settings.xml clean install -Pframework,examples -Dvalidate-format $QUARKUS_VERSION $EXCLUDE_MODULES
+          mvn -B -fae -s .github/mvn-settings.xml clean install -Pexamples
       - name: Zip Artifacts
         run: |
           zip -R artifacts-quarkus${{ matrix.quarkus-version }}-linux-jvm${{ matrix.java }}.zip '*-reports/*'
@@ -158,6 +172,60 @@ jobs:
         with:
           name: ci-artifacts
           path: artifacts-latest-linux-jvm${{ matrix.java }}.zip
+  linux-build-native-released:
+    name: Daily - Linux - Native build - Released Version
+    runs-on: ubuntu-latest
+    needs: validate-format
+    strategy:
+      matrix:
+        quarkus-version: [ "current" ]
+        java: [ 17 ]
+        examples: [
+          'examples/pingpong,examples/restclient,examples/greetings,examples/blocking-reactive-model,examples/https,examples/grpc,examples/consul,examples/infinispan,examples/microprofile,examples/keycloak,examples/kafka,examples/kafka-registry,examples/kafka-streams',
+          '!examples/pingpong,!examples/restclient,!examples/greetings,!examples/blocking-reactive-model,!examples/https,!examples/grpc,!examples/consul,!examples/infinispan,!examples/microprofile,!examples/keycloak,!examples/kafka,!examples/kafka-registry,!examples/kafka-streams'
+        ]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Reclaim Disk Space
+        run: .github/ci-prerequisites.sh
+      - name: Install JDK {{ matrix.java }}
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.java }}
+          check-latest: true
+          cache: 'maven'
+      - name: Install Helm client
+        uses: azure/setup-helm@v3
+        with:
+          version: v3.9.0
+        id: install-helm
+      - name: Setup helmfile
+        uses: mamezou-tech/setup-helmfile@v1.2.0
+        with:
+          helmfile-version: "v0.145.2"
+          install-helm: no
+      - name: Download Maven Repo
+        uses: actions/download-artifact@v3
+        with:
+          name: maven-repo-current-fw
+          path: .
+      - name: Extract Maven Repo
+        shell: bash
+        run: tar -xzf maven-repo-current-fw.tgz -C ~
+      - name: Build
+        run: |
+          mvn -B -fae -s .github/mvn-settings.xml clean install -Pexamples,native -pl '${{ matrix.examples }}'
+      - name: Zip Artifacts
+        if: failure()
+        run: |
+          zip -R artifacts-native-${{ matrix.quarkus-version }}-${{ matrix.java }}.zip '*-reports/*'
+      - name: Archive artifacts
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: ci-artifacts
+          path: artifacts-native-${{ matrix.quarkus-version }}-${{ matrix.java }}.zip
   windows-build-jvm-latest:
     name: Windows - JVM build - Latest Version
     runs-on: windows-latest


### PR DESCRIPTION
### Summary

closes #886

- Quarkus version is the released one as we already run daily's with `999-SNAPSHOT` but don't check released one. Running both seems expensive (waiting time).
- No sense to check for Quarkus 1.x version as thanks to Jakarta migration there is no chance it would work anyway
- Don't validate framework twice, instead store result as maven repo, which allows me in next run not to re-run "framework" profile anyway (yes, it's very fast, but when I specify `-pl examples/xyz` it wouldn't run)

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)