### PR TITLE
Fix OpenShiftAmqpAmqIT by changing service name and bump ActiveMQ Artemis Broker to same as Dev Svcs are using

### DIFF
--- a/examples/amq-amqp/src/main/resources/application.properties
+++ b/examples/amq-amqp/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-amqp-host=amq-broker-amqp
+amqp-host=amq-amqp
 amqp-port=5672
 # Configure the AMQP connector to write to the `prices` address
 mp.messaging.outgoing.generated-price.connector=smallrye-amqp

--- a/quarkus-test-service-amq/src/main/java/io/quarkus/test/services/AmqContainer.java
+++ b/quarkus-test-service-amq/src/main/java/io/quarkus/test/services/AmqContainer.java
@@ -13,7 +13,7 @@ import io.quarkus.test.services.containers.model.AmqProtocol;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface AmqContainer {
 
-    String image() default "quay.io/artemiscloud/activemq-artemis-broker:0.1.2";
+    String image() default "quay.io/artemiscloud/activemq-artemis-broker:1.0.22";
 
     String expectedLog() default "Artemis Console available";
 


### PR DESCRIPTION
### Summary

- service name seems to be changed since 3.5.0.CR1 from amq-broker-amqp to amq-amqp. I didn't find a commit that caused it yet, but I'm clear that it works with 3.4.3 and that oc get service says amq-amqp and this fixes failing OC test
- we are using old image version, let's use the same version as dev services are using

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)