### PR TITLE
Include service name in Openshif deployment template

### DIFF
--- a/quarkus-test-service-amq/src/main/resources/amq-openshift-deployment-template.yml
+++ b/quarkus-test-service-amq/src/main/resources/amq-openshift-deployment-template.yml
@@ -42,7 +42,7 @@ items:
         spec:
           containers:
             - name: ${SERVICE_NAME}
-              image: image-registry.openshift-image-registry.svc:5000/${CURRENT_NAMESPACE}/amq:latest
+              image: image-registry.openshift-image-registry.svc:5000/${CURRENT_NAMESPACE}/${SERVICE_NAME}:latest
               imagePullPolicy: Always
               env:
                 - name: AMQ_QUEUES


### PR DESCRIPTION
### Summary
Without it, tests may fail, when service has name other, than `amq`. First caught here: https://github.com/quarkus-qe/quarkus-test-suite/pull/1650

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)