### PR TITLE
Move baseline from Java 11 to Java 17

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 11 ]
+        java: [ 17 ]
     steps:
       - uses: actions/checkout@v4
       - name: Reclaim Disk Space
@@ -41,7 +41,7 @@ jobs:
     strategy:
       matrix:
         quarkus-version: ["current"]
-        java: [ 11, 17 ]
+        java: [ 17, 21 ]
     steps:
       - uses: actions/checkout@v4
       - name: Reclaim Disk Space
@@ -89,7 +89,7 @@ jobs:
     strategy:
       matrix:
         quarkus-version: ["999-SNAPSHOT"]
-        java: [ 11, 17 ]
+        java: [ 17, 21 ]
     steps:
       - uses: actions/checkout@v4
       - name: Reclaim Disk Space
@@ -253,7 +253,7 @@ jobs:
     needs: quarkus-main-build
     strategy:
       matrix:
-        java: [ 11, 17 ]
+        java: [ 17, 21 ]
         quarkus-version: ["999-SNAPSHOT"]
     steps:
       - uses: actions/checkout@v4
@@ -307,7 +307,8 @@ jobs:
       matrix:
         java: [ 17 ]
         quarkus-version: ["999-SNAPSHOT"]
-        graalvm-version: ["mandrel-23.0.1.2-Final"]
+        graalvm-version: ["mandrel-latest"]
+        graalvm-java: ["21"]
     steps:
       - uses: actions/checkout@v4
       - name: Install JDK {{ matrix.java }}
@@ -350,7 +351,7 @@ jobs:
         uses: graalvm/setup-graalvm@v1
         with:
           version: ${{ matrix.graalvm-version }}
-          java-version: ${{ matrix.java }}
+          java-version: ${{ matrix.graalvm-java }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Configure Pagefile
         # Increased the page-file size due to memory-consumption of native-image command
@@ -379,7 +380,7 @@ jobs:
 #    strategy:
 #      matrix:
 #        quarkus-version: ["999-SNAPSHOT"]
-#        java: [ 11 ]
+#        java: [ 17 ]
 #    steps:
 #      - uses: actions/checkout@v4
 #      - name: Reclaim Disk Space

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 11 ]
+        java: [ 17 ]
     steps:
       - uses: actions/checkout@v4
       - name: Reclaim Disk Space
@@ -39,7 +39,7 @@ jobs:
     needs: validate-format
     strategy:
       matrix:
-        java: [ 11 ]
+        java: [ 17 ]
     steps:
       - uses: actions/checkout@v4
       - name: Reclaim Disk Space
@@ -232,7 +232,7 @@ jobs:
     needs: quarkus-main-build
     strategy:
       matrix:
-        java: [ 11 ]
+        java: [ 17 ]
         quarkus-version: ["999-SNAPSHOT"]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,11 +29,11 @@ jobs:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
-      - name: Install JDK 11
+      - name: Install JDK 17
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 17
           check-latest: true
 
       - name: Configure Git author

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,7 +105,7 @@ Be sure to test your pull request in:
 If you have not done so on this machine, you need to:
  
 * Install Git and configure your GitHub access
-* Install Java SDK 11+ (OpenJDK recommended)
+* Install Java SDK 17+ (OpenJDK recommended)
 * Install Docker - Check [the installation guide](https://docs.docker.com/install/), and [the MacOS installation guide](https://docs.docker.com/docker-for-mac/install/)
 
 ### Code Style

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Main features:
 
 # Requirements
 
-- JDK 11+
+- JDK 17+
 - Maven 3+
 - Docker
 - Helm

--- a/examples/quarkus-helm/src/main/docker/Dockerfile.jvm
+++ b/examples/quarkus-helm/src/main/docker/Dockerfile.jvm
@@ -75,7 +75,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-11:1.14
+FROM registry.access.redhat.com/ubi8/openjdk-17:latest
 
 ENV LANGUAGE='en_US:en'
 

--- a/examples/quarkus-helm/src/main/docker/Dockerfile.native
+++ b/examples/quarkus-helm/src/main/docker/Dockerfile.native
@@ -14,7 +14,7 @@
 # docker run -i --rm -p 8080:8080 quarkus/helm-quickstart
 #
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/pom.xml
+++ b/pom.xml
@@ -33,8 +33,8 @@
         <source-plugin.version>3.3.0</source-plugin.version>
         <javadoc-plugin.version>3.6.2</javadoc-plugin.version>
         <maven.compiler.parameters>true</maven.compiler.parameters>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <maven.javadoc.failOnError>false</maven.javadoc.failOnError>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/quarkus-test-images/src/main/resources/Dockerfile.jvm
+++ b/quarkus-test-images/src/main/resources/Dockerfile.jvm
@@ -75,7 +75,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-17:1.14
+FROM registry.access.redhat.com/ubi8/openjdk-17:latest
 
 ENV LANGUAGE='en_US:en'
 

--- a/quarkus-test-images/src/main/resources/Dockerfile.legacy-jar
+++ b/quarkus-test-images/src/main/resources/Dockerfile.legacy-jar
@@ -76,7 +76,7 @@
 #
 ###
 
-FROM registry.access.redhat.com/ubi8/openjdk-17:1.14
+FROM registry.access.redhat.com/ubi8/openjdk-17:latest
 
 ENV LANGUAGE='en_US:en'
 

--- a/quarkus-test-images/src/main/resources/Dockerfile.native
+++ b/quarkus-test-images/src/main/resources/Dockerfile.native
@@ -14,7 +14,7 @@
 # docker run -i --rm -p 8080:8080 quarkus/code-with-quarkus
 #
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \


### PR DESCRIPTION
### Summary

Upstream is moving baseline to Java 17 - https://github.com/quarkusio/quarkus/pull/37335, therefore we need to move right now.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)