### PR TITLE
Bump kafka CRD version to 3.5.0

### DIFF
--- a/quarkus-test-service-kafka/src/main/resources/strimzi-operator-kafka-instance.yaml
+++ b/quarkus-test-service-kafka/src/main/resources/strimzi-operator-kafka-instance.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kafka-instance
 spec:
   kafka:
-    version: 3.4.0
+    version: 3.5.0
     replicas: 1
     listeners:
       - name: plain


### PR DESCRIPTION
### Summary

* With updates to Strimzi operator, anything below 3.4.0 does not work. Also bumping this because 1.2.z RHBQ 2.13 branch got bumped to 3.5.0 as Kafka seems to be pursuing aggressive update policy.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)