### PR TITLE
Propagate quarkus OPTS to openshift deployment

### DIFF
--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/BuildOpenShiftQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/BuildOpenShiftQuarkusApplicationManagedResource.java
@@ -104,6 +104,10 @@ public class BuildOpenShiftQuarkusApplicationManagedResource
         String s2iVersion = getS2iImageVersion(s2iImage);
         String quarkusOpts = getQuarkusOpts();
 
+        if (!quarkusOpts.isEmpty()) {
+            Log.info("Setting QUARKUS_OPTS, based on " + QUARKUS_OPENSHIFT_OPTS_PROPERTY + " to " + quarkusOpts);
+        }
+
         return content.replaceAll(quote("${QUARKUS_S2I_IMAGE_BUILDER}"),
                 StringUtils.substringBeforeLast(s2iImage, IMAGE_TAG_SEPARATOR))
                 .replaceAll(quote("${QUARKUS_S2I_IMAGE_BUILDER_VERSION}"), s2iVersion)

--- a/quarkus-test-openshift/src/main/resources/quarkus-build-openshift-template.yml
+++ b/quarkus-test-openshift/src/main/resources/quarkus-build-openshift-template.yml
@@ -92,7 +92,7 @@ items:
                 - name: "QUARKUS_HOME"
                   value: "/home/quarkus/"
                 - name: "QUARKUS_OPTS"
-                  value: ""
+                  value: "${QUARKUS_OPTS}"
                 - name: "JAVA_APP_JAR"
                   value: "/deployments/${ARTIFACT}"
               image: "${IMAGE_NAME}"


### PR DESCRIPTION
### Summary

Fix #1034 
Propagate quarkus OPTS to openshift deployment.

Please check the relevant options

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [X] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)