### PR TITLE
Enable Camel example external applications

### DIFF
--- a/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftExtensionCamelFileBindyFtpIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftExtensionCamelFileBindyFtpIT.java
@@ -7,11 +7,8 @@ import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusSnapshot;
-import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
 import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 
-// TODO: enable test when Camel Quarkus Examples migrate to Quarkus 3.0
-@DisabledOnQuarkusVersion(version = "(3\\.[0-9]\\..*)", reason = "Camel Quarkus Examples is using Quarkus 2.16")
 @DisabledOnQuarkusSnapshot(reason = "Camel Quarkus 999-SNAPSHOT is not available in maven repository") // f.e. 'quarkus-camel-bom:pom:999-SNAPSHOT' is not available
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtension)
 public class OpenShiftExtensionCamelFileBindyFtpIT {

--- a/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftExtensionUsingDockerBuildStrategyCamelFileBindyFtpIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftExtensionUsingDockerBuildStrategyCamelFileBindyFtpIT.java
@@ -7,11 +7,8 @@ import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusSnapshot;
-import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
 import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 
-// TODO: enable test when Camel Quarkus Examples migrate to Quarkus 3.0
-@DisabledOnQuarkusVersion(version = "(3\\.[0-9]\\..*)", reason = "Camel Quarkus Examples is using Quarkus 2.16")
 @DisabledOnQuarkusSnapshot(reason = "Camel Quarkus 999-SNAPSHOT is not available in maven repository") // f.e. 'quarkus-camel-bom:pom:999-SNAPSHOT' is not available
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingOpenShiftExtensionAndDockerBuildStrategy)
 public class OpenShiftExtensionUsingDockerBuildStrategyCamelFileBindyFtpIT {


### PR DESCRIPTION
### Summary

https://github.com/apache/camel-quarkus-examples.git is now on Quarkus 3.y, so we should be fine re-enabling them.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Dependency update
- [x] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)