### PR TITLE
Detect and report flaky tests

### DIFF
--- a/.github/workflows/add-flaky-test-label.yml
+++ b/.github/workflows/add-flaky-test-label.yml
@@ -1,0 +1,29 @@
+name: Add 'triage/flaky-test' label and inform if PR CI run contained flaky tests
+on:
+  workflow_run:
+    workflows: ["PR"]
+    types:
+      - completed
+jobs:
+  handle-flaky-tests-in-pr-ci:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+      WORKFLOW_ID:  ${{ github.event.workflow_run.id }}
+    steps:
+      - name: 'Download "jobs-with-flaky-tests" artifact'
+        run: gh run download $WORKFLOW_ID -n jobs-with-flaky-tests || true
+      - name: 'Get PR number'
+        if: ${{ hashFiles('**/jobs-with-flaky-tests') != '' }}
+        run: gh run download $WORKFLOW_ID -n pr-number || true
+      - name: 'Add "triage/flaky-test" label'
+        if: ${{ hashFiles('**/pr-number') != '' }}
+        run: |
+          gh pr edit "$(cat pr-number)" --add-label 'triage/flaky-test'
+      - name: 'Comment on PR about flaky tests'
+        if: ${{ hashFiles('**/pr-number') != '' }}
+        run: |
+          gh pr comment "$(cat pr-number)" --body "Following jobs contain at least one flaky test: $(cat jobs-with-flaky-tests)"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -73,6 +73,8 @@ jobs:
       matrix:
         quarkus-version: ["current"]
         java: [ 17 ]
+    outputs:
+      has-flaky-tests: ${{steps.flaky-test-detector.outputs.has-flaky-tests}}
     steps:
       - uses: actions/checkout@v4
       - name: Reclaim Disk Space
@@ -105,6 +107,11 @@ jobs:
       - name: Build in JVM mode
         run: |
           mvn -B -fae -s .github/mvn-settings.xml clean install -Pexamples
+      - name: Detect flaky tests
+        id: flaky-test-detector
+        shell: bash
+        if: ${{ hashFiles('**/flaky-run-report.json') != '' }}
+        run: echo "has-flaky-tests=true" >> "$GITHUB_OUTPUT"
       - name: Zip Artifacts
         run: |
           zip -R artifacts-quarkus${{ matrix.quarkus-version }}-linux-jvm${{ matrix.java }}.zip '*-reports/*'
@@ -121,6 +128,8 @@ jobs:
       matrix:
         quarkus-version: ["999-SNAPSHOT"]
         java: [ 17 ]
+    outputs:
+      has-flaky-tests: ${{steps.flaky-test-detector.outputs.has-flaky-tests}}
     steps:
       - uses: actions/checkout@v4
       - name: Reclaim Disk Space
@@ -164,6 +173,11 @@ jobs:
       - name: Build in JVM mode
         run: |
           mvn -B -fae -s .github/mvn-settings.xml clean install -Pframework,examples,extensions -Drun-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli" -Dquarkus.platform.version="${{ matrix.quarkus-version }}"
+      - name: Detect flaky tests
+        id: flaky-test-detector
+        shell: bash
+        if: ${{ hashFiles('**/flaky-run-report.json') != '' }}
+        run: echo "has-flaky-tests=true" >> "$GITHUB_OUTPUT"
       - name: Zip Artifacts
         run: |
           zip -R artifacts-latest-linux-jvm${{ matrix.java }}.zip '*-reports/*'
@@ -184,6 +198,8 @@ jobs:
           'examples/pingpong,examples/restclient,examples/greetings,examples/blocking-reactive-model,examples/https,examples/grpc,examples/consul,examples/infinispan,examples/microprofile,examples/keycloak,examples/kafka,examples/kafka-registry,examples/kafka-streams',
           '!examples/pingpong,!examples/restclient,!examples/greetings,!examples/blocking-reactive-model,!examples/https,!examples/grpc,!examples/consul,!examples/infinispan,!examples/microprofile,!examples/keycloak,!examples/kafka,!examples/kafka-registry,!examples/kafka-streams'
         ]
+    outputs:
+      has-flaky-tests: ${{steps.flaky-test-detector.outputs.has-flaky-tests}}
     steps:
       - uses: actions/checkout@v4
       - name: Reclaim Disk Space
@@ -216,6 +232,11 @@ jobs:
       - name: Build
         run: |
           mvn -B -fae -s .github/mvn-settings.xml clean install -Pexamples,native -pl '${{ matrix.examples }}'
+      - name: Detect flaky tests
+        id: flaky-test-detector
+        shell: bash
+        if: ${{ hashFiles('**/flaky-run-report.json') != '' }}
+        run: echo "has-flaky-tests=true" >> "$GITHUB_OUTPUT"
       - name: Zip Artifacts
         if: failure()
         run: |
@@ -234,6 +255,8 @@ jobs:
       matrix:
         java: [ 17 ]
         quarkus-version: ["999-SNAPSHOT"]
+    outputs:
+      has-flaky-tests: ${{steps.flaky-test-detector.outputs.has-flaky-tests}}
     steps:
       - uses: actions/checkout@v4
       - name: Install JDK {{ matrix.java }}
@@ -266,6 +289,11 @@ jobs:
         shell: bash
         run: |
           mvn -B -fae -s .github/mvn-settings.xml clean install -Pframework,examples -Dquarkus.platform.version="${{ matrix.quarkus-version }}"
+      - name: Detect flaky tests
+        shell: bash
+        id: flaky-test-detector
+        if: ${{ hashFiles('**/flaky-run-report.json') != '' }}
+        run: echo "has-flaky-tests=true" >> "$GITHUB_OUTPUT"
       - name: Zip Artifacts
         shell: bash
         if: failure()
@@ -278,3 +306,51 @@ jobs:
         with:
           name: artifacts-latest-windows-jvm${{ matrix.java }}
           path: artifacts-latest-windows-jvm${{ matrix.java }}.tar
+  detect-flaky-tests:
+    name: Detect flaky tests
+    runs-on: ubuntu-latest
+    needs: [linux-build-jvm-released, linux-build-jvm-latest, linux-build-native-released, windows-build-jvm-latest]
+    steps:
+      - name: Create file with information about job with flaky test
+        if: needs.linux-build-jvm-released.outputs.has-flaky-tests == 'true' || needs.linux-build-jvm-latest.outputs.has-flaky-tests == 'true' || needs.linux-build-native-released.outputs.has-flaky-tests == 'true' || needs.windows-build-jvm-latest.outputs.has-flaky-tests == 'true'
+        run: |
+          job_name=""
+          if $IS_LINUX_JVM_LATEST
+          then
+          job_name+=", 'Linux - JVM build - Latest Version'"
+          fi
+          if $IS_LINUX_JVM_RELEASED
+          then
+          job_name+=", 'Linux - JVM build - Released Versions'"
+          fi
+          if $IS_LINUX_NATIVE_RELEASED
+          then
+          job_name+=", 'Daily - Linux - Native build - Released Version'"
+          fi
+          if $IS_WINDOWS_JVM_LATEST
+          then
+          job_name+=", 'Windows - JVM build - Latest Version'"
+          fi
+          echo "${job_name:2}" > jobs-with-flaky-tests
+        env:
+          IS_LINUX_JVM_LATEST: ${{ needs.linux-build-jvm-latest.outputs.has-flaky-tests == 'true' }}
+          IS_LINUX_JVM_RELEASED: ${{ needs.linux-build-jvm-released.outputs.has-flaky-tests == 'true' }}
+          IS_LINUX_NATIVE_RELEASED: ${{ needs.linux-build-native-released.outputs.has-flaky-tests == 'true' }}
+          IS_WINDOWS_JVM_LATEST: ${{ needs.windows-build-jvm-latest.outputs.has-flaky-tests == 'true' }}
+      - name: Archive 'jobs-with-flaky-tests' artifact
+        if: ${{ hashFiles('**/jobs-with-flaky-tests') != '' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: jobs-with-flaky-tests
+          path: jobs-with-flaky-tests
+      - name: Save PR number
+        if: ${{ hashFiles('**/jobs-with-flaky-tests') != '' }}
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: echo $PR_NUMBER > pr-number
+      - name: Archive PR number
+        uses: actions/upload-artifact@v4
+        if: ${{ hashFiles('**/jobs-with-flaky-tests') != '' }}
+        with:
+          name: pr-number
+          path: pr-number

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,7 @@
         <infinispan.image>docker.io/infinispan/server:14.0</infinispan.image>
         <infinispan-legacy.image>docker.io/infinispan/server:13.0</infinispan-legacy.image>
         <reruns>2</reruns>
+        <flaky-run-reporter.version>0.1.2.Beta1</flaky-run-reporter.version>
     </properties>
     <distributionManagement>
         <snapshotRepository>
@@ -219,6 +220,14 @@
         </dependency>
     </dependencies>
     <build>
+        <extensions>
+            <!--Creates report about detected flaky tests during SureFire and FailSafe test runs -->
+            <extension>
+                <groupId>io.quarkus.qe</groupId>
+                <artifactId>flaky-run-reporter</artifactId>
+                <version>${flaky-run-reporter.version}</version>
+            </extension>
+        </extensions>
         <pluginManagement>
             <plugins>
                 <plugin>


### PR DESCRIPTION
### Summary

Flaky tests from SureFire and FailSafe reports and aggregated by a Maven extension added in this PR. The flaky report can be used in Jenkins or in GitHub Actions. Here on GitHub when PR contains flaky tests, we add `triage/flaky-test` label and comment which job contained flaky tests so that someone can inspect artifacts with actual test names.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)