### PR TITLE
Add release version checker to GitHub Actions workflow

### DIFF
--- a/.github/workflows/check-release-version.yml
+++ b/.github/workflows/check-release-version.yml
@@ -1,0 +1,44 @@
+name: Check release version
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+    paths:
+      - .github/project.yml
+jobs:
+  check-release-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check release version
+        run: |
+          current_release=$(curl -sSL "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/latest" | jq -r .tag_name)
+          current_release_patch_version=$(echo "$current_release" | cut -d"." -f3,3)
+          current_release_pre_number=$(echo "$current_release" | cut -d"." -f4,4 | grep -o '[0-9]' || true)
+
+          next_release=$(grep -E 'current-version:\s*' .github/project.yml | awk '{print $2}')
+          next_release_patch_version=$(echo "$next_release" | cut -d"." -f3,3)
+          next_release_pre_number=$(echo "$next_release" | cut -d"." -f4,4 | grep -o '[0-9]' || true)
+          
+          if ! [[ $current_release =~ .*Final$ ]]; then
+            if [[ $next_release_patch_version > $current_release_patch_version ]]; then
+              echo "Error: you are bumping the FW patch version when the previous release was not Final"
+              exit 1;
+            fi
+            if [[ $next_release_pre_number != $(("$current_release_pre_number" + 1)) ]]; then
+              echo "Error: pre-release version should go one by one as sequence"
+              correct_version=$(echo "$current_release" | cut -d"." -f1,2,3)
+              correct_prerelease_number=$(($current_release_pre_number + 1))
+              echo "After" $current_release "should go "$correct_version".Beta"$correct_prerelease_number or Final release
+              exit 1;
+            fi
+          else
+            if [[ $(("$current_release_patch_version" + 1)) != $next_release_patch_version || ($next_release_pre_number != 1) ]]; then
+                echo "Error: release patch versions should be bumped one by one as sequence and pre-release version must be Beta1"
+                correct_minor_release=$(echo "$current_release" | cut -d"." -f1,2)
+                correct_patch_version=$(("$current_release_patch_version" + 1))
+                echo "After" $current_release "should go" $correct_minor_release"."$correct_patch_version".Beta1"
+                exit 1;
+              fi
+          fi


### PR DESCRIPTION
### Summary

Add release versioning check to GH Actions workflow. When user change project.yaml `check-release-version` job is triggered
If the new version is wrong, job fails with error message

Example PR and test runs. I add debug print to print from what version to what version FW bumps, for example (1.4.2.Beta8 -> 1.4.2.Beta10)

https://github.com/gtroitsk/quarkus-test-framework/pull/1

Success: 1.4.2.Beta8 -> 1.4.2.Beta9 	
(https://github.com/gtroitsk/quarkus-test-framework/actions/runs/8185766438/job/22382750464?pr=1)
Success: 1.4.2.Final -> 1.4.3.Beta1	
(https://github.com/gtroitsk/quarkus-test-framework/actions/runs/8185802974/job/22382862356?pr=1)
Failure: 1.4.2.Beta8 -> 1.4.2.Beta10 	
(https://github.com/gtroitsk/quarkus-test-framework/actions/runs/8185784491/job/22382806672?pr=1)
Failure: 1.4.2.Final -> 1.4.3.Beta2 	
(https://github.com/gtroitsk/quarkus-test-framework/actions/runs/8185818924/job/22382914371?pr=1)
Failure: 1.4.2.Final -> 1.4.4.Beta1	
(https://github.com/gtroitsk/quarkus-test-framework/actions/runs/8185827502/job/22382941018?pr=1)

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)