### PR TITLE
Bump kafka-avro-serializer to 7.5.1, add jackson-dataformat-csv dependency

### DIFF
--- a/examples/kafka-registry/pom.xml
+++ b/examples/kafka-registry/pom.xml
@@ -10,7 +10,7 @@
     <artifactId>examples-kafka-registry</artifactId>
     <name>Quarkus - Test Framework - Examples - Kafka with Registry</name>
     <properties>
-        <confluent.kafka-avro-serializer.version>7.3.4</confluent.kafka-avro-serializer.version>
+        <confluent.kafka-avro-serializer.version>7.5.1</confluent.kafka-avro-serializer.version>
     </properties>
 
     <dependencies>
@@ -37,6 +37,10 @@
             <groupId>io.confluent</groupId>
             <artifactId>kafka-avro-serializer</artifactId>
             <version>${confluent.kafka-avro-serializer.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-csv</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus.qe</groupId>


### PR DESCRIPTION
Bump kafka-avro-serializer to 7.5.1, add jackson-dataformat-csv dependency

See https://github.com/quarkusio/quarkus/issues/36372 for details

### Summary

(Summarize the problem solved by this PR, and how to verify it manually)

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)