### PR TITLE
Fix tests using Apicurio registry by using 2.4.x-release Docker image tag as previous tags do not have manifest

### DIFF
--- a/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/model/KafkaRegistry.java
+++ b/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/model/KafkaRegistry.java
@@ -2,7 +2,7 @@ package io.quarkus.test.services.containers.model;
 
 public enum KafkaRegistry {
     CONFLUENT("confluentinc/cp-schema-registry", "7.3.3", "/", 8081),
-    APICURIO("quay.io/apicurio/apicurio-registry-mem", "2.4.2.Final", "/apis", 8080);
+    APICURIO("quay.io/apicurio/apicurio-registry-mem", "2.4.x-release", "/apis", 8080);
 
     private final String image;
     private final String defaultVersion;


### PR DESCRIPTION
### Summary

I tried 2.4.2.Final, ..., 2.14.4.Final both on quay.io/apicurio/apicurio-registry-mem and https://hub.docker.com/r/apicurio/apicurio-registry-mem/tags and they just don't seem to have a manifest. Waited until now, but we need to fix TS / FW daily builds so that we don't miss other bugs. Not sure if the issue is temporary or it was an intention. I can't see anything about it here https://www.apicur.io/blog/.

Using 2.14.x stream as upstream Java libraries are adapted with 2.4.14.Final ATM: https://github.com/quarkusio/quarkus/blob/6198267029b4feba6c61153d9feff4a25cb25e23/bom/application/pom.xml#L207

This needs to be released and propagated to TS.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)