### PR TITLE
Fix Apicurio docker image pull as Docker tag is case sensitive and use fixed Apicurio image

### DIFF
--- a/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/KafkaContainerManagedResourceBuilder.java
+++ b/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/KafkaContainerManagedResourceBuilder.java
@@ -87,7 +87,7 @@ public class KafkaContainerManagedResourceBuilder implements ManagedResourceBuil
             }
         }
 
-        return registryImage.toLowerCase();
+        return registryImage;
     }
 
     @Override

--- a/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/model/KafkaRegistry.java
+++ b/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/model/KafkaRegistry.java
@@ -2,7 +2,7 @@ package io.quarkus.test.services.containers.model;
 
 public enum KafkaRegistry {
     CONFLUENT("confluentinc/cp-schema-registry", "7.3.3", "/", 8081),
-    APICURIO("quay.io/apicurio/apicurio-registry-mem", "2.4.x-release", "/apis", 8080);
+    APICURIO("quay.io/apicurio/apicurio-registry-mem", "2.4.14.Final", "/apis", 8080);
 
     private final String image;
     private final String defaultVersion;


### PR DESCRIPTION
### Summary

Here I tried to fix Docker pull #951, but it seems the root cause of failures was in tag. Docker image tag `2.4.14.Final` will work, but `2.4.14.final` will not.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)