### PR TITLE
Do  ci-coverage name unique for Archive Coverage Report 

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -190,7 +190,7 @@ jobs:
       - name: Archive Coverage Report
         uses: actions/upload-artifact@v4
         with:
-          name: ci-coverage
+          name: ci-coverage${{ matrix.java }}
           path: coverage-report/target/site/jacoco
           retention-days: 1
   linux-build-native:


### PR DESCRIPTION
### Summary

With actions/upload-artifact@v4 the names should be unique so this commit is to fix this kind of error
`Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run`

https://github.com/quarkus-qe/quarkus-test-framework/actions/runs/7268621531/job/19805104185

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)