### PR TITLE
Support OCP secrets with destination mount path

### DIFF
--- a/quarkus-test-core/src/main/java/io/quarkus/test/utils/PropertiesUtils.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/utils/PropertiesUtils.java
@@ -16,8 +16,10 @@ import org.junit.jupiter.api.condition.OS;
 
 public final class PropertiesUtils {
 
+    public static final String DESTINATION_TO_FILENAME_SEPARATOR = "|";
     public static final String RESOURCE_PREFIX = "resource::/";
     public static final String RESOURCE_WITH_DESTINATION_PREFIX = "resource_with_destination::";
+    public static final String SECRET_WITH_DESTINATION_PREFIX = "secret_with_destination::";
     public static final String RESOURCE_WITH_DESTINATION_SPLIT_CHAR = "\\|";
     public static final String RESOURCE_WITH_DESTINATION_PREFIX_MATCHER = ".*" + RESOURCE_WITH_DESTINATION_SPLIT_CHAR + ".*";
     public static final String SECRET_PREFIX = "secret::/";


### PR DESCRIPTION
### Summary

From user POV it's same as we already support for resources (config maps), I just wrote it slightly differently. Keycloak image has only certain dirs writable so I need to specify destination, but for certs can't use config maps as binary data needs to be base64 encoded as secrets do. I've tested it on what I am preparing for mTLS OIDC test (not that I'm done, but Keycloak starts with keystores and truststores).

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)