### PR TITLE
Skip Quarkus build done my maven plugin in modules where we experienced race on Windows to find out if its related

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -353,7 +353,7 @@ jobs:
       - name: Build in Native mode
         shell: bash
         run: |
-          mvn -B -fae -s .github/mvn-settings.xml clean install -Pframework,examples,native,skip-tests-on-windows-in-native -Dquarkus.native.container-build=false -Dquarkus.platform.version="${{ matrix.quarkus-version }}"
+          mvn -B -fae -s .github/mvn-settings.xml clean install -Pframework,examples,native -Dquarkus.native.container-build=false -Dquarkus.platform.version="${{ matrix.quarkus-version }}"
       - name: Zip Artifacts
         shell: bash
         if: failure()

--- a/examples/blocking-reactive-model/pom.xml
+++ b/examples/blocking-reactive-model/pom.xml
@@ -9,6 +9,10 @@
     </parent>
     <artifactId>examples-blocking-reactive</artifactId>
     <name>Quarkus - Test Framework - Examples - Blocking + Reactive Model</name>
+    <properties>
+        <!-- Skip build since our framework will build own executable anyway as it detects build-time properties -->
+        <quarkus.build.skip>true</quarkus.build.skip>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -59,34 +63,6 @@
                     <artifactId>quarkus-openshift</artifactId>
                 </dependency>
             </dependencies>
-        </profile>
-        <!-- Skipped on Windows in a native mode due to https://github.com/quarkusio/quarkus/issues/27061 -->
-        <profile>
-            <id>skip-tests-on-windows-in-native</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-                <property>
-                    <name>native</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
     </profiles>
 </project>

--- a/examples/consul/pom.xml
+++ b/examples/consul/pom.xml
@@ -66,5 +66,17 @@
                 </dependency>
             </dependencies>
         </profile>
+        <profile>
+            <id>skip-build-on-windows</id>
+            <activation>
+                <os>
+                    <family>windows</family>
+                </os>
+            </activation>
+            <properties>
+                <!-- Skip build to see if we still experience race on Windows -->
+                <quarkus.build.skip>true</quarkus.build.skip>
+            </properties>
+        </profile>
     </profiles>
 </project>

--- a/examples/management/pom.xml
+++ b/examples/management/pom.xml
@@ -9,6 +9,10 @@
     </parent>
     <artifactId>examples-management</artifactId>
     <name>Quarkus - Test Framework - Examples - Management Interface</name>
+    <properties>
+        <!-- Skip build since our framework will build own executable anyway as it detects build-time properties -->
+        <quarkus.build.skip>true</quarkus.build.skip>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
### Summary

So far we experienced race on Windows in native mode in 3 example modules: `consul`, `management`, `blocking-reactive-modul`. Please see daily build failures. 

While in CI we see failures pretty regularly, I couldn't reproduce it in hundred of attempt (maybe related to Windows machine resources). I presume the root of issue is in Quarkus, but can't really be sure if it is not related to fact that Quarkus Maven plugin builds native executable and right after this, we build it again from our framework (for there are build time properties detected).

- I propose to skip Quarkus build performed by plugin completely in all modes / operating systems in `examples-blocking-reactive` and `management` as this executable is actually never used, we build a new one.
- For `examples/consul` I propose to only skip it in Windows, because there at least once is executable created by plugin used (not that it matter IMO).
- `examples-blocking-reactive` is now _temporarily_ enabled till it fails again (for I want to see if it also fails when the plugin is skipped

Judging by the nature of the failure (race for file that is not created by the plugin), we are going to have it disable in next days when we experience failure, but it is already failing every other day and this skipping was suggested here: https://github.com/quarkusio/quarkus/issues/27061#issuecomment-1715525060. I want to be able to prove skipping plugin build will make no difference.

UPDATE: my current plan is to keep it failing and introduce new code in next days that will print out information on processes involved in race.


Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)