### PR TITLE
Fix PEM certificate generation and mounting in OpenShift

### DIFF
--- a/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/BaseService.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/BaseService.java
@@ -274,7 +274,11 @@ public class BaseService<T extends Service> implements Service {
         } else {
             this.configuration = Configuration.load(serviceName, originalServiceName);
         }
+
         this.context = new ServiceContext(this, context);
+        onPreStart(s -> properties.putAll(this.context.getConfigPropertiesWithTestScope()));
+        onPreStop(s -> this.context.getConfigPropertiesWithTestScope().forEach((k, v) -> properties.remove(k)));
+
         onPreStart(s -> futureProperties.forEach(Runnable::run));
         context.getTestStore().put(serviceName, this);
         return this.context;

--- a/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/ServiceContext.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/ServiceContext.java
@@ -11,6 +11,17 @@ public final class ServiceContext {
     private final Path serviceFolder;
     private final Map<String, Object> store = new HashMap<>();
 
+    /**
+     * Whatever we put into {@link Service#withProperty(String, String)} is stored inside static field instance.
+     * Like 'static RestService app = new RestService()'.
+     * If a couple of test classes has same superclass and the 'app' field is in that superclass, properties are shared.
+     * That is if during the execution of the first test class you put there dynamically property "a",
+     * the "a" property will be there when the next test class is executed.
+     *
+     * This field stores properties that has only a test class scope.
+     */
+    private final Map<String, String> configPropertiesWithTestScope = new HashMap<>();
+
     ServiceContext(Service owner, ScenarioContext scenarioContext) {
         this.owner = owner;
         this.scenarioContext = scenarioContext;
@@ -52,6 +63,15 @@ public final class ServiceContext {
     @SuppressWarnings("unchecked")
     public <T> T get(String key) {
         return (T) store.get(key);
+    }
+
+    public ServiceContext withTestScopeConfigProperty(String key, String value) {
+        configPropertiesWithTestScope.put(key, value);
+        return this;
+    }
+
+    Map<String, String> getConfigPropertiesWithTestScope() {
+        return configPropertiesWithTestScope;
     }
 
     private String getArtifactIdFromGav(String gav) {

--- a/quarkus-test-core/src/main/java/io/quarkus/test/security/certificate/CertificateBuilder.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/security/certificate/CertificateBuilder.java
@@ -11,6 +11,8 @@ public interface CertificateBuilder {
 
     List<Certificate> certificates();
 
+    Certificate findCertificateByPrefix(String prefix);
+
     static CertificateBuilder of(io.quarkus.test.services.Certificate[] certificates) {
         if (certificates == null || certificates.length == 0) {
             return null;

--- a/quarkus-test-core/src/main/java/io/quarkus/test/security/certificate/CertificateBuilderImp.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/security/certificate/CertificateBuilderImp.java
@@ -1,6 +1,12 @@
 package io.quarkus.test.security.certificate;
 
 import java.util.List;
+import java.util.Objects;
 
 record CertificateBuilderImp(List<Certificate> certificates) implements CertificateBuilder {
+    @Override
+    public Certificate findCertificateByPrefix(String prefix) {
+        Objects.requireNonNull(prefix);
+        return certificates.stream().filter(c -> prefix.equals(c.prefix())).findFirst().orElse(null);
+    }
 }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/security/certificate/CertificateImpl.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/security/certificate/CertificateImpl.java
@@ -5,7 +5,8 @@ import java.util.Map;
 import java.util.Objects;
 
 record CertificateImpl(String keystorePath, String truststorePath, Map<String, String> configProperties,
-        Collection<ClientCertificate> clientCertificates, String password, String format) implements Certificate {
+        Collection<ClientCertificate> clientCertificates, String password, String format, String keyPath, String certPath,
+        String prefix) implements Certificate.PemCertificate {
 
     @Override
     public ClientCertificate getClientCertificateByCn(String cn) {

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusApplicationManagedResourceBuilder.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusApplicationManagedResourceBuilder.java
@@ -221,7 +221,7 @@ public abstract class QuarkusApplicationManagedResourceBuilder implements Manage
                     .certificates()
                     .forEach(certificate -> certificate
                             .configProperties()
-                            .forEach((k, v) -> context.getOwner().withProperty(k, v)));
+                            .forEach((k, v) -> getContext().withTestScopeConfigProperty(k, v)));
         }
     }
 


### PR DESCRIPTION
### Summary

Fixes:

- PEM NPE in OCP:  I have fixes in Quarkus QE Test Suite that requires FIPS-compatible PEM certificates. However right now the certificate library we use to generation returns path to the `some-prefix-server-ca.crt` even though it doesn't exist and so mounting in OpenShift fails over missing file. 
- PEM cert and key mounting: private key and certificates are not mounted for us. This fixes that issue.
- scope of certificate config properties: I mentioned that when tests share same base class as Vert.x JWT tests do, all previously generated certs are mounted to OCP because the scope of properties set via `io.quarkus.test.bootstrap.BaseService#withProperty(java.lang.String, java.lang.String)` is _all the tests of all test classes_ (AKA `RestService` is stored in a static field). This PR avoids mounting of certs from previous tests.

Here are tests https://github.com/quarkus-qe/quarkus-test-suite/commit/774d6d02acbd32011fe2f962f2214ff83241e891 I run both baremetal (in FIPS) and OpenShift tests with this change and they pass.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)