### PR TITLE
Make Dependabot bump Quarkus BOM

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    ignore:
-      # For Quarkus Maven Plugin, updates are managed by the Quarkus Bom dependency
-      - dependency-name: io.quarkus:quarkus-maven-plugin
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
### Summary

I think we should let Dependabot bump Quarkus BOM as we keep forgetting doing it (and there is no point of doing it manually). Dependabot has ignore option that will allow us to skip bumps as long as we want to stick to old version and it always requires QE team approval anyway, so... I thought it wasn't working due to bug https://github.com/dependabot/dependabot-core/issues/7309 but now I hear that Quarkus Superheroes project has same setup. So my only explanation is that it can be related to quarkus-maven-plugin ignore rule. No idea why it was added here https://github.com/quarkus-qe/quarkus-test-framework/pull/147.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)