### PR TITLE
Re-use native executable when test is re-run by FailSafe plugin

### DIFF
--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/LocalhostQuarkusApplicationManagedResource.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/LocalhostQuarkusApplicationManagedResource.java
@@ -120,7 +120,7 @@ public abstract class LocalhostQuarkusApplicationManagedResource extends Quarkus
     @Override
     public void restart() {
         stop();
-        if (model.containsBuildProperties()) {
+        if (model.buildPropertiesChanged()) {
             model.build();
         }
 

--- a/quarkus-test-core/src/main/java/io/quarkus/test/utils/FileUtils.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/utils/FileUtils.java
@@ -12,6 +12,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.Optional;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import org.apache.commons.io.IOUtils;
@@ -128,9 +129,13 @@ public final class FileUtils {
     }
 
     public static Optional<String> findTargetFile(Path basePath, String endsWith) {
+        return findTargetFile(basePath, fileName -> fileName.endsWith(endsWith));
+    }
+
+    public static Optional<String> findTargetFile(Path basePath, Predicate<String> fileNameMatcher) {
         try (Stream<Path> binariesFound = Files
                 .find(basePath, NO_RECURSIVE,
-                        (path, basicFileAttributes) -> path.toFile().getName().endsWith(endsWith))) {
+                        (path, basicFileAttributes) -> fileNameMatcher.test(path.toFile().getName()))) {
             return binariesFound.map(path -> path.normalize().toString()).findFirst();
         } catch (IOException ex) {
             // ignored

--- a/quarkus-test-kubernetes/src/main/java/io/quarkus/test/services/quarkus/KubernetesQuarkusApplicationManagedResource.java
+++ b/quarkus-test-kubernetes/src/main/java/io/quarkus/test/services/quarkus/KubernetesQuarkusApplicationManagedResource.java
@@ -98,7 +98,7 @@ public abstract class KubernetesQuarkusApplicationManagedResource<T extends Quar
     @Override
     public void restart() {
         stop();
-        if (model.containsBuildProperties()) {
+        if (model.buildPropertiesChanged()) {
             init = false;
             model.build();
         }

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftQuarkusApplicationManagedResource.java
@@ -121,7 +121,7 @@ public abstract class OpenShiftQuarkusApplicationManagedResource<T extends Quark
     @Override
     public void restart() {
         stop();
-        if (model.containsBuildProperties()) {
+        if (model.buildPropertiesChanged()) {
             init = false;
             model.build();
         }


### PR DESCRIPTION
### Summary

Right now if you do `mvn verify` (or with `clean` but there is Quarkus maven plugin in your POM file) and there are no build-time properties, the native executable from `/target` is re-used. However when there are build-time properties, it is not re-used. Logic behind that is probably _build-time properties requires new build of native executable_. But what if you added a new class, or removed one, or changed source code, doesn't it require new native executable? That is why user should use `clean` like `mvn clean verify` when he made changes that require new executable/JAR (we are talking user changes, not changes done by the test itself).

This way, we can re-use custom builds kept in module target for test re-run by Failsafe plugin when test fails (which saves time and we do not need to test indempotency of Quarkus build). On the other hand it means if there is 10 different test classes with build properties, there will be 10 different native executable kept in target (=we will keep custom builds). Native executable should be small, so I do not consider it an issue.

It saves a lot of time when test is re-run by the Failsafe plugin.

Another effect of this PR is that it makes also native executable build by this framework without build-time properties re-usable, which should allow us to disable Quarkus plugin build in native mode in the future. If we want to . I'll propose and explain that in a separate PR.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)