### PR TITLE
OpenShift environment variables with dashes or other special chars in name must be also present in lower priority dotted config source to be matched

### DIFF
--- a/quarkus-test-openshift/pom.xml
+++ b/quarkus-test-openshift/pom.xml
@@ -33,6 +33,11 @@
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
         </dependency>
+        <!-- Used to transform configuration properties to environment variables -->
+        <dependency>
+            <groupId>io.smallrye.config</groupId>
+            <artifactId>smallrye-config-common</artifactId>
+        </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-builder</artifactId>

--- a/quarkus-test-service-kafka/src/main/resources/strimzi-operator-kafka-instance.yaml
+++ b/quarkus-test-service-kafka/src/main/resources/strimzi-operator-kafka-instance.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kafka-instance
 spec:
   kafka:
-    version: 3.4.0
+    version: 3.6.0
     replicas: 1
     listeners:
       - name: plain


### PR DESCRIPTION
### Summary

#904 and #917 follow-up

Right now OpenShift tests that has dashes or other non-alphanumeric charcters in property key name (between dots) are not resolved if they are also not present in dotted config source as explain by Quarkus docs https://quarkus.io/version/main/guides/config-reference#environment-variables. This PR adds these properties as Quarkus Application config source and thus helps SR Config to resolve them.

Also bumps Kafka operator version so that we can test related tests and Kafka operator doesn't support 3.4.0 version anymore.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)