### PR TITLE
Do not search for command line arguments during native executable build on Windows as they are not accessible via Java proccess API

### DIFF
--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusMavenPluginBuildHelper.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusMavenPluginBuildHelper.java
@@ -65,7 +65,10 @@ class QuarkusMavenPluginBuildHelper {
         this.appFolder = resourceBuilder.getApplicationFolder();
         this.appClassNames = Arrays.stream(resourceBuilder.getAppClasses()).map(Class::getName).collect(toUnmodifiableSet());
         this.forcedDependencies = List.copyOf(resourceBuilder.getForcedDependencies());
-        this.cmdLineBuildArgs = findMavenCommandLineArgs();
+        // we don't look for command line args on Windows as arguments are not accessible via the 'ProcessHandle' API
+        // TODO: if we ever extend native executable coverage on Windows, we must find a way how to access only original args
+        this.cmdLineBuildArgs = OS.WINDOWS.isCurrent() ? Set.copyOf(resourceBuilder.getBuildPropertiesSetAsSystemProperties())
+                : findMavenCommandLineArgs();
     }
 
     private static Set<String> findMavenCommandLineArgs() {


### PR DESCRIPTION
### Summary

Fixes daily build.

It's bit strange, but I went through all parent hierarchy of the running process as well as over all others (for example here https://github.com/quarkus-qe/quarkus-test-framework/actions/runs/7398328549/job/20127258589?pr=1005) and there are no arguments even though I pass system properties as `-D` so I suggest to fallback on Windows to previous strategy. It is not problem for now , but if we ever extend native executable coverage on Windows in Jenkins etc. we need to find a way to detect or propagate original arguments. I'll do that eventually.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)