### PR TITLE
OCP env vars used by Quarkus runtime must be uppercase to match non-kebab cases

### DIFF
--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
@@ -824,7 +824,7 @@ public final class OpenShiftClient {
     private static Map<String, String> convertPropertiesToEnvironment(Map<String, String> properties) {
         HashMap<String, String> environment = new HashMap<>(properties.size());
         properties.forEach((property, value) -> {
-            String variable = StringUtil.replaceNonAlphanumericByUnderscores(property);
+            String variable = StringUtil.replaceNonAlphanumericByUnderscores(property).toUpperCase();
             environment.put(variable, value);
         });
         return environment;


### PR DESCRIPTION
### Summary

This fixes `io.quarkus.ts.opentelemetry.reactive.OpenShiftOpentelemetryReactiveIT.testContextPropagation`, `io.quarkus.ts.opentelemetry.OpenShiftOpenTelemetryIT.testContextPropagation`.

Docs https://quarkus.io/guides/config-reference#environment-variables says that as second option is tested `foo_BAR_baz - Replace each character that is neither alphanumeric nor _ with _ ` so I expected original case (mostly lower case) will work, but I didn't consider following format:

```
io.quarkus.ts.opentelemetry.PingPongService/mp-rest/url=${pongservice_url}:${pongservice_port}
```

For which I get exception like this:

```
Invalid REST Client URL used: 'http://pongservice-ts-yfyycuckno.apps.ocp4-13.dynamic.quarkus:tcp://172.30.209.30:8080/hello'
```

This certainly seems like a bug, but it should be noted `pongservice_port` is rather snake-case than kebab-case.

I've opened https://github.com/quarkusio/quarkus/issues/36671.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)