### PR TITLE
Treat x.y.999-SNAPSHOT as snapshot version

### DIFF
--- a/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/annotations/DisabledOnQuarkusSnapshotCondition.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/annotations/DisabledOnQuarkusSnapshotCondition.java
@@ -31,6 +31,6 @@ public class DisabledOnQuarkusSnapshotCondition implements ExecutionCondition {
     }
 
     public static boolean isQuarkusSnapshotVersion() {
-        return QUARKUS_SNAPSHOT_VERSION.equals(QuarkusProperties.getVersion());
+        return QuarkusProperties.getVersion().contains(QUARKUS_SNAPSHOT_VERSION); // to cover cases like 3.2.999-SNAPSHOT
     }
 }


### PR DESCRIPTION
### Summary

Treat x.y.999-SNAPSHOT as snapshot version

Port of one change from https://github.com/quarkus-qe/quarkus-test-framework/pull/920
To cover cases like 3.2.999-SNAPSHOT and whatever future 3.y.999-SNAPSHOT

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)