### PR TITLE
Use Kafka 3.5 as AMQ operator does not support 3.6

### DIFF
--- a/quarkus-test-service-kafka/src/main/resources/strimzi-operator-kafka-instance.yaml
+++ b/quarkus-test-service-kafka/src/main/resources/strimzi-operator-kafka-instance.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kafka-instance
 spec:
   kafka:
-    version: 3.6.0
+    version: 3.5.0
     replicas: 1
     listeners:
       - name: plain


### PR DESCRIPTION
### Summary

`OperatorOpenShiftAmqStreamsKafkaStreamIT` fails as AMQ operator `amqstreams.v2.5.1-0` only supports 3.5 and 3.4 so you were right here https://github.com/quarkus-qe/quarkus-test-framework/pull/925.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)