### PR TITLE
Fix Kubernetes test scenario 

### DIFF
--- a/examples/database-postgresql/pom.xml
+++ b/examples/database-postgresql/pom.xml
@@ -46,6 +46,11 @@
             <artifactId>quarkus-test-openshift</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus.qe</groupId>
+            <artifactId>quarkus-test-kubernetes</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/examples/database-postgresql/src/test/java/io/quarkus/qe/database/postgresql/KubernetesPostgresqlIT.java
+++ b/examples/database-postgresql/src/test/java/io/quarkus/qe/database/postgresql/KubernetesPostgresqlIT.java
@@ -1,0 +1,28 @@
+package io.quarkus.qe.database.postgresql;
+
+import io.quarkus.test.bootstrap.PostgresqlService;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.KubernetesScenario;
+import io.quarkus.test.services.Container;
+import io.quarkus.test.services.QuarkusApplication;
+
+@KubernetesScenario
+public class KubernetesPostgresqlIT extends AbstractSqlDatabaseIT {
+
+    private static final int POSTGRESQL_PORT = 5432;
+
+    @Container(image = "${postgresql.image}", port = POSTGRESQL_PORT, expectedLog = "is ready")
+    static PostgresqlService database = new PostgresqlService()
+            .withProperty("PGDATA", "/tmp/psql");
+
+    @QuarkusApplication
+    static RestService app = new RestService()
+            .withProperty("quarkus.datasource.username", database.getUser())
+            .withProperty("quarkus.datasource.password", database.getPassword())
+            .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl);
+
+    @Override
+    protected RestService getApp() {
+        return app;
+    }
+}

--- a/examples/pingpong/src/test/java/io/quarkus/qe/KubernetesUsingExtensionPingPongResourceIT.java
+++ b/examples/pingpong/src/test/java/io/quarkus/qe/KubernetesUsingExtensionPingPongResourceIT.java
@@ -11,8 +11,7 @@ import io.quarkus.test.services.QuarkusApplication;
 public class KubernetesUsingExtensionPingPongResourceIT {
 
     @QuarkusApplication
-    static final RestService pingpong = new RestService()
-            .withProperty("quarkus.kubernetes.service-type", "LoadBalancer");
+    static final RestService pingpong = new RestService();
 
     @Test
     public void shouldPingPongIsUpAndRunning() {

--- a/pom.xml
+++ b/pom.xml
@@ -501,6 +501,23 @@
                 <include.tests>**/Kubernetes*IT.java</include.tests>
                 <exclude.kubernetes.tests>no</exclude.kubernetes.tests>
             </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <configuration>
+                                    <systemPropertyVariables>
+                                        <!-- always set 'Kubernetes' property as that's how detect Kubernetes tests inside FW -->
+                                        <kubernetes>true</kubernetes>
+                                    </systemPropertyVariables>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
         <profile>
             <id>validate-format</id>

--- a/quarkus-test-kubernetes/pom.xml
+++ b/quarkus-test-kubernetes/pom.xml
@@ -19,7 +19,14 @@
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
-            <artifactId>openshift-client</artifactId>
+            <artifactId>kubernetes-client</artifactId>
+            <!--  Excludes artifact from CVE-2023-0833  -->
+            <exclusions>
+                <exclusion>
+                    <groupId>com.squareup.okhttp3</groupId>
+                    <artifactId>okhttp</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.rest-assured</groupId>

--- a/quarkus-test-kubernetes/src/main/java/io/quarkus/test/services/containers/KubernetesContainerManagedResource.java
+++ b/quarkus-test-kubernetes/src/main/java/io/quarkus/test/services/containers/KubernetesContainerManagedResource.java
@@ -2,7 +2,9 @@ package io.quarkus.test.services.containers;
 
 import static java.util.regex.Pattern.quote;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -73,7 +75,7 @@ public class KubernetesContainerManagedResource implements ManagedResource {
         }
 
         return createURI("http",
-                client.host(model.getContext().getOwner()),
+                client.host(),
                 client.port(model.getContext().getOwner()));
     }
 
@@ -100,11 +102,11 @@ public class KubernetesContainerManagedResource implements ManagedResource {
             // replace it by the service owner name
             content = content.replaceAll(quote(customServiceName), model.getContext().getName());
         }
-
+        String args = Arrays.stream(model.getCommand()).map(cmd -> "\"" + cmd + "\"").collect(Collectors.joining(", "));
         return content.replaceAll(quote("${IMAGE}"), model.getImage())
                 .replaceAll(quote("${SERVICE_NAME}"), model.getContext().getName())
                 .replaceAll(quote("${INTERNAL_PORT}"), "" + model.getPort())
-                .replaceAll(quote("${ARGS}"), String.join(" ", model.getCommand()));
+                .replaceAll(quote("${ARGS}"), args);
     }
 
     private boolean useInternalServiceAsUrl() {

--- a/quarkus-test-kubernetes/src/main/java/io/quarkus/test/services/quarkus/ContainerRegistryKubernetesQuarkusApplicationManagedResource.java
+++ b/quarkus-test-kubernetes/src/main/java/io/quarkus/test/services/quarkus/ContainerRegistryKubernetesQuarkusApplicationManagedResource.java
@@ -64,7 +64,6 @@ public class ContainerRegistryKubernetesQuarkusApplicationManagedResource
         return content
                 .replaceAll(quote("${IMAGE}"), image)
                 .replaceAll(quote("${SERVICE_NAME}"), model.getContext().getName())
-                .replaceAll(quote("${ARTIFACT}"), model.getArtifact().getFileName().toString())
                 .replaceAll(quote("${INTERNAL_PORT}"),
                         model.getContext().getOwner().getProperty(QUARKUS_HTTP_PORT_PROPERTY, "" + HTTP_PORT_DEFAULT));
     }

--- a/quarkus-test-kubernetes/src/main/java/io/quarkus/test/services/quarkus/ExtensionKubernetesQuarkusApplicationManagedResource.java
+++ b/quarkus-test-kubernetes/src/main/java/io/quarkus/test/services/quarkus/ExtensionKubernetesQuarkusApplicationManagedResource.java
@@ -34,7 +34,7 @@ public class ExtensionKubernetesQuarkusApplicationManagedResource
 
     private static final String USING_EXTENSION_PROFILE = "-Pdeploy-to-kubernetes-using-extension";
     private static final String QUARKUS_PLUGIN_DEPLOY = "-Dquarkus.kubernetes.deploy=true";
-    private static final String QUARKUS_PLUGIN_INGRESS_EXPOSE = "-Dquarkus.kubernetes.ingress.expose=true";
+    private static final String USING_SERVICE_TYPE_NODE_PORT = "-Dquarkus.kubernetes.service-type=NodePort";
     private static final String QUARKUS_CONTAINER_NAME = "quarkus.application.name";
     private static final String QUARKUS_CONTAINER_IMAGE_REGISTRY = "quarkus.container-image.registry";
     private static final String QUARKUS_CONTAINER_IMAGE_GROUP = "quarkus.container-image.group";
@@ -100,7 +100,7 @@ public class ExtensionKubernetesQuarkusApplicationManagedResource
 
         List<String> args = mvnCommand(model.getContext());
         args.addAll(Arrays.asList(USING_EXTENSION_PROFILE, BATCH_MODE, DISPLAY_VERSION, PACKAGE_GOAL,
-                QUARKUS_PLUGIN_DEPLOY, QUARKUS_PLUGIN_INGRESS_EXPOSE,
+                QUARKUS_PLUGIN_DEPLOY, USING_SERVICE_TYPE_NODE_PORT,
                 SKIP_TESTS, SKIP_ITS, SKIP_CHECKSTYLE, ENSURE_QUARKUS_BUILD));
         propagateContainerRegistryIfSet(args);
         args.add(withContainerName());

--- a/quarkus-test-kubernetes/src/main/java/io/quarkus/test/services/quarkus/KubernetesQuarkusApplicationManagedResource.java
+++ b/quarkus-test-kubernetes/src/main/java/io/quarkus/test/services/quarkus/KubernetesQuarkusApplicationManagedResource.java
@@ -71,13 +71,9 @@ public abstract class KubernetesQuarkusApplicationManagedResource<T extends Quar
 
     @Override
     public URILike getURI(Protocol protocol) {
-        if (protocol == Protocol.HTTPS) {
-            fail("SSL is not supported for Kubernetes tests yet");
-        } else if (protocol == Protocol.GRPC) {
-            fail("gRPC is not supported for Kubernetes tests yet");
-        }
+        validateProtocol(protocol);
         return createURI(protocol.getValue(),
-                client.host(model.getContext().getOwner()),
+                client.host(),
                 client.port(model.getContext().getOwner()));
     }
 

--- a/quarkus-test-kubernetes/src/main/resources/quarkus-app-kubernetes-template.yml
+++ b/quarkus-test-kubernetes/src/main/resources/quarkus-app-kubernetes-template.yml
@@ -2,40 +2,46 @@
 apiVersion: "v1"
 kind: "List"
 items:
-- apiVersion: "v1"
-  kind: "Service"
-  metadata:
-    name: "${SERVICE_NAME}"
-  spec:
-    type: LoadBalancer
-    ports:
-    - port: ${INTERNAL_PORT}
-    selector:
-      app.kubernetes.io/name: "${SERVICE_NAME}"
-- apiVersion: "apps/v1"
-  kind: "Deployment"
-  metadata:
-    labels:
-      app.kubernetes.io/runtime: "quarkus"
-      app.kubernetes.io/name: "${SERVICE_NAME}"
-    name: "${SERVICE_NAME}"
-  spec:
-    replicas: 1
-    selector:
-      matchLabels:
+  - apiVersion: "v1"
+    kind: "Service"
+    metadata:
+      name: "${SERVICE_NAME}"
+      labels:
+        app.kubernetes.io/runtime: "quarkus"
         app.kubernetes.io/name: "${SERVICE_NAME}"
-    template:
-      metadata:
-        labels:
-          app.kubernetes.io/runtime: "quarkus"
+    spec:
+      type: NodePort
+      ports:
+        - name: "http"
+          port: ${INTERNAL_PORT}
+          targetPort: 8080
+          protocol: TCP
+      selector:
+        app.kubernetes.io/name: "${SERVICE_NAME}"
+
+  - apiVersion: "apps/v1"
+    kind: "Deployment"
+    metadata:
+      labels:
+        app.kubernetes.io/runtime: "quarkus"
+        app.kubernetes.io/name: "${SERVICE_NAME}"
+      name: "${SERVICE_NAME}"
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
           app.kubernetes.io/name: "${SERVICE_NAME}"
-          deployment: "${SERVICE_NAME}"
-      spec:
-        containers:
-        - image: "${IMAGE}"
-          name: "${SERVICE_NAME}"
-          ports:
-          - containerPort: ${INTERNAL_PORT}
-            name: "http"
-            protocol: "TCP"
-      
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/runtime: "quarkus"
+            app.kubernetes.io/name: "${SERVICE_NAME}"
+            deployment: "${SERVICE_NAME}"
+        spec:
+          containers:
+            - image: "${IMAGE}"
+              name: "${SERVICE_NAME}"
+              ports:
+                - containerPort: ${INTERNAL_PORT}
+                  name: "http"
+                  protocol: "TCP"

--- a/quarkus-test-service-keycloak/pom.xml
+++ b/quarkus-test-service-keycloak/pom.xml
@@ -27,5 +27,11 @@
             <optional>true</optional>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus.qe</groupId>
+            <artifactId>quarkus-test-kubernetes</artifactId>
+            <optional>true</optional>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/quarkus-test-service-keycloak/src/main/java/io/quarkus/test/services/containers/KubernetesKeycloakContainerManagedResource.java
+++ b/quarkus-test-service-keycloak/src/main/java/io/quarkus/test/services/containers/KubernetesKeycloakContainerManagedResource.java
@@ -1,0 +1,11 @@
+package io.quarkus.test.services.containers;
+
+public class KubernetesKeycloakContainerManagedResource extends KubernetesContainerManagedResource {
+
+    private final KeycloakContainerManagedResourceBuilder model;
+
+    protected KubernetesKeycloakContainerManagedResource(KeycloakContainerManagedResourceBuilder model) {
+        super(model);
+        this.model = model;
+    }
+}

--- a/quarkus-test-service-keycloak/src/main/java/io/quarkus/test/services/containers/KubernetesKeycloakContainerManagedResourceBinding.java
+++ b/quarkus-test-service-keycloak/src/main/java/io/quarkus/test/services/containers/KubernetesKeycloakContainerManagedResourceBinding.java
@@ -1,0 +1,16 @@
+package io.quarkus.test.services.containers;
+
+import io.quarkus.test.bootstrap.ManagedResource;
+import io.quarkus.test.scenarios.KubernetesScenario;
+
+public class KubernetesKeycloakContainerManagedResourceBinding implements KeycloakContainerManagedResourceBinding {
+    @Override
+    public boolean appliesFor(KeycloakContainerManagedResourceBuilder builder) {
+        return builder.getContext().getTestContext().getRequiredTestClass().isAnnotationPresent(KubernetesScenario.class);
+    }
+
+    @Override
+    public ManagedResource init(KeycloakContainerManagedResourceBuilder builder) {
+        return new KubernetesKeycloakContainerManagedResource(builder);
+    }
+}

--- a/quarkus-test-service-keycloak/src/main/resources/META-INF/services/io.quarkus.test.services.containers.KeycloakContainerManagedResourceBinding
+++ b/quarkus-test-service-keycloak/src/main/resources/META-INF/services/io.quarkus.test.services.containers.KeycloakContainerManagedResourceBinding
@@ -1,1 +1,2 @@
 io.quarkus.test.services.containers.OpenShiftKeycloakContainerManagedResourceBinding
+io.quarkus.test.services.containers.KubernetesKeycloakContainerManagedResourceBinding


### PR DESCRIPTION
### Summary

Fix issue https://github.com/quarkus-qe/quarkus-test-framework/issues/433

Now services are exposed with NodePort instead of LoadBalancer
`KubectlClient` was updated to use the new functions from Fabric8 Kubernetes client, deprecated functions were removed. 

Existing Kubernetes test coverage was run locally with connection to temporary Kubernetes cluster. 

I add `KubernetesPostgresqlIT`  to test containers creating for basic scenario.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Dependency update
- [x] Refactoring
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)