### PR TITLE
Always skip native build by Quarkus maven plugin to avoid unused native executable builds when all tests require custom builds

### DIFF
--- a/examples/blocking-reactive-model/pom.xml
+++ b/examples/blocking-reactive-model/pom.xml
@@ -9,10 +9,6 @@
     </parent>
     <artifactId>examples-blocking-reactive</artifactId>
     <name>Quarkus - Test Framework - Examples - Blocking + Reactive Model</name>
-    <properties>
-        <!-- Skip build since our framework will build own executable anyway as it detects build-time properties -->
-        <quarkus.build.skip>true</quarkus.build.skip>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/examples/consul/pom.xml
+++ b/examples/consul/pom.xml
@@ -66,17 +66,5 @@
                 </dependency>
             </dependencies>
         </profile>
-        <profile>
-            <id>skip-build-on-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <properties>
-                <!-- Skip build to see if we still experience race on Windows -->
-                <quarkus.build.skip>true</quarkus.build.skip>
-            </properties>
-        </profile>
     </profiles>
 </project>

--- a/examples/debug/pom.xml
+++ b/examples/debug/pom.xml
@@ -64,10 +64,6 @@
                     <name>native</name>
                 </property>
             </activation>
-            <properties>
-                <!-- Skipped Quarkus build in native as there is nothing to compile or test -->
-                <quarkus.build.skip>true</quarkus.build.skip>
-            </properties>
         </profile>
     </profiles>
 </project>

--- a/examples/management/pom.xml
+++ b/examples/management/pom.xml
@@ -9,10 +9,6 @@
     </parent>
     <artifactId>examples-management</artifactId>
     <name>Quarkus - Test Framework - Examples - Management Interface</name>
-    <properties>
-        <!-- Skip build since our framework will build own executable anyway as it detects build-time properties -->
-        <quarkus.build.skip>true</quarkus.build.skip>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -448,6 +448,8 @@
                 <quarkus.native.container-build>true</quarkus.native.container-build>
                 <quarkus.native.native-image-xmx>5g</quarkus.native.native-image-xmx>
                 <exclude.quarkus.devmode.tests>**/*DevMode*IT.java</exclude.quarkus.devmode.tests>
+                <!-- Let FW handle the native executable build to avoid unused build when all tests require custom build -->
+                <quarkus.build.skip>true</quarkus.build.skip>
             </properties>
         </profile>
         <profile>


### PR DESCRIPTION
### Summary

https://github.com/quarkus-qe/quarkus-test-framework/pull/1021 follow-up

1. When all test classes require custom build, the executable build by the Quarkus Maven plugin is ignored. We hope that we mention all of these cases and disable the plugin build, but it's really impossible to keep this in mind when doing every single change in tests.
There is no advantage on always building native executable at the moment when we are yet to know whether we are going to need it or not. Our FW is now using very same maven plugin to build the executable and also supports re-using of executables that do not require custom classes, dependencies or configuration properties.
Strictly speaking, this PR also enables plugin build in JVM in cases it previously wasn't, but I suppose it doesn't matter, I think mostly it was me who added these properties and I was just lazy to create specific native profile or I forgot. it can have positive impact as well (re-using build?).
Unlike JVM build, the native build takes significant time.

2. I mentioned when native build done by the framework is not a custom one, the runner name is `-runner`. It doesn't cause issues on Linux (not sure on Windows as it's not part of the PR workflow, probably, but it needs to be fixed anyway). Sorry. New name will be `quarkus-runner` or `quarkus-runner.exe`.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)