### PR TITLE
Change check of Kubernetes annotation for Keycloak resource binding

### DIFF
--- a/quarkus-test-service-keycloak/src/main/java/io/quarkus/test/services/containers/KubernetesKeycloakContainerManagedResourceBinding.java
+++ b/quarkus-test-service-keycloak/src/main/java/io/quarkus/test/services/containers/KubernetesKeycloakContainerManagedResourceBinding.java
@@ -1,12 +1,17 @@
 package io.quarkus.test.services.containers;
 
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+
 import io.quarkus.test.bootstrap.ManagedResource;
-import io.quarkus.test.scenarios.KubernetesScenario;
 
 public class KubernetesKeycloakContainerManagedResourceBinding implements KeycloakContainerManagedResourceBinding {
     @Override
     public boolean appliesFor(KeycloakContainerManagedResourceBuilder builder) {
-        return builder.getContext().getTestContext().getRequiredTestClass().isAnnotationPresent(KubernetesScenario.class);
+        Annotation[] annotations = builder.getContext().getTestContext().getRequiredTestClass().getAnnotations();
+        return Arrays.stream(annotations)
+                .anyMatch(annotation -> annotation.annotationType().getName()
+                        .equals("io.quarkus.test.scenarios.KubernetesScenario"));
     }
 
     @Override


### PR DESCRIPTION
### Summary

After adding Kubernetes support in https://github.com/quarkus-qe/quarkus-test-framework/pull/1083, tests that uses KeycloakContainer start to fail on bare metal because of `java.lang.NoClassDefFoundError: io/quarkus/test/scenarios/KubernetesScenario`.
Ideally we don't want to add `quarkus-test-kubernetes` dependency in each test module, so the next workaround is provided in this PR


Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)
- [x] This change requires execution against K8s (use `run kube tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)