### PR TITLE
Use Quarkus Maven plugin to build native executables

### DIFF
--- a/examples/amq-amqp/pom.xml
+++ b/examples/amq-amqp/pom.xml
@@ -34,4 +34,20 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>${quarkus.platform.group-id}</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <version>${quarkus.platform.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/examples/amq-tcp/pom.xml
+++ b/examples/amq-tcp/pom.xml
@@ -35,4 +35,20 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>${quarkus.platform.group-id}</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <version>${quarkus.platform.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/ProdQuarkusApplicationManagedResourceBuilder.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/ProdQuarkusApplicationManagedResourceBuilder.java
@@ -157,8 +157,17 @@ public class ProdQuarkusApplicationManagedResourceBuilder extends ArtifactQuarku
     }
 
     private Path buildArtifact() {
-        if (QuarkusProperties.isNativePackageType(getContext()) && OS.WINDOWS.isCurrentOs()) {
-            return new QuarkusMavenPluginBuildHelper(this).buildNativeExecutable();
+        if (QuarkusProperties.isNativePackageType(getContext())) {
+            return new QuarkusMavenPluginBuildHelper(this)
+                    .buildNativeExecutable()
+                    .orElseGet(() -> {
+                        LOG.warn("""
+                                Quarkus Maven plugin is missing, falling back to Quarkus bootstrap strategy.
+                                Please add 'quarkus-maven-plugin' to your project as the bootstrap strategy will be removed
+                                in the future.
+                                """);
+                        return buildArtifactUsingQuarkusBootstrap();
+                    });
         }
         return buildArtifactUsingQuarkusBootstrap();
     }


### PR DESCRIPTION
### Summary

Fact that (so far) #949 fixed win race issue when building native executable on Windows tells me that by using `QuarkusBootstrap` class directly we just hope our setup is same as Quarkus Maven plugin is using. Users will have native executable built by Quarkus maven plugin, and so should we.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)