### PR TITLE
Migrate hardcoded images to Maven properties

### DIFF
--- a/examples/database-mysql/src/test/java/io/quarkus/qe/database/mysql/AbstractMysqlReusableInstance.java
+++ b/examples/database-mysql/src/test/java/io/quarkus/qe/database/mysql/AbstractMysqlReusableInstance.java
@@ -14,7 +14,7 @@ public abstract class AbstractMysqlReusableInstance extends AbstractSqlDatabaseI
      * property `ts.database.container.reusable` is enabled on test.properties
      **/
 
-    @Container(image = "docker.io/mysql:8.0.30", port = 3306, expectedLog = "port: 3306  MySQL Community Server")
+    @Container(image = "${mysql.image}", port = 3306, expectedLog = "port: 3306  MySQL Community Server")
     public static MySqlService database = new MySqlService();
 
     static Integer containerPort;

--- a/examples/database-mysql/src/test/java/io/quarkus/qe/database/mysql/DevModeMySqlDatabaseIT.java
+++ b/examples/database-mysql/src/test/java/io/quarkus/qe/database/mysql/DevModeMySqlDatabaseIT.java
@@ -17,7 +17,7 @@ public class DevModeMySqlDatabaseIT extends AbstractSqlDatabaseIT {
     static final String MYSQL_DATABASE = "mydb";
     static final int MYSQL_PORT = 3306;
 
-    @Container(image = "docker.io/mysql:8.0", port = MYSQL_PORT, expectedLog = "ready for connections")
+    @Container(image = "${mysql.image}", port = MYSQL_PORT, expectedLog = "ready for connections")
     static DefaultService database = new DefaultService()
             .withProperty("MYSQL_ROOT_USER", MYSQL_USER)
             .withProperty("MYSQL_ROOT_PASSWORD", MYSQL_PASSWORD)

--- a/examples/database-postgresql/src/test/java/io/quarkus/qe/database/postgresql/DuplicatedPostgresqlDatabaseIT.java
+++ b/examples/database-postgresql/src/test/java/io/quarkus/qe/database/postgresql/DuplicatedPostgresqlDatabaseIT.java
@@ -1,7 +1,5 @@
 package io.quarkus.qe.database.postgresql;
 
-import static io.quarkus.qe.database.postgresql.PostgresqlDatabaseIT.POSTGRES_IMG;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -16,7 +14,7 @@ public class DuplicatedPostgresqlDatabaseIT {
 
     private static final int POSTGRESQL_PORT = 5432;
 
-    @Container(image = POSTGRES_IMG, port = POSTGRESQL_PORT, expectedLog = "is ready")
+    @Container(image = "${postgresql.image}", port = POSTGRESQL_PORT, expectedLog = "is ready")
     static PostgresqlService database = new PostgresqlService();
 
     @QuarkusApplication

--- a/examples/database-postgresql/src/test/java/io/quarkus/qe/database/postgresql/OpenShiftPostgresqlIT.java
+++ b/examples/database-postgresql/src/test/java/io/quarkus/qe/database/postgresql/OpenShiftPostgresqlIT.java
@@ -11,8 +11,9 @@ public class OpenShiftPostgresqlIT extends AbstractSqlDatabaseIT {
 
     private static final int POSTGRESQL_PORT = 5432;
 
-    @Container(image = "quay.io/quarkusqeteam/postgres:14.0", port = POSTGRESQL_PORT, expectedLog = "is ready")
-    static PostgresqlService database = new PostgresqlService();
+    @Container(image = "${postgresql.image}", port = POSTGRESQL_PORT, expectedLog = "is ready")
+    static PostgresqlService database = new PostgresqlService()
+            .withProperty("PGDATA", "/tmp/psql");
 
     @QuarkusApplication
     static RestService app = new RestService()

--- a/examples/database-postgresql/src/test/java/io/quarkus/qe/database/postgresql/PostgresqlDatabaseIT.java
+++ b/examples/database-postgresql/src/test/java/io/quarkus/qe/database/postgresql/PostgresqlDatabaseIT.java
@@ -10,9 +10,8 @@ import io.quarkus.test.services.QuarkusApplication;
 public class PostgresqlDatabaseIT extends AbstractSqlDatabaseIT {
 
     private static final int POSTGRESQL_PORT = 5432;
-    public static final String POSTGRES_IMG = "docker.io/postgres:13.8";
 
-    @Container(image = POSTGRES_IMG, port = POSTGRESQL_PORT, expectedLog = "is ready")
+    @Container(image = "${postgresql.image}", port = POSTGRESQL_PORT, expectedLog = "is ready")
     static PostgresqlService database = new PostgresqlService();
 
     @QuarkusApplication

--- a/examples/infinispan/src/test/java/io/quarkus/qe/books/BasicInfinispanBookCacheIT.java
+++ b/examples/infinispan/src/test/java/io/quarkus/qe/books/BasicInfinispanBookCacheIT.java
@@ -9,7 +9,7 @@ import io.quarkus.test.services.QuarkusApplication;
 @QuarkusScenario
 public class BasicInfinispanBookCacheIT extends BaseBookCacheIT {
 
-    @Container(image = "docker.io/infinispan/server:14.0", expectedLog = "Infinispan Server.*started in", port = 11222)
+    @Container(image = "${infinispan.image}", expectedLog = "Infinispan Server.*started in", port = 11222)
     static final InfinispanService infinispan = new InfinispanService();
 
     @QuarkusApplication

--- a/examples/infinispan/src/test/java/io/quarkus/qe/books/LegacyUsingJksInfinispanBookCacheIT.java
+++ b/examples/infinispan/src/test/java/io/quarkus/qe/books/LegacyUsingJksInfinispanBookCacheIT.java
@@ -9,7 +9,7 @@ import io.quarkus.test.services.QuarkusApplication;
 @QuarkusScenario
 public class LegacyUsingJksInfinispanBookCacheIT extends BaseBookCacheIT {
 
-    @Container(image = "docker.io/infinispan/server:13.0", expectedLog = "Infinispan Server.*started in", port = 11222)
+    @Container(image = "${infinispan-legacy.image}", expectedLog = "Infinispan Server.*started in", port = 11222)
     static final InfinispanService infinispan = new InfinispanService()
             .withConfigFile("/jks-config.yaml")
             .withSecretFiles("/jks/server.jks");

--- a/examples/infinispan/src/test/java/io/quarkus/qe/books/UsingJksInfinispanBookCacheIT.java
+++ b/examples/infinispan/src/test/java/io/quarkus/qe/books/UsingJksInfinispanBookCacheIT.java
@@ -9,7 +9,7 @@ import io.quarkus.test.services.QuarkusApplication;
 @QuarkusScenario
 public class UsingJksInfinispanBookCacheIT extends BaseBookCacheIT {
 
-    @Container(image = "docker.io/infinispan/server:14.0", expectedLog = "Infinispan Server.*started in", port = 11222)
+    @Container(image = "${infinispan.image}", expectedLog = "Infinispan Server.*started in", port = 11222)
     static final InfinispanService infinispan = new InfinispanService()
             .withConfigFile("infinispan.xml")
             .withSecretFiles("/jks/keystore.jks");

--- a/examples/keycloak/src/test/java/io/quarkus/qe/OpenShiftUsingCustomTemplateResourceIT.java
+++ b/examples/keycloak/src/test/java/io/quarkus/qe/OpenShiftUsingCustomTemplateResourceIT.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 import io.quarkus.test.bootstrap.KeycloakService;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
-import io.quarkus.test.services.Container;
+import io.quarkus.test.services.KeycloakContainer;
 import io.quarkus.test.services.QuarkusApplication;
 
 @OpenShiftScenario
@@ -18,7 +18,7 @@ public class OpenShiftUsingCustomTemplateResourceIT {
     private static final String CLIENT_ID_DEFAULT = "test-application-client";
     private static final String CLIENT_SECRET_DEFAULT = "test-application-client-secret";
 
-    @Container(image = "quay.io/keycloak/keycloak:22.0.1", expectedLog = "started", port = 8080)
+    @KeycloakContainer(command = { "start-dev", "--import-realm" })
     static final KeycloakService customkeycloak = new KeycloakService(DEFAULT_REALM_FILE, DEFAULT_REALM,
             DEFAULT_REALM_BASE_PATH);
 

--- a/examples/keycloak/src/test/resources/keycloak-custom-template.yaml
+++ b/examples/keycloak/src/test/resources/keycloak-custom-template.yaml
@@ -12,7 +12,8 @@ items:
       - name: latest
         from:
           kind: DockerImage
-          name: quay.io/keycloak/keycloak:22.0.1
+          # Hardcoded image is used only here, tests use one from KeycloakContainer
+          name: quay.io/keycloak/keycloak:23.0
 - apiVersion: apps.openshift.io/v1
   kind: DeploymentConfig
   metadata:

--- a/misc/jaeger-for-tracing.yaml
+++ b/misc/jaeger-for-tracing.yaml
@@ -75,6 +75,7 @@ items:
             app: 'jaeger'
         spec:
           containers:
+            # Image is used only in this configuration, no need in tracking the image in Maven properties
             - image: 'quay.io/jaegertracing/all-in-one:1.41'
               name: 'jaeger'
               env:

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,10 @@
         <quarkus.build.skip>${skipTests}</quarkus.build.skip>
         <!-- Oracle image - we aim to use same version as Dev Services for Oracle so that we only download one image -->
         <oracle.image>docker.io/gvenzl/oracle-free:23-slim-faststart</oracle.image>
+        <postgresql.image>docker.io/postgres:16.1</postgresql.image>
+        <mysql.image>docker.io/mysql:8.2.0</mysql.image>
+        <infinispan.image>docker.io/infinispan/server:14.0</infinispan.image>
+        <infinispan-legacy.image>docker.io/infinispan/server:13.0</infinispan-legacy.image>
     </properties>
     <distributionManagement>
         <snapshotRepository>
@@ -344,6 +348,10 @@
                         <configuration>
                             <systemProperties>
                                 <oracle.image>${oracle.image}</oracle.image>
+                                <postgresql.image>${postgresql.image}</postgresql.image>
+                                <mysql.image>${mysql.image}</mysql.image>
+                                <infinispan.image>${infinispan.image}</infinispan.image>
+                                <infinispan-legacy.image>${infinispan-legacy.image}</infinispan-legacy.image>
                             </systemProperties>
                             <argLine>${jacoco.agent.argLine}</argLine>
                             <excludedGroups>${exclude.tests.with.tags}</excludedGroups>


### PR DESCRIPTION
### Summary

Migrates all hardcoded images with versions into POM

It is not possible to get rid of hardcoded images in JaegerContainer, KeycloakContainer, AmqContainer, because FW system properties  will be ignored while using them in TS

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Dependency update
- [x] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)