### PR TITLE
Migrate from URL to URI constructor

### DIFF
--- a/quarkus-test-helm/src/main/java/io/quarkus/test/bootstrap/QuarkusHelmClient.java
+++ b/quarkus-test-helm/src/main/java/io/quarkus/test/bootstrap/QuarkusHelmClient.java
@@ -7,7 +7,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
-import java.net.URL;
+import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
@@ -124,8 +124,8 @@ public class QuarkusHelmClient {
     public void waitToReadiness(String fullReadinessPath, Duration atMost) {
         await().ignoreExceptions().atMost(atMost)
                 .untilAsserted(() -> {
-                    URL url = new URL(fullReadinessPath);
-                    HttpURLConnection con = (HttpURLConnection) url.openConnection();
+                    URI uri = URI.create(fullReadinessPath);
+                    HttpURLConnection con = (HttpURLConnection) uri.toURL().openConnection();
                     try {
                         con.setRequestMethod("GET");
                         con.connect();


### PR DESCRIPTION
…ecated.

### Summary

Hi, this PR updating some deprecated method. To be prepared to JDK 21.

URL constructors was deprecated in JDK 20. Now is possible to create URL from URI.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)