### PR TITLE
Fix remote DEV tests after breaking package config changes

### DIFF
--- a/examples/external-applications/src/test/java/io/quarkus/qe/QuickstartUsingUsingUberJarIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/QuickstartUsingUsingUberJarIT.java
@@ -15,7 +15,8 @@ import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Windows does not support long file paths")
 public class QuickstartUsingUsingUberJarIT {
 
-    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", contextDir = "getting-started", mavenArgs = "-Dquarkus.package.type=uber-jar -DskipTests=true -Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus.platform.version=${QUARKUS_PLATFORM_VERSION}")
+    // TODO: drop config key quarkus.package.type when Quarkus is bumped to 3.10
+    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", contextDir = "getting-started", mavenArgs = "-Dquarkus.package.jar.type=uber-jar -Dquarkus.package.type=uber-jar -DskipTests=true -Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus.platform.version=${QUARKUS_PLATFORM_VERSION}")
     static final RestService app = new RestService();
 
     @Test

--- a/examples/external-applications/src/test/java/io/quarkus/qe/TodoDemoIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/TodoDemoIT.java
@@ -16,7 +16,8 @@ import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 public class TodoDemoIT {
     private static final String REPO = "https://github.com/quarkusio/todo-demo-app.git";
     private static final String DEFAULT_ARGS = "-DskipTests=true -Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus.platform.version=${QUARKUS_PLATFORM_VERSION} ";
-    private static final String UBER = "-Dquarkus.package.type=uber-jar ";
+    // TODO: drop config key quarkus.package.type when Quarkus is bumped to 3.10
+    private static final String UBER = "-Dquarkus.package.type=uber-jar -Dquarkus.package.jar.type=uber-jar ";
 
     @GitRepositoryQuarkusApplication(repo = REPO, mavenArgs = DEFAULT_ARGS + UBER)
     static final RestService app = new RestService();

--- a/pom.xml
+++ b/pom.xml
@@ -436,6 +436,7 @@
                             <execution>
                                 <configuration>
                                     <systemProperties>
+                                        <quarkus.native.enabled>${quarkus.native.enabled}</quarkus.native.enabled>
                                         <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
                                         <quarkus.package.type>${quarkus.package.type}</quarkus.package.type>
                                         <quarkus.native.container-build>${quarkus.native.container-build}</quarkus.native.container-build>
@@ -448,6 +449,8 @@
                 </plugins>
             </build>
             <properties>
+                <quarkus.native.enabled>true</quarkus.native.enabled>
+                <!-- TODO: drop next line when Quarkus is bumped to 3.10 -->
                 <quarkus.package.type>native</quarkus.package.type>
                 <quarkus.native.container-build>true</quarkus.native.container-build>
                 <quarkus.native.native-image-xmx>5g</quarkus.native.native-image-xmx>

--- a/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/execution/condition/AbstractQuarkusScenarioContainerExecutionCondition.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/execution/condition/AbstractQuarkusScenarioContainerExecutionCondition.java
@@ -26,9 +26,9 @@ public abstract class AbstractQuarkusScenarioContainerExecutionCondition impleme
             + " Linux containers");
     public static final String ENV_DOES_NOT_SUPPORT_LINUX_CONTAINERS = "Test class '%s' requires Linux containers, "
             + "but the environment does not support them";
-    private static final Logger LOG = Logger.getLogger(AbstractQuarkusScenarioContainerExecutionCondition.class.getName());
-    private static final ConditionEvaluationResult CONDITION_NOT_MATCHED = enabled("This condition should "
+    static final ConditionEvaluationResult CONDITION_NOT_MATCHED = enabled("This condition should "
             + "only be applied on test classes annotated with the '@QuarkusScenario' annotation");
+    private static final Logger LOG = Logger.getLogger(AbstractQuarkusScenarioContainerExecutionCondition.class.getName());
     private static final String LINUX_CONTAINERS_NOT_REQUIRED = "Test class '%s' does not require containers";
     private static final String LINUX_CONTAINER_OS_TYPE = "linux";
     private static final String PODMAN = "podman";
@@ -109,7 +109,7 @@ public abstract class AbstractQuarkusScenarioContainerExecutionCondition impleme
         }
     }
 
-    private static boolean isQuarkusScenario(AnnotatedElement annotatedElement) {
+    static boolean isQuarkusScenario(AnnotatedElement annotatedElement) {
         return annotatedElement.isAnnotationPresent(QuarkusScenario.class);
     }
 

--- a/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/execution/condition/DisableDevModeTestsInNativeExecutionCondition.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/execution/condition/DisableDevModeTestsInNativeExecutionCondition.java
@@ -1,0 +1,41 @@
+package io.quarkus.test.scenarios.execution.condition;
+
+import static io.quarkus.test.scenarios.execution.condition.AbstractQuarkusScenarioContainerExecutionCondition.CONDITION_NOT_MATCHED;
+import static io.quarkus.test.services.quarkus.model.QuarkusProperties.isNativePackageType;
+
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import io.quarkus.test.services.DevModeQuarkusApplication;
+import io.quarkus.test.services.RemoteDevModeQuarkusApplication;
+
+public class DisableDevModeTestsInNativeExecutionCondition implements QuarkusScenarioExecutionCondition {
+
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+        return context
+                .getElement()
+                .filter(AbstractQuarkusScenarioContainerExecutionCondition::isQuarkusScenario)
+                .map(clazz -> (Class<?>) clazz)
+                .map(DisableDevModeTestsInNativeExecutionCondition::evaluate)
+                .orElse(CONDITION_NOT_MATCHED);
+    }
+
+    private static ConditionEvaluationResult evaluate(Class<?> testClass) {
+        if (isNativePackageType() && isDevModeTest(testClass)) {
+            return ConditionEvaluationResult.disabled("DEV mode tests can't be run when native mode is enabled");
+        } else {
+            return ConditionEvaluationResult.enabled("Not a DEV mode test in native mode");
+        }
+    }
+
+    private static boolean isDevModeTest(Class<?> testClass) {
+        return Arrays.stream(testClass.getDeclaredFields())
+                .filter(m -> Modifier.isStatic(m.getModifiers()))
+                .anyMatch(m -> m.isAnnotationPresent(RemoteDevModeQuarkusApplication.class)
+                        || m.isAnnotationPresent(DevModeQuarkusApplication.class));
+    }
+}

--- a/quarkus-test-core/src/main/resources/META-INF/services/io.quarkus.test.scenarios.execution.condition.QuarkusScenarioExecutionCondition
+++ b/quarkus-test-core/src/main/resources/META-INF/services/io.quarkus.test.scenarios.execution.condition.QuarkusScenarioExecutionCondition
@@ -1,1 +1,2 @@
 io.quarkus.test.scenarios.execution.condition.AnnotationBindingQuarkusScenarioContainerExecutionCondition
+io.quarkus.test.scenarios.execution.condition.DisableDevModeTestsInNativeExecutionCondition

--- a/quarkus-test-core/src/main/resources/build-time-list
+++ b/quarkus-test-core/src/main/resources/build-time-list
@@ -69,7 +69,10 @@ quarkus.resteasy-client-oidc-token-propagation.enabled
 quarkus.oidc.enabled
 quarkus.openshift.
 quarkus.otel.enabled
+FIXME: drop next line when Quarkus version is bumped to 3.10
 quarkus.package.type
+quarkus.package.jar.type
+quarkus.native.enabled
 quarkus.messaging.health.enabled
 quarkus.messaging.kafka.serializer-autodetection.enabled
 quarkus.messaging.metrics.enabled

--- a/quarkus-test-images/src/main/resources/Dockerfile.legacy-jar
+++ b/quarkus-test-images/src/main/resources/Dockerfile.legacy-jar
@@ -3,7 +3,7 @@
 #
 # Before building the container image run:
 #
-# ./mvnw package -Dquarkus.package.type=legacy-jar
+# ./mvnw package -Dquarkus.package.jar.type=legacy-jar
 #
 # Then, build the image with:
 #


### PR DESCRIPTION
### Summary

Remote DEV mode tests running with Quarkus 999-SNAPSHOT are failing after https://github.com/quarkusio/quarkus/pull/39295 got merged. One example can be https://github.com/quarkus-qe/quarkus-test-suite/actions/runs/8374170247/job/22929729333. Quarkus introduced fallback config interceptors, however we also need to detect it correctly, which seems to be a problem. This PR does:

- disables DEV mode tests in native as there is no point to run them there
- sets new properties and keep the old ones for compatibility as FW is also run with released version

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)