### PR TITLE
Update Kafka utils to use images from Maven properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,10 @@
         <quarkus.build.skip>${skipTests}</quarkus.build.skip>
         <!-- Oracle image - we aim to use same version as Dev Services for Oracle so that we only download one image -->
         <oracle.image>docker.io/gvenzl/oracle-free:23-slim-faststart</oracle.image>
+        <kafka.registry.confluent.image>confluentinc/cp-schema-registry:7.3.3</kafka.registry.confluent.image>
+        <kafka.registry.apicurio.image>quay.io/apicurio/apicurio-registry-mem:2.4.14.Final</kafka.registry.apicurio.image>
+        <kafka.vendor.confluent.image>confluentinc/cp-kafka:7.3.3</kafka.vendor.confluent.image>
+        <kafka.vendor.strimzi.image>quay.io/strimzi/kafka:0.34.0-kafka-3.4.0</kafka.vendor.strimzi.image>
     </properties>
     <distributionManagement>
         <snapshotRepository>
@@ -345,6 +349,10 @@
                         <configuration>
                             <systemProperties>
                                 <oracle.image>${oracle.image}</oracle.image>
+                                <kafka.registry.confluent.image>${kafka.registry.confluent.image}</kafka.registry.confluent.image>
+                                <kafka.registry.apicurio.image>${kafka.registry.apicurio.image}</kafka.registry.apicurio.image>
+                                <kafka.vendor.confluent.image>${kafka.vendor.confluent.image}</kafka.vendor.confluent.image>
+                                <kafka.vendor.strimzi.image>${kafka.vendor.strimzi.image}</kafka.vendor.strimzi.image>
                             </systemProperties>
                             <argLine>${jacoco.agent.argLine}</argLine>
                             <excludedGroups>${exclude.tests.with.tags}</excludedGroups>

--- a/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/model/KafkaRegistry.java
+++ b/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/model/KafkaRegistry.java
@@ -1,23 +1,26 @@
 package io.quarkus.test.services.containers.model;
 
-public enum KafkaRegistry {
-    CONFLUENT("confluentinc/cp-schema-registry", "7.3.3", "/", 8081),
-    APICURIO("quay.io/apicurio/apicurio-registry-mem", "2.4.14.Final", "/apis", 8080);
+import static io.quarkus.test.utils.ImageUtil.getImageName;
+import static io.quarkus.test.utils.ImageUtil.getImageVersion;
 
-    private final String image;
+public enum KafkaRegistry {
+    CONFLUENT("kafka.registry.confluent.image", "/", 8081),
+    APICURIO("kafka.registry.apicurio.image", "/apis", 8080);
+
+    private final String imageName;
     private final String defaultVersion;
     private final String path;
     private final int port;
 
-    KafkaRegistry(String image, String defaultVersion, String path, int port) {
-        this.image = image;
-        this.defaultVersion = defaultVersion;
+    KafkaRegistry(String imagePropertyName, String path, int port) {
+        this.imageName = getImageName(imagePropertyName);
+        this.defaultVersion = getImageVersion(imagePropertyName);
         this.path = path;
         this.port = port;
     }
 
     public String getImage() {
-        return image;
+        return imageName;
     }
 
     public String getDefaultVersion() {

--- a/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/model/KafkaVendor.java
+++ b/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/model/KafkaVendor.java
@@ -1,23 +1,26 @@
 package io.quarkus.test.services.containers.model;
 
-public enum KafkaVendor {
-    CONFLUENT("confluentinc/cp-kafka", "7.3.3", 9093, KafkaRegistry.CONFLUENT),
-    STRIMZI("quay.io/strimzi/kafka", "0.34.0-kafka-3.4.0", 9092, KafkaRegistry.APICURIO);
+import static io.quarkus.test.utils.ImageUtil.getImageName;
+import static io.quarkus.test.utils.ImageUtil.getImageVersion;
 
-    private final String image;
+public enum KafkaVendor {
+    CONFLUENT("kafka.vendor.confluent.image", 9093, KafkaRegistry.CONFLUENT),
+    STRIMZI("kafka.vendor.strimzi.image", 9092, KafkaRegistry.APICURIO);
+
+    private final String imageName;
     private final String defaultVersion;
     private final int port;
     private final KafkaRegistry registry;
 
-    KafkaVendor(String image, String defaultVersion, int port, KafkaRegistry registry) {
-        this.image = image;
-        this.defaultVersion = defaultVersion;
+    KafkaVendor(String imagePropertyName, int port, KafkaRegistry registry) {
+        this.imageName = getImageName(imagePropertyName);
+        this.defaultVersion = getImageVersion(imagePropertyName);
         this.port = port;
         this.registry = registry;
     }
 
     public String getImage() {
-        return image;
+        return imageName;
     }
 
     public String getDefaultVersion() {


### PR DESCRIPTION
### Summary

KafkaRegistry and KafkaVendor now using image defined in Maven properties. It helps track versions from one place.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Dependency update
- [x] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)