### PR TITLE
Revert "Release 1.4.0.Beta3"

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 name: Quarkus QE Test Framework
 release:
-  current-version: 1.4.0.Beta3
-  next-version: 1.4.0.Beta4
+  current-version: 1.4.0.Beta2
+  next-version: 1.4.0.Beta3


### PR DESCRIPTION
Reverts quarkus-qe/quarkus-test-framework#978 as [update of Kafka utils](https://github.com/quarkus-qe/quarkus-test-framework/pull/976) turned out to be a bad decision. It is not possible to retrieve systemProperties from FW parent POM in the Quarkus QE TS