### PR TITLE
[1.4.z] Fix OpenShiftStrimziOperatorKafkaWithoutRegistryMessagingIT

### DIFF
--- a/quarkus-test-service-kafka/src/main/resources/strimzi-operator-kafka-instance.yaml
+++ b/quarkus-test-service-kafka/src/main/resources/strimzi-operator-kafka-instance.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kafka-instance
 spec:
   kafka:
-    version: 3.5.0
+    version: 3.6.0
     replicas: 1
     listeners:
       - name: plain


### PR DESCRIPTION
### Summary

This test fails over _Unsupported Kafka.spec.kafka.version: 3.5.0. Supported versions are: [3.6.0, 3.6.1, 3.7.0]_. We cannot use 3.7 without changes in TS as AMQ does not support it https://github.com/quarkus-qe/quarkus-test-suite/pull/1762.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)