### PR TITLE
Fix selection of application classes from test directory in native mode

### DIFF
--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusApplicationManagedResourceBuilder.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusApplicationManagedResourceBuilder.java
@@ -50,6 +50,10 @@ public abstract class QuarkusApplicationManagedResourceBuilder implements Manage
     private static final int DEPENDENCY_DIRECT_FLAG = 0b000010;
 
     private Class<?>[] appClasses;
+    /**
+     * Whether build consist of all source classes or only some of them.
+     */
+    private boolean buildWithAllClasses = true;
     private List<AppDependency> forcedDependencies = Collections.emptyList();
     private boolean requiresCustomBuild = false;
     private ServiceContext context;
@@ -90,6 +94,10 @@ public abstract class QuarkusApplicationManagedResourceBuilder implements Manage
 
     protected Class<?>[] getAppClasses() {
         return appClasses;
+    }
+
+    protected boolean isBuildWithAllClasses() {
+        return buildWithAllClasses;
     }
 
     protected List<AppDependency> getForcedDependencies() {
@@ -156,6 +164,8 @@ public abstract class QuarkusApplicationManagedResourceBuilder implements Manage
         if (appClasses == null || appClasses.length == 0) {
             appClasses = ClassPathUtils.findAllClassesFromSource();
             requiresCustomBuild = false;
+        } else {
+            buildWithAllClasses = false;
         }
     }
 


### PR DESCRIPTION
### Summary

QE TS daily build in native fails following FW bump. It's consequence of Quarkus Maven plugin build strategy where I didn't take into consideration that app classes selected via annotation (e.g. `@QuarkusApplication(classes = ClassicResource.class)`) can also come from `src/test/java` and not only `src/main/java`

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)