### PR TITLE
Drop disabling on previous Quarkus versions as this framework is branched and MP test that tests nothing

### DIFF
--- a/examples/greetings/src/test/java/io/quarkus/qe/DevModeGreetingResourceIT.java
+++ b/examples/greetings/src/test/java/io/quarkus/qe/DevModeGreetingResourceIT.java
@@ -10,12 +10,10 @@ import org.junit.jupiter.api.TestMethodOrder;
 
 import io.quarkus.test.bootstrap.DevModeQuarkusService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
 import io.quarkus.test.services.DevModeQuarkusApplication;
 import io.quarkus.test.utils.AwaitilityUtils;
 
 @QuarkusScenario
-@DisabledOnQuarkusVersion(version = "3.0.0.CR2", reason = "Continuous Testing page was added to DEV UI in Quarkus 3.0.0.Final")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class DevModeGreetingResourceIT {
 

--- a/examples/infinispan/src/test/java/io/quarkus/qe/books/BaseBookCacheIT.java
+++ b/examples/infinispan/src/test/java/io/quarkus/qe/books/BaseBookCacheIT.java
@@ -6,10 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
 import io.restassured.http.ContentType;
 
-@DisabledOnQuarkusVersion(version = "1\\..*", reason = "Auto marshallers do not work on Quarkus 1.x")
 public abstract class BaseBookCacheIT {
 
     private static final String BOOK_TITLE = "testBook";

--- a/examples/kafka-registry/src/test/java/io/quarkus/qe/OpenShiftStrimziKafkaWithRegistryMessagingIT.java
+++ b/examples/kafka-registry/src/test/java/io/quarkus/qe/OpenShiftStrimziKafkaWithRegistryMessagingIT.java
@@ -2,9 +2,7 @@
 package io.quarkus.qe;
 
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
 
-@DisabledOnQuarkusVersion(version = "(3\\.[0]\\..*)", reason = "Breaking change in Quarkus 3.1 - Apicurio Rest Client is not compatible with Apicurio Registry 2.2.5.Final")
 @OpenShiftScenario
 public class OpenShiftStrimziKafkaWithRegistryMessagingIT extends StrimziKafkaWithRegistryMessagingIT {
 

--- a/examples/kafka-registry/src/test/java/io/quarkus/qe/StrimziKafkaWithRegistryMessagingIT.java
+++ b/examples/kafka-registry/src/test/java/io/quarkus/qe/StrimziKafkaWithRegistryMessagingIT.java
@@ -17,12 +17,10 @@ import io.quarkus.test.bootstrap.KafkaService;
 import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
 import io.quarkus.test.services.KafkaContainer;
 import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.test.services.containers.model.KafkaVendor;
 
-@DisabledOnQuarkusVersion(version = "(3\\.[0]\\..*)", reason = "Breaking change in Quarkus 3.1 - Apicurio Rest Client is not compatible with Apicurio Registry 2.2.5.Final")
 @QuarkusScenario
 public class StrimziKafkaWithRegistryMessagingIT {
 

--- a/examples/microprofile/src/test/java/io/quarkus/qe/VerifyNonAppEndpointsIT.java
+++ b/examples/microprofile/src/test/java/io/quarkus/qe/VerifyNonAppEndpointsIT.java
@@ -12,8 +12,6 @@ import org.junit.jupiter.api.Test;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnNative;
-import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusSnapshot;
-import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
 import io.quarkus.test.services.QuarkusApplication;
 
 @DisabledOnNative(reason = "Due to high native build execution time in every restart")
@@ -50,14 +48,6 @@ public class VerifyNonAppEndpointsIT {
         givenNonAppRootPath("/");
         whenUpdateProperties();
         thenNonAppEndpointsShouldBeNotFound("/api");
-    }
-
-    @DisabledOnQuarkusVersion(version = "2\\..*", reason = "Redirection is no longer supported in 2.x")
-    @DisabledOnQuarkusSnapshot(reason = "Redirection is no longer supported in 999-SNAPSHOT")
-    @Test
-    public void verifyNonAppRootPathIsRedirected() {
-        givenRootPath("/api");
-        givenNonAppRootPath("/q");
     }
 
     private void givenNonAppRootPath(String path) {

--- a/quarkus-test-helm/src/test/java/io/quarkus/test/QuarkusHelmClientIT.java
+++ b/quarkus-test-helm/src/test/java/io/quarkus/test/QuarkusHelmClientIT.java
@@ -9,11 +9,9 @@ import org.junit.jupiter.api.condition.EnabledIf;
 
 import io.quarkus.test.bootstrap.QuarkusHelmClient;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
 
 @Tag("quarkus-helm")
 @QuarkusScenario
-@DisabledOnQuarkusVersion(version = "1\\..*", reason = "Quarkus Helm not supported")
 @EnabledIf(value = "io.quarkus.test.bootstrap.HelmUtils#isHelmInstalled", disabledReason = "Helm needs to be locally installed")
 public class QuarkusHelmClientIT {
 


### PR DESCRIPTION
### Summary

- we don't need to disable tests for older versions (and thus evaluate execution conditions) for we have branched FW
- `VerifyNonAppEndpointsIT#verifyNonAppRootPathIsRedirected` sets properties, but doesn't restart or test anything, it's nonsense

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)