### PR TITLE
Fix daily action - rename artifacts to just maven repo

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -115,7 +115,7 @@ jobs:
       - name: Download Maven Repo
         uses: actions/download-artifact@v4
         with:
-          name: maven-repo-linux-build-jvm
+          name: maven-repo
           path: .
       - name: Extract Maven Repo
         shell: bash
@@ -225,7 +225,7 @@ jobs:
       - name: Download Maven Repo
         uses: actions/download-artifact@v4
         with:
-          name: maven-repo-linux-build-native
+          name: maven-repo
           path: .
       - name: Extract Maven Repo
         shell: bash
@@ -278,7 +278,7 @@ jobs:
       - name: Download Maven Repo
         uses: actions/download-artifact@v4
         with:
-          name: maven-repo-windows-build-jvm
+          name: maven-repo
           path: .
       - name: Extract Maven Repo
         shell: bash
@@ -338,7 +338,7 @@ jobs:
       - name: Download Maven Repo
         uses: actions/download-artifact@v4
         with:
-          name: maven-repo-windows-build-native
+          name: maven-repo
           path: .
       - name: Extract Maven Repo
         shell: bash


### PR DESCRIPTION
### Summary
This PR reverts change on daily.yaml made in #1000

Currently the downloaded artifacts are named maven-repo-<runtime>, which does not correspond to the one uploaded artifact "maven-repo". It leads to actions failing on non-found artifact.  See e.g. https://github.com/quarkus-qe/quarkus-test-framework/actions/runs/7304561952/job/19907115554  which fails on e.g. :
`Error: Unable to download artifact(s): Artifact not found for name: maven-repo-windows-build-native`

Original reason for making the names unique was to fulfill https://github.com/actions/download-artifact/blob/main/docs/MIGRATION.md . Which states that artifact with one name can only be uploaded once on upload-artifact@v4. But we're uploading the artifact only once on https://github.com/quarkus-qe/quarkus-test-framework/blob/2056dcd7d0e6b7fc56e0bdac9aa11612cb3513b0/.github/workflows/daily.yaml#L32
All other occurrences are for downloading the artifact. Therefore there is no need to make the name unique. On the contrary we need the name on downloads to match the name on the upload.

I tried this change here: https://github.com/mocenas/quarkus-test-framework/actions/runs/7384969337/job/20089159569
Pipeline still failed on something, but it fixed the issue with artifact download.


Please check the relevant options

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)