### PR TITLE
Authenticate using SASL/SCRAM-SHA-512 in Kafka SASL_SSL scenarios as PLAIN authentication doesn't work in FIPS-enabled environment

### DIFF
--- a/quarkus-test-service-kafka/src/main/resources/strimzi-default-server-sasl-ssl.properties
+++ b/quarkus-test-service-kafka/src/main/resources/strimzi-default-server-sasl-ssl.properties
@@ -63,14 +63,12 @@ inter.broker.listener.name=BROKER
 
 ############################# SASL_SSL Settings #############################
 
-sasl.enabled.mechanisms=PLAIN
-sasl.mechanism.inter.broker.protocol=PLAIN
+sasl.enabled.mechanisms=SCRAM-SHA-512
+sasl.mechanism.inter.broker.protocol=SCRAM-SHA-512
 
-listener.name.sasl_ssl.plain.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required \
-    username="broker" \
-    password="broker-secret" \
-    user_broker="broker-secret" \
-    user_client="client-secret";
+# Password must have at least 32 characters to work in FIPS-enabled environment
+# see https://strimzi.io/blog/2023/01/25/running-apache-kafka-on-fips-enabled-kubernetes-cluster/
+listener.name.sasl_ssl.scram-sha-512.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="client" password="client-secret12345678912345678912";
 
 ############################# SSL #############################
 


### PR DESCRIPTION
### Summary

This PR makes our SASL_SSL tests pass in FIPS-enabled environment once we migrate them to SCRAM-SHA-512. It's also safer and more likely to be used in production, so win-win. This PR has no relation to OCP tests and is tested in FW by `StrimziKafkaWithDefaultSaslSslMessagingIT`. On FIPS I used `KafkaSaslSslIT` with additional changes.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)