### PR TITLE
List running processes and file handles when native build fails on Window

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -328,6 +328,12 @@ jobs:
       - name: Install helmfile through windows scoop
         shell: bash
         run: scoop install helmfile
+      - name: Download Sysinternals Handle program used for native race debugging
+        shell: pwsh
+        run: Invoke-WebRequest https://download.sysinternals.com/files/Handle.zip -OutFile .\handle.zip
+      - name: Unzip Sysinternals Handle
+        shell: pwsh
+        run: Expand-Archive .\handle.zip -DestinationPath .
       - name: Download Maven Repo
         uses: actions/download-artifact@v3
         with:
@@ -353,7 +359,7 @@ jobs:
       - name: Build in Native mode
         shell: bash
         run: |
-          mvn -B -fae -s .github/mvn-settings.xml clean install -Pframework,examples,native -Dquarkus.native.container-build=false -Dquarkus.platform.version="${{ matrix.quarkus-version }}"
+          mvn -B -fae -s .github/mvn-settings.xml clean install -Pframework,examples,native -Dquarkus.native.container-build=false -Dquarkus.platform.version="${{ matrix.quarkus-version }}" -Denable-win-race-debug=true
       - name: Zip Artifacts
         shell: bash
         if: failure()


### PR DESCRIPTION
### Summary

It's literally impossible for me to reproduce it outside of GH CI, wasted incredible amount of time on that. Daily fails regularly, let's print out all processes and open handles. I hope it will allow me to better determine concrete process, though I'm bit worried I know result already (shared parent process pid should be same as of the one running tests).

related to: https://github.com/quarkusio/quarkus/issues/27061

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)