### PR TITLE
Add ImageUtil class

### DIFF
--- a/quarkus-test-images/src/main/java/io/quarkus/test/utils/ImageUtil.java
+++ b/quarkus-test-images/src/main/java/io/quarkus/test/utils/ImageUtil.java
@@ -1,0 +1,36 @@
+package io.quarkus.test.utils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public final class ImageUtil {
+
+    private static final String COLON = ":";
+    private static final Map<String, String[]> PROPERTY_TO_IMAGE = new HashMap<>();
+
+    private ImageUtil() {
+        // util class
+    }
+
+    public static String getImageVersion(String imageProperty) {
+        return getImage(imageProperty)[1];
+    }
+
+    public static String getImageName(String imageProperty) {
+        return getImage(imageProperty)[0];
+    }
+
+    private static String[] getImage(String imageProperty) {
+        return PROPERTY_TO_IMAGE.computeIfAbsent(imageProperty, ip -> {
+            final String image = System.getProperty(imageProperty);
+            if (image == null) {
+                throw new IllegalStateException(String.format("System property '%s' is missing.", imageProperty));
+            }
+            if (!image.contains(COLON)) {
+                throw new IllegalStateException(String.format("'%s' is not valid Docker image", image));
+            }
+            return image.split(COLON);
+        });
+    }
+
+}


### PR DESCRIPTION
### Summary

Retrieves image name and version from Maven property. This util class primarily will be used in TS.
It is not included in any test in FW.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)