### PR TITLE
[1.4.z] Fix runtime config properties recording in OpenShift

### DIFF
--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/GitRepositoryQuarkusApplicationManagedResourceBuilder.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/GitRepositoryQuarkusApplicationManagedResourceBuilder.java
@@ -3,6 +3,7 @@ package io.quarkus.test.services.quarkus;
 import static java.util.regex.Pattern.quote;
 
 import java.lang.annotation.Annotation;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ServiceLoader;
 
@@ -90,5 +91,19 @@ public class GitRepositoryQuarkusApplicationManagedResourceBuilder extends ProdQ
         }
 
         return appFolder;
+    }
+
+    @Override
+    protected void copyResourcesInFolderToAppFolder(Path folder) {
+        // normal apps will create application.properties from parent folder but our source is git project
+        super.copyResourcesInFolderToAppFolder(getApplicationFolder().resolve(folder));
+    }
+
+    @Override
+    protected void copyResourcesToAppFolder() {
+        // app folder may not exist when S2I scenario use OpenShift build strategy where we do not clone git project
+        if (Files.exists(getApplicationFolder())) {
+            super.copyResourcesToAppFolder();
+        }
     }
 }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusApplicationManagedResourceBuilder.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusApplicationManagedResourceBuilder.java
@@ -269,7 +269,7 @@ public abstract class QuarkusApplicationManagedResourceBuilder implements Manage
                         || name.equals(build)); // or it's equal to
     }
 
-    private void copyResourcesInFolderToAppFolder(Path folder) {
+    protected void copyResourcesInFolderToAppFolder(Path folder) {
         try (Stream<Path> binariesFound = Files
                 .find(folder, Integer.MAX_VALUE,
                         (path, basicFileAttributes) -> !Files.isDirectory(path))) {


### PR DESCRIPTION
### Summary

Backports https://github.com/quarkus-qe/quarkus-test-framework/pull/1094 as `io.quarkus.qe.OpenShiftDockerBuildIT`, `io.quarkus.qe.OpenShiftExtensionIT` are failing quite a lot now (in 1.4.z CI) and I think maybe, it could be related to https://github.com/quarkusio/quarkus/pull/40079.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [x] Backport
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)