### PR TITLE
Sanitize OpenShift deployment service name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -470,6 +470,23 @@
                 <include.tests>**/OpenShift*IT.java</include.tests>
                 <exclude.openshift.tests>no</exclude.openshift.tests>
             </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <configuration>
+                                    <systemPropertyVariables>
+                                        <!-- always set 'OpenShift' property as that's how detect OpenShift tests inside FW -->
+                                        <openshift>true</openshift>
+                                    </systemPropertyVariables>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
         <profile>
             <!-- You need to be connected to a Kubernetes instance to activate 

--- a/quarkus-test-core/src/main/java/io/quarkus/test/configuration/Configuration.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/configuration/Configuration.java
@@ -85,12 +85,14 @@ public final class Configuration {
         return new Configuration(properties);
     }
 
-    public static Configuration load(String serviceName) {
+    public static Configuration load(String... serviceNames) {
         Configuration configuration = load();
-        // Then, properties from test.properties and scope as service name
-        configuration.properties.putAll(loadPropertiesFrom(TEST_PROPERTIES, serviceName));
-        // Then, highest priority: properties from system properties and scope as service name
-        configuration.properties.putAll(loadPropertiesFromSystemProperties(serviceName));
+        for (String serviceName : serviceNames) {
+            // Then, properties from test.properties and scope as service name
+            configuration.properties.putAll(loadPropertiesFrom(TEST_PROPERTIES, serviceName));
+            // Then, highest priority: properties from system properties and scope as service name
+            configuration.properties.putAll(loadPropertiesFromSystemProperties(serviceName));
+        }
 
         return configuration;
     }


### PR DESCRIPTION
### Summary

Here https://github.com/quarkus-qe/quarkus-test-framework/pull/1066 I've renamed `blocking` to the `resteasyClassic` and OpenShift test started to fail with:

```
16:20:40,515 INFO  oc: Error from server (Invalid): error when creating "/home/mvavrik/sources/quarkus-test-framework/examples/blocking-reactive-model/target/OpenShiftGreetingResourceIT/resteasyClassic/openshift.yml": Deployment.apps "resteasyClassic" is invalid: [metadata.name: Invalid value: "resteasyClassic": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'), spec.template.spec.containers[0].name: Invalid value: "resteasyClassic": a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')]
```

We need to check that name used in OpenShift Deployment follow these rules, however we also need to keep consistency across whole application (f.e. we can't use different name inside OpenShift extension module and different in another places). Situation is easy because we only need to handle situations where user do not explicitly write name (like operator name), so they are Java class fields and already follow some rules.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)