### PR TITLE
Revert "Release 1.4.4"

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 name: Quarkus QE Test Framework
 release:
-  current-version: 1.4.4
-  next-version: 1.4.5
+  current-version: 1.4.2.Beta8
+  next-version: 1.4.3.Beta8


### PR DESCRIPTION
Reverts quarkus-qe/quarkus-test-framework#1109, because we didn't have correct version of project set and we cannot release non-SNAPSHOT version.