### PR TITLE
Fix runtime config properties recording in OpenShift

### DIFF
--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/GitRepositoryQuarkusApplicationManagedResourceBuilder.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/GitRepositoryQuarkusApplicationManagedResourceBuilder.java
@@ -3,6 +3,7 @@ package io.quarkus.test.services.quarkus;
 import static java.util.regex.Pattern.quote;
 
 import java.lang.annotation.Annotation;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ServiceLoader;
 
@@ -90,5 +91,19 @@ public class GitRepositoryQuarkusApplicationManagedResourceBuilder extends ProdQ
         }
 
         return appFolder;
+    }
+
+    @Override
+    protected void copyResourcesInFolderToAppFolder(Path folder) {
+        // normal apps will create application.properties from parent folder but our source is git project
+        super.copyResourcesInFolderToAppFolder(getApplicationFolder().resolve(folder));
+    }
+
+    @Override
+    protected void copyResourcesToAppFolder() {
+        // app folder may not exist when S2I scenario use OpenShift build strategy where we do not clone git project
+        if (Files.exists(getApplicationFolder())) {
+            super.copyResourcesToAppFolder();
+        }
     }
 }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusApplicationManagedResourceBuilder.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusApplicationManagedResourceBuilder.java
@@ -252,7 +252,7 @@ public abstract class QuarkusApplicationManagedResourceBuilder implements Manage
                         || name.equals(build)); // or it's equal to
     }
 
-    private void copyResourcesInFolderToAppFolder(Path folder) {
+    protected void copyResourcesInFolderToAppFolder(Path folder) {
         try (Stream<Path> binariesFound = Files
                 .find(folder, Integer.MAX_VALUE,
                         (path, basicFileAttributes) -> !Files.isDirectory(path))) {


### PR DESCRIPTION
### Summary

Fixes openshift-tf-jvm-nightly and openshift-tf-native-nightly. _(full disclosure: I also mentioned they can be flaky due to network blips in at least one run of great many I executed, and there was many of blocking warnings, but I suppose that would be a separate issue if repeated)_

OpenShiftExtensionIT and OpenShiftDockerBuildIT are failing with Quarkus 3.8.4 (but not 3.8.3) and 999-SNAPSHOT as runtime values recorder at build time are not kept any more https://github.com/quarkusio/quarkus/pull/39604. In OpenShift, runtime system properties set to mvn when we do `.withProperty("quarkus.management.port", "9002")` are not propagated so we need to copy them always to application properties. This behavior is IMHO correct because the change in Quarkus solved leaking of sensitive information.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)