### PR TITLE
Fix Kafka SSL scenarios in FIPS enabled environment by regenerating certs

### DIFF
--- a/examples/kafka/src/test/java/io/quarkus/qe/StrimziKafkaWithDefaultSaslSslMessagingIT.java
+++ b/examples/kafka/src/test/java/io/quarkus/qe/StrimziKafkaWithDefaultSaslSslMessagingIT.java
@@ -17,24 +17,13 @@ import io.quarkus.test.services.containers.model.KafkaVendor;
 @QuarkusScenario
 public class StrimziKafkaWithDefaultSaslSslMessagingIT {
 
-    private final static String SASL_USERNAME_VALUE = "client";
-    private final static String SASL_PASSWORD_VALUE = "client-secret";
-    private static final String TRUSTSTORE_FILE = "strimzi-server-ssl-truststore.p12";
-
-    @KafkaContainer(vendor = KafkaVendor.STRIMZI, protocol = KafkaProtocol.SASL_SSL, kafkaConfigResources = TRUSTSTORE_FILE)
+    @KafkaContainer(vendor = KafkaVendor.STRIMZI, protocol = KafkaProtocol.SASL_SSL)
     static final KafkaService kafka = new KafkaService();
 
     @QuarkusApplication
     static final RestService app = new RestService()
-            .withProperty("kafka.bootstrap.servers", kafka::getBootstrapUrl)
-            .withProperty("kafka.security.protocol", "SASL_SSL")
-            .withProperty("kafka.ssl.truststore.location", TRUSTSTORE_FILE)
-            .withProperty("kafka.ssl.truststore.password", "top-secret")
-            .withProperty("kafka.ssl.truststore.type", "PKCS12")
-            .withProperty("kafka.sasl.mechanism", "PLAIN")
-            .withProperty("kafka.sasl.jaas.config", "org.apache.kafka.common.security.plain.PlainLoginModule required "
-                    + "username=\"" + SASL_USERNAME_VALUE + "\" "
-                    + "password=\"" + SASL_PASSWORD_VALUE + "\";");
+            .withProperties(kafka::getSslProperties)
+            .withProperty("kafka.bootstrap.servers", kafka::getBootstrapUrl);
 
     @Test
     public void checkUserResourceByNormalUser() {

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,7 @@
         <infinispan-legacy.image>docker.io/infinispan/server:13.0</infinispan-legacy.image>
         <reruns>2</reruns>
         <flaky-run-reporter.version>0.1.2.Beta1</flaky-run-reporter.version>
+        <certificate-generator.version>0.5.0</certificate-generator.version>
     </properties>
     <distributionManagement>
         <snapshotRepository>
@@ -199,6 +200,11 @@
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-test-maven</artifactId>
                 <version>${quarkus.platform.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>me.escoffier.certs</groupId>
+                <artifactId>certificate-generator</artifactId>
+                <version>${certificate-generator.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/quarkus-test-containers/src/main/java/io/quarkus/test/services/Container.java
+++ b/quarkus-test-containers/src/main/java/io/quarkus/test/services/Container.java
@@ -19,5 +19,11 @@ public @interface Container {
 
     String[] command() default {};
 
+    /**
+     * If true, forwards Docker ports from localhost to Docker host on Windows.
+     * This works around issue when certificates are only generated for localhost.
+     */
+    boolean portDockerHostToLocalhost() default false;
+
     Class<? extends ManagedResourceBuilder> builder() default ContainerManagedResourceBuilder.class;
 }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/BaseService.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/BaseService.java
@@ -102,6 +102,17 @@ public class BaseService<T extends Service> implements Service {
     /**
      * The runtime configuration property to be used if the built artifact is
      * configured to be run.
+     *
+     * NOTE: unlike other {@link this::withProperties}, here we add new properties and keep the old ones
+     */
+    public T withProperties(Supplier<Map<String, String>> newProperties) {
+        futureProperties.add(() -> properties.putAll(newProperties.get()));
+        return (T) this;
+    }
+
+    /**
+     * The runtime configuration property to be used if the built artifact is
+     * configured to be run.
      */
     @Override
     public T withProperty(String key, String value) {

--- a/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/LocalhostManagedResource.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/LocalhostManagedResource.java
@@ -1,0 +1,115 @@
+package io.quarkus.test.bootstrap;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.junit.jupiter.api.condition.OS;
+
+import io.quarkus.test.services.URILike;
+import io.quarkus.test.utils.Command;
+
+/**
+ * Forward Docker ports from localhost to Docker host on Windows. This works around issue when
+ * certificates are only generated for localhost.
+ */
+public final class LocalhostManagedResource implements ManagedResource {
+
+    /**
+     * Our Linux bare-metal instances use Docker on localhost.
+     */
+    private static final boolean FORWARD_PORT = OS.current() == OS.WINDOWS;
+    private final ManagedResource delegate;
+
+    public LocalhostManagedResource(ManagedResource delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return delegate.getDisplayName();
+    }
+
+    @Override
+    public void stop() {
+        if (FORWARD_PORT) {
+            try {
+                // stop port proxy
+                new Command("netsh", "interface", "portproxy", "delete", "v4tov4",
+                        "listenport=" + getExposedPort(), "listenaddress=127.0.0.1").runAndWait();
+            } catch (IOException | InterruptedException e) {
+                throw new RuntimeException(
+                        "Failed delete port proxy for Kafka container port " + getExposedPort(), e);
+            }
+        }
+        delegate.stop();
+    }
+
+    @Override
+    public void start() {
+        delegate.start();
+        if (FORWARD_PORT) {
+            try {
+                // forward localhost:somePort to dockerIp:somePort
+                new Command("netsh", "interface", "portproxy", "add", "v4tov4", "listenport=" + getExposedPort(),
+                        "listenaddress=127.0.0.1", "connectport=" + getExposedPort(),
+                        "connectaddress=" + getDockerHost()).runAndWait();
+            } catch (IOException | InterruptedException e) {
+                throw new RuntimeException(
+                        "Failed to setup forwarding for Kafka container port " + getExposedPort(), e);
+            }
+        }
+    }
+
+    @Override
+    public URILike getURI(Protocol protocol) {
+        var uriLike = delegate.getURI(protocol);
+        if (FORWARD_PORT) {
+            // replace Docker IP with local host
+            uriLike = new URILike(uriLike.getScheme(), "localhost", uriLike.getPort(), uriLike.getPath());
+        }
+        return uriLike;
+    }
+
+    private String getDockerHost() {
+        return delegate.getURI(Protocol.NONE).getHost();
+    }
+
+    private int getExposedPort() {
+        return delegate.getURI(Protocol.NONE).getPort();
+    }
+
+    @Override
+    public boolean isRunning() {
+        return delegate.isRunning();
+    }
+
+    @Override
+    public boolean isFailed() {
+        return delegate.isFailed();
+    }
+
+    @Override
+    public List<String> logs() {
+        return delegate.logs();
+    }
+
+    @Override
+    public void restart() {
+        delegate.restart();
+    }
+
+    @Override
+    public void validate() {
+        delegate.validate();
+    }
+
+    @Override
+    public void afterStart() {
+        delegate.afterStart();
+    }
+
+    @Override
+    public URILike createURI(String scheme, String host, int port) {
+        return delegate.createURI(scheme, host, port);
+    }
+}

--- a/quarkus-test-service-kafka/pom.xml
+++ b/quarkus-test-service-kafka/pom.xml
@@ -52,5 +52,9 @@
             <optional>true</optional>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>me.escoffier.certs</groupId>
+            <artifactId>certificate-generator</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/quarkus-test-service-kafka/src/main/java/io/quarkus/test/bootstrap/KafkaService.java
+++ b/quarkus-test-service-kafka/src/main/java/io/quarkus/test/bootstrap/KafkaService.java
@@ -1,8 +1,13 @@
 package io.quarkus.test.bootstrap;
 
+import static java.util.Objects.requireNonNull;
+
+import java.util.Map;
+
 public class KafkaService extends BaseService<KafkaService> {
 
     public static final String KAFKA_REGISTRY_URL_PROPERTY = "ts.kafka.registry.url";
+    public static final String KAFKA_SSL_PROPERTIES = "ts.kafka.ssl.properties";
 
     public String getBootstrapUrl() {
         var host = getURI();
@@ -11,5 +16,9 @@ public class KafkaService extends BaseService<KafkaService> {
 
     public String getRegistryUrl() {
         return getPropertyFromContext(KAFKA_REGISTRY_URL_PROPERTY);
+    }
+
+    public Map<String, String> getSslProperties() {
+        return requireNonNull(getPropertyFromContext(KAFKA_SSL_PROPERTIES));
     }
 }

--- a/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/KafkaContainerManagedResourceBuilder.java
+++ b/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/KafkaContainerManagedResourceBuilder.java
@@ -3,6 +3,7 @@ package io.quarkus.test.services.containers;
 import java.lang.annotation.Annotation;
 import java.util.ServiceLoader;
 
+import io.quarkus.test.bootstrap.LocalhostManagedResource;
 import io.quarkus.test.bootstrap.ManagedResource;
 import io.quarkus.test.bootstrap.ManagedResourceBuilder;
 import io.quarkus.test.bootstrap.ServiceContext;
@@ -115,7 +116,7 @@ public class KafkaContainerManagedResourceBuilder implements ManagedResourceBuil
         }
 
         if (vendor == KafkaVendor.STRIMZI) {
-            return new StrimziKafkaContainerManagedResource(this);
+            return new LocalhostManagedResource(new StrimziKafkaContainerManagedResource(this));
         }
 
         return new ConfluentKafkaContainerManagedResource(this);

--- a/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/StrimziKafkaContainerManagedResource.java
+++ b/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/StrimziKafkaContainerManagedResource.java
@@ -1,25 +1,42 @@
 package io.quarkus.test.services.containers;
 
+import static me.escoffier.certs.Format.PKCS12;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
 import org.testcontainers.containers.GenericContainer;
 
+import io.quarkus.test.bootstrap.KafkaService;
 import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.services.URILike;
 import io.quarkus.test.services.containers.model.KafkaProtocol;
 import io.quarkus.test.services.containers.model.KafkaVendor;
 import io.quarkus.test.services.containers.strimzi.ExtendedStrimziKafkaContainer;
 import io.quarkus.test.utils.DockerUtils;
+import me.escoffier.certs.CertificateGenerator;
+import me.escoffier.certs.CertificateRequest;
+import me.escoffier.certs.Pkcs12CertificateFiles;
 
 public class StrimziKafkaContainerManagedResource extends BaseKafkaContainerManagedResource {
 
+    private static final String STRIMZI_SERVER_SSL = "strimzi-server-ssl";
     private static final String SSL_SERVER_PROPERTIES_DEFAULT = "strimzi-default-server-ssl.properties";
-    private static final String SSL_SERVER_KEYSTORE_DEFAULT = "strimzi-default-server-ssl-keystore.p12";
+    private static final String DEPRECATED_SSL_SERVER_KEYSTORE = "strimzi-default-server-ssl-keystore.p12";
+    private static final String SSL_SERVER_KEYSTORE = STRIMZI_SERVER_SSL + "-keystore.p12";
+    private static final String SSL_SERVER_TRUSTSTORE = STRIMZI_SERVER_SSL + "-truststore.p12";
     private static final String SASL_SERVER_PROPERTIES_DEFAULT = "strimzi-default-server-sasl.properties";
     private static final String SASL_SSL_SERVER_PROPERTIES_DEFAULT = "strimzi-default-server-sasl-ssl.properties";
+    private static final String SASL_USERNAME_VALUE = "client";
+    private static final String SASL_PASSWORD_VALUE = "client-secret";
 
     protected StrimziKafkaContainerManagedResource(KafkaContainerManagedResourceBuilder model) {
         super(model);
@@ -86,14 +103,76 @@ public class StrimziKafkaContainerManagedResource extends BaseKafkaContainerMana
     }
 
     @Override
+    protected String getResourceTargetName(String resource) {
+        return DEPRECATED_SSL_SERVER_KEYSTORE.equals(resource) ? SSL_SERVER_KEYSTORE : resource;
+    }
+
+    @Override
     protected String[] getKafkaConfigResources() {
         List<String> effectiveUserKafkaConfigResources = new ArrayList<>();
         effectiveUserKafkaConfigResources.addAll(Arrays.asList(super.getKafkaConfigResources()));
 
         if (model.getProtocol() == KafkaProtocol.SSL || model.getProtocol() == KafkaProtocol.SASL_SSL) {
-            effectiveUserKafkaConfigResources.add(SSL_SERVER_KEYSTORE_DEFAULT);
+            final String trustStoreLocation;
+            if (useDefaultServerProperties()) {
+                if (useDefaultTrustStore()) {
+                    // generate certs
+                    final Path certsDir;
+                    try {
+                        certsDir = Files.createTempDirectory("certs");
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                    CertificateGenerator generator = new CertificateGenerator(certsDir, true);
+                    CertificateRequest request = (new CertificateRequest()).withName(STRIMZI_SERVER_SSL)
+                            .withClientCertificate(false).withFormat(PKCS12).withCN("localhost").withPassword("top-secret")
+                            .withDuration(Duration.ofDays(2));
+                    try {
+                        var certFile = (Pkcs12CertificateFiles) generator.generate(request).get(0);
+                        trustStoreLocation = certFile.trustStoreFile().toString();
+                        effectiveUserKafkaConfigResources.add(trustStoreLocation);
+                        effectiveUserKafkaConfigResources.add(certFile.keyStoreFile().toString());
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                } else {
+                    // truststore in application resources dir
+                    trustStoreLocation = SSL_SERVER_TRUSTSTORE;
+
+                    // this we add for backwards compatibility with older tests
+                    // TODO: remove deprecated keystore
+                    effectiveUserKafkaConfigResources.add(DEPRECATED_SSL_SERVER_KEYSTORE);
+                }
+            } else {
+                trustStoreLocation = "${custom-kafka-trust-store-location:}";
+            }
+
+            var configPropertyIterator = Map.of(
+                    "kafka.ssl.enable", "true",
+                    "kafka.ssl.truststore.location", trustStoreLocation,
+                    "kafka.ssl.truststore.password", "top-secret",
+                    "kafka.ssl.truststore.type", "PKCS12");
+            if (model.getProtocol() == KafkaProtocol.SASL_SSL) {
+                configPropertyIterator = new HashMap<>(configPropertyIterator);
+                configPropertyIterator.put("kafka.security.protocol", "SASL_SSL");
+                configPropertyIterator.put("kafka.sasl.mechanism", "PLAIN");
+                configPropertyIterator.put("kafka.sasl.jaas.config",
+                        "org.apache.kafka.common.security.plain.PlainLoginModule required "
+                                + "username=\"" + SASL_USERNAME_VALUE + "\" "
+                                + "password=\"" + SASL_PASSWORD_VALUE + "\";");
+                configPropertyIterator.put("ssl.endpoint.identification.algorithm", "https");
+            }
+            model.getContext().put(KafkaService.KAFKA_SSL_PROPERTIES, Map.copyOf(configPropertyIterator));
         }
 
         return effectiveUserKafkaConfigResources.toArray(new String[effectiveUserKafkaConfigResources.size()]);
+    }
+
+    private boolean useDefaultTrustStore() {
+        return super.getKafkaConfigResources().length == 0;
+    }
+
+    private boolean useDefaultServerProperties() {
+        return model.getServerProperties() == null || model.getServerProperties().isEmpty();
     }
 }

--- a/quarkus-test-service-kafka/src/main/resources/strimzi-default-server-sasl-ssl.properties
+++ b/quarkus-test-service-kafka/src/main/resources/strimzi-default-server-sasl-ssl.properties
@@ -74,14 +74,14 @@ listener.name.sasl_ssl.plain.sasl.jaas.config=org.apache.kafka.common.security.p
 
 ############################# SSL #############################
 
-ssl.keystore.location=/opt/kafka/config/strimzi-default-server-ssl-keystore.p12
+ssl.keystore.location=/opt/kafka/config/strimzi-server-ssl-keystore.p12
 ssl.keystore.password=top-secret
 ssl.keystore.type=PKCS12
 ssl.key.password=top-secret
 ssl.truststore.location=/opt/kafka/config/strimzi-server-ssl-truststore.p12
 ssl.truststore.password=top-secret
 ssl.truststore.type=PKCS12
-ssl.endpoint.identification.algorithm=
+ssl.endpoint.identification.algorithm=https
 ssl.client.auth=required
 
 

--- a/quarkus-test-service-kafka/src/main/resources/strimzi-default-server-ssl.properties
+++ b/quarkus-test-service-kafka/src/main/resources/strimzi-default-server-ssl.properties
@@ -62,7 +62,7 @@ inter.broker.listener.name=BROKER
 
 #### SSL ####
 
-ssl.keystore.location=/opt/kafka/config/strimzi-default-server-ssl-keystore.p12
+ssl.keystore.location=/opt/kafka/config/strimzi-server-ssl-keystore.p12
 ssl.keystore.password=top-secret
 ssl.keystore.type=PKCS12
 ssl.key.password=top-secret


### PR DESCRIPTION
### Summary

We have in place default p12 keystore for Strimzi vendor that has certs generated with algorithm not supported in FIPS. I can't just override it in tests because they all are expecting one truststore. I have decided to re-generate them and refactor it bit to avoid repetition. It's quite quick.

Sadly, this doesn't fix SASL_SSL scenarios as plain auth mechanism just doesn't work in FIPS. I don't know what to do about that part and in the future there will be follow-up, but this PR will help to to fix SSL scenarios at least.

I am adding support for Docker host porting to localhost that we use for Kafka SSL scenarios to also drop repetition.

This PR should be backwards compatible and should not break anything, I run couple of Kafka modules in TS with it.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)