### PR TITLE
Set keystore file type as required due to upstream changes the type can't be inferred anymore

### DIFF
--- a/examples/https/src/main/resources/application.properties
+++ b/examples/https/src/main/resources/application.properties
@@ -1,4 +1,5 @@
 # HTTPS
 quarkus.http.ssl.certificate.key-store-file=META-INF/resources/server.keystore
+quarkus.http.ssl.certificate.key-store-file-type=JKS
 quarkus.http.ssl.certificate.key-store-password=password
 quarkus.ssl.native=true

--- a/examples/management/src/test/java/io/quarkus/qe/LocalTLSIT.java
+++ b/examples/management/src/test/java/io/quarkus/qe/LocalTLSIT.java
@@ -18,6 +18,7 @@ public class LocalTLSIT {
     static final RestService service = new RestService()
             .withProperty("quarkus.management.port", "9003")
             .withProperty("quarkus.management.ssl.certificate.key-store-file", "META-INF/resources/server.keystore")
+            .withProperty("quarkus.management.ssl.certificate.key-store-file-type", "JKS")
             .withProperty("quarkus.management.ssl.certificate.key-store-password", "password");
 
     @Test


### PR DESCRIPTION
### Summary

Sets keystore file type as tests are now failing. See https://github.com/quarkusio/quarkus/pull/39106 and https://github.com/quarkusio/quarkus/issues/39151 for explanation what changed and why it is okay.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)