### PR TITLE
[1.2.z] Don't enforce lowercase Kafka registry image name as Apicurio Docker tag don't get recognized

### DIFF
--- a/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/KafkaContainerManagedResourceBuilder.java
+++ b/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/KafkaContainerManagedResourceBuilder.java
@@ -87,7 +87,7 @@ public class KafkaContainerManagedResourceBuilder implements ManagedResourceBuil
             }
         }
 
-        return registryImage.toLowerCase();
+        return registryImage;
     }
 
     @Override


### PR DESCRIPTION
### Summary

Docker tag `2.2.5.final` is not recognized, but `2.2.5.Final` is.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)