### PR TITLE
Fix OpenShiftStrimziOperatorKafkaWithoutRegistryMessagingIT by bumping Kafka instance to 3.7 supported by the operator

### DIFF
--- a/quarkus-test-service-kafka/src/main/resources/strimzi-operator-kafka-instance.yaml
+++ b/quarkus-test-service-kafka/src/main/resources/strimzi-operator-kafka-instance.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kafka-instance
 spec:
   kafka:
-    version: 3.5.0
+    version: 3.7.0
     replicas: 1
     listeners:
       - name: plain


### PR DESCRIPTION
### Summary

The test is failing and Kafka operator supports only 3.6.0, 3.6.1 and 3.7.0.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)