### PR TITLE
Disable SurefireDebugIT on Quarkus snapshot due to different version used by bumped RestAssured which is causing class loading issues

### DIFF
--- a/examples/debug/src/test/java/io/quarkus/qe/debug/SureFireDebugIT.java
+++ b/examples/debug/src/test/java/io/quarkus/qe/debug/SureFireDebugIT.java
@@ -21,7 +21,12 @@ import io.quarkus.maven.it.MojoTestBase;
 import io.quarkus.maven.it.verifier.MavenProcessInvocationResult;
 import io.quarkus.maven.it.verifier.RunningInvoker;
 import io.quarkus.test.scenarios.annotations.DisabledOnNative;
+import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusSnapshot;
 
+// FIXME: run tests on Quarkus snapshot as well when we are on 3.6.x
+//   we can't run them now due to conflicting Groovy versions used by RestAssured library
+//   which is causing class loading issues when on 999-SNAPSHOT
+@DisabledOnQuarkusSnapshot(reason = "RestAssured 5.3.2 is using different Groovy version than 5.3.0")
 @DisabledOnOs(WINDOWS)
 @DisabledOnNative
 public class SureFireDebugIT extends MojoTestBase {


### PR DESCRIPTION
### Summary

Added some logging inside test and got pretty explanative exception

```
java.lang.ExceptionInInitializerError
throwable is m: null
	at org.codehaus.groovy.reflection.ClassInfo.isValidWeakMetaClass(ClassInfo.java:283)
	at org.codehaus.groovy.reflection.ClassInfo.getMetaClassForClass(ClassInfo.java:253)
	at org.codehaus.groovy.reflection.ClassInfo.getMetaClass(ClassInfo.java:309)
	at io.restassured.authentication.NoAuthScheme.$getStaticMetaClass(NoAuthScheme.groovy)
	at io.restassured.authentication.NoAuthScheme.<init>(NoAuthScheme.groovy)
	at io.restassured.RestAssured.<clinit>(RestAssured.java:355)
	at io.quarkus.test.bootstrap.RestService.start(RestService.java:66)
	at io.quarkus.test.bootstrap.QuarkusScenarioBootstrap.launchService(QuarkusScenarioBootstrap.java:170)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at io.quarkus.test.bootstrap.QuarkusScenarioBootstrap.beforeAll(QuarkusScenarioBootstrap.java:71)
	at io.quarkus.test.debug.SureFireDebugProvider.invoke(SureFireDebugProvider.java:68)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:385)
	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
	at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:507)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:495)
Caused by: groovy.lang.GroovyRuntimeException: Conflicting module versions. Module [groovy-xml is loaded in version 4.0.11 and you are trying to load version 4.0.6
	at org.codehaus.groovy.runtime.metaclass.MetaClassRegistryImpl$DefaultModuleListener.onModule(MetaClassRegistryImpl.java:524)
	at org.codehaus.groovy.runtime.m12n.ExtensionModuleScanner.scanExtensionModuleFromProperties(ExtensionModuleScanner.java:87)
	at org.codehaus.groovy.runtime.m12n.ExtensionModuleScanner.scanExtensionModuleFromMetaInf(ExtensionModuleScanner.java:81)
	at org.codehaus.groovy.runtime.m12n.ExtensionModuleScanner.scanClasspathModulesFrom(ExtensionModuleScanner.java:63)
	at org.codehaus.groovy.runtime.m12n.ExtensionModuleScanner.scanClasspathModules(ExtensionModuleScanner.java:54)
	at org.codehaus.groovy.runtime.metaclass.MetaClassRegistryImpl.<init>(MetaClassRegistryImpl.java:133)
	at org.codehaus.groovy.runtime.metaclass.MetaClassRegistryImpl.<init>(MetaClassRegistryImpl.java:94)
	at groovy.lang.GroovySystem.<clinit>(GroovySystem.java:37)
	... 15 more
```

This issue is automatically fixed when we bump Quarkus version to 3.6.x, I tested it with 999-SNAPHOT and issue is not there. I think it goes down to this bump https://github.com/quarkusio/quarkus/pull/36080.

Daily build fails because of this.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)