### PR TITLE
Change mandrel version in CI

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -307,7 +307,7 @@ jobs:
       matrix:
         java: [ 17 ]
         quarkus-version: ["999-SNAPSHOT"]
-        graalvm-version: ["mandrel-latest"]
+        graalvm-version: ["mandrel-23.0.1.2-Final"]
     steps:
       - uses: actions/checkout@v4
       - name: Install JDK {{ matrix.java }}


### PR DESCRIPTION
### Summary

Change CI definition from latest mandrel version to specific version (23.0.1.2-Final) as the newest one was built only by JDK 21.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)