### PR TITLE
Support and test Kafka authentication with SASL_SSL protocols

### DIFF
--- a/examples/kafka/src/test/java/io/quarkus/qe/StrimziKafkaWithDefaultSaslSslMessagingIT.java
+++ b/examples/kafka/src/test/java/io/quarkus/qe/StrimziKafkaWithDefaultSaslSslMessagingIT.java
@@ -1,0 +1,47 @@
+package io.quarkus.qe;
+
+import java.time.Duration;
+
+import org.apache.http.HttpStatus;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.KafkaService;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.KafkaContainer;
+import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.test.services.containers.model.KafkaProtocol;
+import io.quarkus.test.services.containers.model.KafkaVendor;
+
+@QuarkusScenario
+public class StrimziKafkaWithDefaultSaslSslMessagingIT {
+
+    private final static String SASL_USERNAME_VALUE = "client";
+    private final static String SASL_PASSWORD_VALUE = "client-secret";
+    private static final String TRUSTSTORE_FILE = "strimzi-server-ssl-truststore.p12";
+
+    @KafkaContainer(vendor = KafkaVendor.STRIMZI, protocol = KafkaProtocol.SASL_SSL, kafkaConfigResources = TRUSTSTORE_FILE)
+    static final KafkaService kafka = new KafkaService();
+
+    @QuarkusApplication
+    static final RestService app = new RestService()
+            .withProperty("kafka.bootstrap.servers", kafka::getBootstrapUrl)
+            .withProperty("kafka.security.protocol", "SASL_SSL")
+            .withProperty("kafka.ssl.truststore.location", TRUSTSTORE_FILE)
+            .withProperty("kafka.ssl.truststore.password", "top-secret")
+            .withProperty("kafka.ssl.truststore.type", "PKCS12")
+            .withProperty("kafka.sasl.mechanism", "PLAIN")
+            .withProperty("kafka.sasl.jaas.config", "org.apache.kafka.common.security.plain.PlainLoginModule required "
+                    + "username=\"" + SASL_USERNAME_VALUE + "\" "
+                    + "password=\"" + SASL_PASSWORD_VALUE + "\";");
+
+    @Test
+    public void checkUserResourceByNormalUser() {
+        Awaitility.await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+            app.given().get("/prices/poll")
+                    .then()
+                    .statusCode(HttpStatus.SC_OK);
+        });
+    }
+}

--- a/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/StrimziKafkaContainerManagedResource.java
+++ b/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/StrimziKafkaContainerManagedResource.java
@@ -19,6 +19,7 @@ public class StrimziKafkaContainerManagedResource extends BaseKafkaContainerMana
     private static final String SSL_SERVER_PROPERTIES_DEFAULT = "strimzi-default-server-ssl.properties";
     private static final String SSL_SERVER_KEYSTORE_DEFAULT = "strimzi-default-server-ssl-keystore.p12";
     private static final String SASL_SERVER_PROPERTIES_DEFAULT = "strimzi-default-server-sasl.properties";
+    private static final String SASL_SSL_SERVER_PROPERTIES_DEFAULT = "strimzi-default-server-sasl-ssl.properties";
 
     protected StrimziKafkaContainerManagedResource(KafkaContainerManagedResourceBuilder model) {
         super(model);
@@ -36,6 +37,8 @@ public class StrimziKafkaContainerManagedResource extends BaseKafkaContainerMana
             uri = uri.withScheme("SSL");
         } else if (model.getProtocol() == KafkaProtocol.SASL) {
             uri = uri.withScheme("SASL_PLAINTEXT");
+        } else if (model.getProtocol() == KafkaProtocol.SASL_SSL) {
+            uri = uri.withScheme("SASL_SSL");
         }
         return uri;
     }
@@ -75,6 +78,8 @@ public class StrimziKafkaContainerManagedResource extends BaseKafkaContainerMana
             return SSL_SERVER_PROPERTIES_DEFAULT;
         } else if (model.getProtocol() == KafkaProtocol.SASL) {
             return SASL_SERVER_PROPERTIES_DEFAULT;
+        } else if (model.getProtocol() == KafkaProtocol.SASL_SSL) {
+            return SASL_SSL_SERVER_PROPERTIES_DEFAULT;
         }
 
         return super.getServerProperties();
@@ -85,7 +90,7 @@ public class StrimziKafkaContainerManagedResource extends BaseKafkaContainerMana
         List<String> effectiveUserKafkaConfigResources = new ArrayList<>();
         effectiveUserKafkaConfigResources.addAll(Arrays.asList(super.getKafkaConfigResources()));
 
-        if (model.getProtocol() == KafkaProtocol.SSL) {
+        if (model.getProtocol() == KafkaProtocol.SSL || model.getProtocol() == KafkaProtocol.SASL_SSL) {
             effectiveUserKafkaConfigResources.add(SSL_SERVER_KEYSTORE_DEFAULT);
         }
 

--- a/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/model/KafkaProtocol.java
+++ b/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/model/KafkaProtocol.java
@@ -3,5 +3,6 @@ package io.quarkus.test.services.containers.model;
 public enum KafkaProtocol {
     SSL,
     SASL,
-    PLAIN_TEXT
+    SASL_SSL,
+    PLAIN_TEXT,
 }

--- a/quarkus-test-service-kafka/src/main/resources/strimzi-default-server-sasl-ssl.properties
+++ b/quarkus-test-service-kafka/src/main/resources/strimzi-default-server-sasl-ssl.properties
@@ -1,0 +1,167 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# see kafka.server.KafkaConfig for additional details and defaults
+
+############################# Server Basics #############################
+
+# The id of the broker. This must be set to a unique integer for each broker.
+broker.id=0
+
+############################# Socket Server Settings #############################
+
+# The address the socket server listens on. It will get the value returned from
+# java.net.InetAddress.getCanonicalHostName() if not configured.
+#   FORMAT:
+#     listeners = listener_name://host_name:port
+#   EXAMPLE:
+#     listeners = PLAINTEXT://your.host.name:9092
+#listeners=PLAINTEXT://:9092
+listeners=BROKER://0.0.0.0:9093,SASL_SSL://0.0.0.0:9092
+
+
+
+# Hostname and port the broker will advertise to producers and consumers. If not set,
+# it uses the value for "listeners" if configured.  Otherwise, it will use the value
+# returned from java.net.InetAddress.getCanonicalHostName().
+#advertised.listeners=PLAINTEXT://your.host.name:9092
+advertised.listeners=SASL_SSL://localhost:${KAFKA_MAPPED_PORT},BROKER://localhost:9093
+
+# Maps listener names to security protocols, the default is for them to be the same. See the config documentation for more details
+#listener.security.protocol.map=PLAINTEXT:PLAINTEXT,SSL:SSL,SASL_PLAINTEXT:SASL_PLAINTEXT,SASL_SSL:SASL_SSL
+listener.security.protocol.map=BROKER:PLAINTEXT,SASL_SSL:SASL_SSL
+
+# The number of threads that the server uses for receiving requests from the network and sending responses to the network
+num.network.threads=3
+
+# The number of threads that the server uses for processing requests, which may include disk I/O
+num.io.threads=8
+
+# The send buffer (SO_SNDBUF) used by the socket server
+socket.send.buffer.bytes=102400
+
+# The receive buffer (SO_RCVBUF) used by the socket server
+socket.receive.buffer.bytes=102400
+
+# The maximum size of a request that the socket server will accept (protection against OOM)
+socket.request.max.bytes=104857600
+
+
+inter.broker.listener.name=BROKER
+
+############################# SASL_SSL Settings #############################
+
+sasl.enabled.mechanisms=PLAIN
+sasl.mechanism.inter.broker.protocol=PLAIN
+
+listener.name.sasl_ssl.plain.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required \
+    username="broker" \
+    password="broker-secret" \
+    user_broker="broker-secret" \
+    user_client="client-secret";
+
+############################# SSL #############################
+
+ssl.keystore.location=/opt/kafka/config/strimzi-default-server-ssl-keystore.p12
+ssl.keystore.password=top-secret
+ssl.keystore.type=PKCS12
+ssl.key.password=top-secret
+ssl.truststore.location=/opt/kafka/config/strimzi-server-ssl-truststore.p12
+ssl.truststore.password=top-secret
+ssl.truststore.type=PKCS12
+ssl.endpoint.identification.algorithm=
+ssl.client.auth=required
+
+
+############################# Log Basics #############################
+
+# A comma separated list of directories under which to store log files
+log.dirs=/tmp/kafka-logs
+
+# The default number of log partitions per topic. More partitions allow greater
+# parallelism for consumption, but this will also result in more files across
+# the brokers.
+num.partitions=1
+
+# The number of threads per data directory to be used for log recovery at startup and flushing at shutdown.
+# This value is recommended to be increased for installations with data dirs located in RAID array.
+num.recovery.threads.per.data.dir=1
+
+############################# Internal Topic Settings  #############################
+# The replication factor for the group metadata internal topics "__consumer_offsets" and "__transaction_state"
+# For anything other than development testing, a value greater than 1 is recommended to ensure availability such as 3.
+offsets.topic.replication.factor=1
+transaction.state.log.replication.factor=1
+transaction.state.log.min.isr=1
+
+############################# Log Flush Policy #############################
+
+# Messages are immediately written to the filesystem but by default we only fsync() to sync
+# the OS cache lazily. The following configurations control the flush of data to disk.
+# There are a few important trade-offs here:
+#    1. Durability: Unflushed data may be lost if you are not using replication.
+#    2. Latency: Very large flush intervals may lead to latency spikes when the flush does occur as there will be a lot of data to flush.
+#    3. Throughput: The flush is generally the most expensive operation, and a small flush interval may lead to excessive seeks.
+# The settings below allow one to configure the flush policy to flush data after a period of time or
+# every N messages (or both). This can be done globally and overridden on a per-topic basis.
+
+# The number of messages to accept before forcing a flush of data to disk
+#log.flush.interval.messages=10000
+
+# The maximum amount of time a message can sit in a log before we force a flush
+#log.flush.interval.ms=1000
+
+############################# Log Retention Policy #############################
+
+# The following configurations control the disposal of log segments. The policy can
+# be set to delete segments after a period of time, or after a given size has accumulated.
+# A segment will be deleted whenever *either* of these criteria are met. Deletion always happens
+# from the end of the log.
+
+# The minimum age of a log file to be eligible for deletion due to age
+log.retention.hours=168
+
+# A size-based retention policy for logs. Segments are pruned from the log unless the remaining
+# segments drop below log.retention.bytes. Functions independently of log.retention.hours.
+#log.retention.bytes=1073741824
+
+# The maximum size of a log segment file. When this size is reached a new log segment will be created.
+log.segment.bytes=1073741824
+
+# The interval at which log segments are checked to see if they can be deleted according
+# to the retention policies
+log.retention.check.interval.ms=300000
+
+############################# Zookeeper #############################
+
+# Zookeeper connection string (see zookeeper docs for details).
+# This is a comma separated host:port pairs, each corresponding to a zk
+# server. e.g. "127.0.0.1:3000,127.0.0.1:3001,127.0.0.1:3002".
+# You can also append an optional chroot string to the urls to specify the
+# root directory for all kafka znodes.
+zookeeper.connect=localhost:2181
+
+# Timeout in ms for connecting to zookeeper
+zookeeper.connection.timeout.ms=45000
+
+
+############################# Group Coordinator Settings #############################
+
+# The following configuration specifies the time, in milliseconds, that the GroupCoordinator will delay the initial consumer rebalance.
+# The rebalance will be further delayed by the value of group.initial.rebalance.delay.ms as new members join the group, up to a maximum of max.poll.interval.ms.
+# The default value for this is 3 seconds.
+# We override this to 0 here as it makes for a better out-of-the-box experience for development and testing.
+# However, in production environments the default value of 3 seconds is more suitable as this will help to avoid unnecessary, and potentially expensive, rebalances during application startup.
+group.initial.rebalance.delay.ms=0


### PR DESCRIPTION
### Summary

Add test support for Kafka authentication with SASL_SSL protocols
Tests  `kafka.security.protocol=SASL_SSL`  property

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)