### PR TITLE
Allow to disable Linux containers detection execution condition as it can provide false positives when Docker host strategy is used and no CLI is available

### DIFF
--- a/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/execution/condition/AbstractQuarkusScenarioContainerExecutionCondition.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/execution/condition/AbstractQuarkusScenarioContainerExecutionCondition.java
@@ -16,6 +16,7 @@ import org.jboss.logging.Logger;
 import org.junit.jupiter.api.extension.ConditionEvaluationResult;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
+import io.quarkus.test.configuration.PropertyLookup;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.utils.Command;
 
@@ -32,12 +33,19 @@ public abstract class AbstractQuarkusScenarioContainerExecutionCondition impleme
     private static final String LINUX_CONTAINER_OS_TYPE = "linux";
     private static final String PODMAN = "podman";
     private static final String DOCKER_HOST = "DOCKER_HOST";
+    private static final PropertyLookup DOCKER_DETECTION_ENABLED = new PropertyLookup("ts.docker-detection-enabled", "true");
     private static Boolean areLinuxContainersSupported = null;
 
     @Override
     public final ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
         if (TRUE.equals(areLinuxContainersSupported)) {
-            // optimization - don't evaluate condition if we know Linux containers are available
+            // optimization - don't evaluate condition if we know Linux containers are available or evaluation is disabled
+            return ENV_SUPPORTS_LINUX_CONTAINERS;
+        }
+
+        // Docker detection implemented here leverage Docker CLI, however TestContainers does not require the CLI to work
+        if (!DOCKER_DETECTION_ENABLED.getAsBoolean()) {
+            areLinuxContainersSupported = TRUE;
             return ENV_SUPPORTS_LINUX_CONTAINERS;
         }
 


### PR DESCRIPTION
### Summary

Camel Quarkus QE does not install Docker on (some of?) their Windows machines, nor they start Docker on machines that only run OpenShift tests (this part is strange, because condition is only run for `@QuarkusScenario` but I'd need reproducer and time to be worried about OCP), therefore check for Docker CLI can give false positives when only DOCKER_HOST is set, but there is no Docker CLI installed.

My suggestion is that unless Camel Quarkus QE really needs this feature, we only add an option to disable this condition evaluation on Windows. We added this condition to be able to run tests on Windows when Docker is available and at the still time to run TS on Windows when Docker is not available.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)