### PR TITLE
[1.3.z] Pinning external application branches to 3.2

### DIFF
--- a/examples/external-applications/src/test/java/io/quarkus/qe/DevModeQuickstartUsingDefaultsIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/DevModeQuickstartUsingDefaultsIT.java
@@ -13,7 +13,7 @@ import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Windows does not support long file paths")
 public class DevModeQuickstartUsingDefaultsIT {
 
-    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", contextDir = "getting-started", devMode = true)
+    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", branch = "3.2", contextDir = "getting-started", devMode = true)
     static final RestService app = new RestService();
 
     @Test

--- a/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftExtensionCamelFileBindyFtpIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftExtensionCamelFileBindyFtpIT.java
@@ -7,16 +7,14 @@ import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusSnapshot;
-import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
 import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 
 // TODO: enable test when Camel Quarkus Examples migrate to Quarkus 3.0
-@DisabledOnQuarkusVersion(version = "(3\\.[0-9]\\..*)", reason = "Camel Quarkus Examples is using Quarkus 2.16")
 @DisabledOnQuarkusSnapshot(reason = "Camel Quarkus 999-SNAPSHOT is not available in maven repository") // f.e. 'quarkus-camel-bom:pom:999-SNAPSHOT' is not available
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
 public class OpenShiftExtensionCamelFileBindyFtpIT {
 
-    @GitRepositoryQuarkusApplication(repo = "https://github.com/apache/camel-quarkus-examples.git", contextDir = "file-bindy-ftp", mavenArgs = "-Dopenshift")
+    @GitRepositoryQuarkusApplication(repo = "https://github.com/apache/camel-quarkus-examples.git", branch = "3.2.x", contextDir = "file-bindy-ftp", mavenArgs = "-Dopenshift")
     static final RestService app = new RestService();
 
     @Test

--- a/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftExtensionUsingDockerBuildStrategyCamelFileBindyFtpIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftExtensionUsingDockerBuildStrategyCamelFileBindyFtpIT.java
@@ -7,16 +7,14 @@ import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusSnapshot;
-import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
 import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 
 // TODO: enable test when Camel Quarkus Examples migrate to Quarkus 3.0
-@DisabledOnQuarkusVersion(version = "(3\\.[0-9]\\..*)", reason = "Camel Quarkus Examples is using Quarkus 2.16")
 @DisabledOnQuarkusSnapshot(reason = "Camel Quarkus 999-SNAPSHOT is not available in maven repository") // f.e. 'quarkus-camel-bom:pom:999-SNAPSHOT' is not available
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtensionAndDockerBuildStrategy)
 public class OpenShiftExtensionUsingDockerBuildStrategyCamelFileBindyFtpIT {
 
-    @GitRepositoryQuarkusApplication(repo = "https://github.com/apache/camel-quarkus-examples.git", contextDir = "file-bindy-ftp", mavenArgs = "-Dopenshift")
+    @GitRepositoryQuarkusApplication(repo = "https://github.com/apache/camel-quarkus-examples.git", branch = "3.2.x", contextDir = "file-bindy-ftp", mavenArgs = "-Dopenshift")
     static final RestService app = new RestService();
 
     @Test

--- a/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftS2iQuickstartUsingUberJarIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftS2iQuickstartUsingUberJarIT.java
@@ -15,7 +15,7 @@ public class OpenShiftS2iQuickstartUsingUberJarIT {
     /**
      * Package type is set in the custom template.
      */
-    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", contextDir = "getting-started")
+    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", branch = "3.2", contextDir = "getting-started")
     static final RestService appuberjar = new RestService();
 
     @Test

--- a/examples/external-applications/src/test/java/io/quarkus/qe/QuickstartUsingDefaultsIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/QuickstartUsingDefaultsIT.java
@@ -13,7 +13,7 @@ import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Windows does not support long file paths")
 public class QuickstartUsingDefaultsIT {
 
-    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", contextDir = "getting-started")
+    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", branch = "3.2", contextDir = "getting-started")
     static final RestService app = new RestService();
 
     @Test

--- a/examples/external-applications/src/test/java/io/quarkus/qe/QuickstartUsingUsingUberJarIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/QuickstartUsingUsingUberJarIT.java
@@ -15,7 +15,7 @@ import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Windows does not support long file paths")
 public class QuickstartUsingUsingUberJarIT {
 
-    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", contextDir = "getting-started", mavenArgs = "-Dquarkus.package.type=uber-jar -DskipTests=true -Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus.platform.version=${QUARKUS_PLATFORM_VERSION}")
+    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", branch = "3.2", contextDir = "getting-started", mavenArgs = "-Dquarkus.package.type=uber-jar -DskipTests=true -Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus.platform.version=${QUARKUS_PLATFORM_VERSION}")
     static final RestService app = new RestService();
 
     @Test


### PR DESCRIPTION
### Summary

* Pinning usages of Camel on Quarkus and Quarkus quickstarts to 3.2 release stream branches.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Dependency update
- [x] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)