### PR TITLE
Catch known exceptions (broken pipe)

### DIFF
--- a/quarkus-test-core/src/main/java/io/quarkus/test/listener/QuarkusTestExceptionFilter.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/listener/QuarkusTestExceptionFilter.java
@@ -1,0 +1,29 @@
+package io.quarkus.test.listener;
+
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestExecutionExceptionHandler;
+
+import io.quarkus.test.logging.Log;
+import io.quarkus.test.utils.KnownExceptionChecker;
+
+/**
+ * Extension is masking exceptions, caused by known issues which cannot be easily disabled.
+ * Originally created for <a href="https://github.com/quarkusio/quarkus/issues/38334">Broken pipe</a> issue.
+ * In case that related exception is thrown, this extension will swallow it, and make test marked as skipped.
+ */
+public class QuarkusTestExceptionFilter implements TestExecutionExceptionHandler {
+
+    @Override
+    public void handleTestExecutionException(ExtensionContext context, Throwable throwable) throws Throwable {
+        // if exception is caused by known issue, swallow it, otherwise propagate it
+        if (KnownExceptionChecker.checkForKnownException(throwable)) {
+            Log.error("Skipping test " + context.getDisplayName() + " known exception found. Printing stack trace");
+            throwable.printStackTrace();
+            // skip the test
+            Assumptions.abort();
+        } else {
+            throw throwable;
+        }
+    }
+}

--- a/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/QuarkusScenario.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/QuarkusScenario.java
@@ -9,12 +9,14 @@ import java.lang.annotation.Target;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import io.quarkus.test.bootstrap.QuarkusScenarioBootstrap;
+import io.quarkus.test.listener.QuarkusTestExceptionFilter;
 import io.quarkus.test.scenarios.execution.condition.QuarkusScenarioExecutionConditions;
 
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @ExtendWith(QuarkusScenarioBootstrap.class)
 @ExtendWith(QuarkusScenarioExecutionConditions.class)
+@ExtendWith(QuarkusTestExceptionFilter.class)
 @Inherited
 public @interface QuarkusScenario {
 }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/utils/KnownExceptionChecker.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/utils/KnownExceptionChecker.java
@@ -1,12 +1,54 @@
 package io.quarkus.test.utils;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+
+import io.quarkus.test.logging.Log;
 
 public final class KnownExceptionChecker {
+
     /**
-     * List of known exception messages. If you want to mask any exception, add its message here
+     * Define all handlers, that can be used to ignore exceptions.
+     * If you want to ignore another exception, just add another predicate and enable it via system property.
      */
-    private static final List<String> KNOWN_EXCEPTION_MESSAGES = List.of("Broken pipe");
+    private static final Map<String, Predicate<Throwable>> ALL_EXCEPTION_HANDLERS = Map.of("broken-pipe", throwable -> {
+        if (throwable.getMessage().contains("Broken pipe")) {
+            return true;
+        }
+        if (throwable.getCause() != null && checkForKnownException(throwable.getCause())) {
+            return true;
+        }
+        for (Throwable t : throwable.getSuppressed()) {
+            if (checkForKnownException(t)) {
+                return true;
+            }
+        }
+        return false;
+    });
+
+    /**
+     * List to store enabled handlers, which are going to be effective.
+     */
+    private static List<Predicate<Throwable>> enabledExceptionsHandlers = new ArrayList<>();
+
+    /*
+     * Read system property and assign desired handlers as enabled ones
+     */
+    static {
+        String enableHandlersParam = System.getProperty("ts.global.ignore-known-issue");
+        if (enableHandlersParam != null && !enableHandlersParam.isEmpty()) {
+            String[] splitParameters = enableHandlersParam.split(",");
+            for (String enableHandler : splitParameters) {
+                if (ALL_EXCEPTION_HANDLERS.containsKey(enableHandler.trim())) {
+                    enabledExceptionsHandlers.add(ALL_EXCEPTION_HANDLERS.get(enableHandler.trim()));
+                } else {
+                    Log.warn("Trying to enable unknown exception handler: " + enableHandler);
+                }
+            }
+        }
+    }
 
     private KnownExceptionChecker() {
     }
@@ -19,14 +61,8 @@ public final class KnownExceptionChecker {
      * @return true if any known exception message is included, false otherwise
      */
     public static boolean checkForKnownException(Throwable throwable) {
-        if (KNOWN_EXCEPTION_MESSAGES.stream().anyMatch(throwable.getMessage()::contains)) {
-            return true;
-        }
-        if (throwable.getCause() != null && checkForKnownException(throwable.getCause())) {
-            return true;
-        }
-        for (Throwable t : throwable.getSuppressed()) {
-            if (checkForKnownException(t)) {
+        for (Predicate<Throwable> p : enabledExceptionsHandlers) {
+            if (p.test(throwable)) {
                 return true;
             }
         }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/utils/KnownExceptionChecker.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/utils/KnownExceptionChecker.java
@@ -1,0 +1,35 @@
+package io.quarkus.test.utils;
+
+import java.util.List;
+
+public final class KnownExceptionChecker {
+    /**
+     * List of known exception messages. If you want to mask any exception, add its message here
+     */
+    private static final List<String> KNOWN_EXCEPTION_MESSAGES = List.of("Broken pipe");
+
+    private KnownExceptionChecker() {
+    }
+
+    /**
+     * Check if thrown message contains any of the known exception messages.
+     * Method is recursive, it will check the exception itself and all causes and suppressed ones as well.
+     *
+     * @param throwable Exception to check
+     * @return true if any known exception message is included, false otherwise
+     */
+    public static boolean checkForKnownException(Throwable throwable) {
+        if (KNOWN_EXCEPTION_MESSAGES.stream().anyMatch(throwable.getMessage()::contains)) {
+            return true;
+        }
+        if (throwable.getCause() != null && checkForKnownException(throwable.getCause())) {
+            return true;
+        }
+        for (Throwable t : throwable.getSuppressed()) {
+            if (checkForKnownException(t)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/scenarios/OpenShiftScenario.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/scenarios/OpenShiftScenario.java
@@ -9,11 +9,13 @@ import java.lang.annotation.Target;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import io.quarkus.test.bootstrap.QuarkusScenarioBootstrap;
+import io.quarkus.test.listener.QuarkusTestExceptionFilter;
 import io.quarkus.test.services.Operator;
 
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @ExtendWith(QuarkusScenarioBootstrap.class)
+@ExtendWith(QuarkusTestExceptionFilter.class)
 @Inherited
 public @interface OpenShiftScenario {
     OpenShiftDeploymentStrategy deployment() default OpenShiftDeploymentStrategy.Build;


### PR DESCRIPTION
### Summary

Add mechanism to catch known exception and make affected tests skipped, not failed. Motivation for this is to not have failed tests, because of known issues, which cannot be easily disabled - such as https://github.com/quarkusio/quarkus/issues/38334.

To catch this single issue, it should be sufficient to catch exceptions just in `QuarkusScenarioBootstrap` (I'm not entire sure if it would be enough). But extending it also to test annotation makes it cover this exception also in tests. 

Same mechanism can be used to catch any other known exception in the future.


Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)