### PR TITLE
Fix non-custom build runner name

### DIFF
--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusApplicationManagedResourceBuilder.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusApplicationManagedResourceBuilder.java
@@ -152,6 +152,10 @@ public abstract class QuarkusApplicationManagedResourceBuilder implements Manage
         }
     }
 
+    public boolean hasAppSpecificConfigProperties() {
+        return propertiesSnapshot != null && !propertiesSnapshot.isEmpty();
+    }
+
     public Map<String, String> createSnapshotOfBuildProperties() {
         propertiesSnapshot = new HashMap<>(context.getOwner().getProperties());
 


### PR DESCRIPTION
### Summary

- I mentioned when native build done by the framework is not a custom one, the runner name is `-runner`. It doesn't cause issues on Linux or Windows, but looks weird. New name will be `quarkus-runner` or `quarkus-runner.exe`.

- When trying https://github.com/quarkus-qe/quarkus-test-framework/pull/1024 I also realized that both custom properties and Quarkus runtime properties are kept when present during native build, therefore we can't re-use executable when there is any `withProperty` or property specified via command line.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)