### PR TITLE
Finishing some TODOs and enable SureFireDebugIT on snapshot

### DIFF
--- a/examples/consul/src/test/java/io/quarkus/qe/GreetingResourceIT.java
+++ b/examples/consul/src/test/java/io/quarkus/qe/GreetingResourceIT.java
@@ -7,11 +7,6 @@ import io.quarkus.test.services.Container;
 @QuarkusScenario
 public class GreetingResourceIT extends BaseGreetingResourceIT {
 
-    /**
-     * The framework will try to resolve the property `property.do.not.exist`
-     * and as it does not exist, it will use the default image.
-     */
-    // TODO use official image when/if this fixed https://github.com/hashicorp/docker-consul/issues/184
-    @Container(image = "${property.do.not.exist:docker.io/bitnami/consul:1.13.1}", expectedLog = "Synced node info", port = 8500)
+    @Container(image = "${consul.image}", expectedLog = "Synced node info", port = 8500)
     static ConsulService consul = new ConsulService().onPostStart(BaseGreetingResourceIT::onLoadConfigureConsul);
 }

--- a/examples/database-oracle/src/test/resources/test.properties
+++ b/examples/database-oracle/src/test/resources/test.properties
@@ -1,4 +1,4 @@
-# TODO https://github.com/quarkusio/quarkus/issues/26228
+# TODO https://github.com/quarkusio/quarkus/issues/26228 update app and database log to true
 ts.app.log.enable=false
 ts.database.log.enable=false
 ts.database.openshift.use-internal-service-as-url=true

--- a/examples/debug/src/test/java/io/quarkus/qe/debug/SureFireDebugIT.java
+++ b/examples/debug/src/test/java/io/quarkus/qe/debug/SureFireDebugIT.java
@@ -21,12 +21,7 @@ import io.quarkus.maven.it.MojoTestBase;
 import io.quarkus.maven.it.verifier.MavenProcessInvocationResult;
 import io.quarkus.maven.it.verifier.RunningInvoker;
 import io.quarkus.test.scenarios.annotations.DisabledOnNative;
-import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusSnapshot;
 
-// FIXME: run tests on Quarkus snapshot as well when we are on 3.6.x
-//   we can't run them now due to conflicting Groovy versions used by RestAssured library
-//   which is causing class loading issues when on 999-SNAPSHOT
-@DisabledOnQuarkusSnapshot(reason = "RestAssured 5.3.2 is using different Groovy version than 5.3.0")
 @DisabledOnOs(WINDOWS)
 @DisabledOnNative
 public class SureFireDebugIT extends MojoTestBase {

--- a/examples/external-applications/src/test/java/io/quarkus/qe/QuickstartUsingUsingUberJarIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/QuickstartUsingUsingUberJarIT.java
@@ -15,8 +15,7 @@ import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Windows does not support long file paths")
 public class QuickstartUsingUsingUberJarIT {
 
-    // TODO: drop config key quarkus.package.type when Quarkus is bumped to 3.10
-    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", contextDir = "getting-started", mavenArgs = "-Dquarkus.package.jar.type=uber-jar -Dquarkus.package.type=uber-jar -DskipTests=true -Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus.platform.version=${QUARKUS_PLATFORM_VERSION}")
+    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", contextDir = "getting-started", mavenArgs = "-Dquarkus.package.jar.type=uber-jar -DskipTests=true -Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus.platform.version=${QUARKUS_PLATFORM_VERSION}")
     static final RestService app = new RestService();
 
     @Test

--- a/examples/external-applications/src/test/java/io/quarkus/qe/TodoDemoIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/TodoDemoIT.java
@@ -16,8 +16,7 @@ import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 public class TodoDemoIT {
     private static final String REPO = "https://github.com/quarkusio/todo-demo-app.git";
     private static final String DEFAULT_ARGS = "-DskipTests=true -Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus.platform.version=${QUARKUS_PLATFORM_VERSION} ";
-    // TODO: drop config key quarkus.package.type when Quarkus is bumped to 3.10
-    private static final String UBER = "-Dquarkus.package.type=uber-jar -Dquarkus.package.jar.type=uber-jar ";
+    private static final String UBER = "-Dquarkus.package.jar.type=uber-jar ";
 
     @GitRepositoryQuarkusApplication(repo = REPO, mavenArgs = DEFAULT_ARGS + UBER)
     static final RestService app = new RestService();

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,8 @@
         <mysql.image>docker.io/mysql:8.3.0</mysql.image>
         <infinispan.image>docker.io/infinispan/server:14.0</infinispan.image>
         <infinispan-legacy.image>docker.io/infinispan/server:13.0</infinispan-legacy.image>
+        <!-- TODO use official image if this fixed https://github.com/hashicorp/docker-consul/issues/184 -->
+        <consul.image>docker.io/bitnami/consul:1.18.1</consul.image>
         <reruns>2</reruns>
         <flaky-run-reporter.version>0.1.2.Beta1</flaky-run-reporter.version>
         <certificate-generator.version>0.6.0</certificate-generator.version>
@@ -358,6 +360,7 @@
                                 <mysql.image>${mysql.image}</mysql.image>
                                 <infinispan.image>${infinispan.image}</infinispan.image>
                                 <infinispan-legacy.image>${infinispan-legacy.image}</infinispan-legacy.image>
+                                <consul.image>${consul.image}</consul.image>
                             </systemProperties>
                             <argLine>${jacoco.agent.argLine}</argLine>
                             <excludedGroups>${exclude.tests.with.tags}</excludedGroups>

--- a/pom.xml
+++ b/pom.xml
@@ -428,7 +428,6 @@
                                     <systemProperties>
                                         <quarkus.native.enabled>${quarkus.native.enabled}</quarkus.native.enabled>
                                         <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                                        <quarkus.package.type>${quarkus.package.type}</quarkus.package.type>
                                         <quarkus.native.container-build>${quarkus.native.container-build}</quarkus.native.container-build>
                                         <quarkus.native.native-image-xmx>${quarkus.native.native-image-xmx}</quarkus.native.native-image-xmx>
                                     </systemProperties>
@@ -440,8 +439,6 @@
             </build>
             <properties>
                 <quarkus.native.enabled>true</quarkus.native.enabled>
-                <!-- TODO: drop next line when Quarkus is bumped to 3.10 -->
-                <quarkus.package.type>native</quarkus.package.type>
                 <quarkus.native.container-build>true</quarkus.native.container-build>
                 <quarkus.native.native-image-xmx>5g</quarkus.native.native-image-xmx>
                 <exclude.quarkus.devmode.tests>**/*DevMode*IT.java</exclude.quarkus.devmode.tests>

--- a/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/annotations/DisabledOnNativeCondition.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/annotations/DisabledOnNativeCondition.java
@@ -10,7 +10,7 @@ public class DisabledOnNativeCondition implements ExecutionCondition {
 
     @Override
     public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
-        if (!QuarkusProperties.isNativePackageType()) {
+        if (!QuarkusProperties.isNativeEnabled()) {
             return ConditionEvaluationResult.enabled("It's not running the test on Native");
         }
 

--- a/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/annotations/EnabledOnNativeCondition.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/annotations/EnabledOnNativeCondition.java
@@ -10,7 +10,7 @@ public class EnabledOnNativeCondition implements ExecutionCondition {
 
     @Override
     public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
-        if (QuarkusProperties.isNativePackageType()) {
+        if (QuarkusProperties.isNativeEnabled()) {
             return ConditionEvaluationResult.enabled("Running test as it's running on Native");
         }
 

--- a/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/execution/condition/DisableDevModeTestsInNativeExecutionCondition.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/execution/condition/DisableDevModeTestsInNativeExecutionCondition.java
@@ -1,7 +1,7 @@
 package io.quarkus.test.scenarios.execution.condition;
 
 import static io.quarkus.test.scenarios.execution.condition.AbstractQuarkusScenarioContainerExecutionCondition.CONDITION_NOT_MATCHED;
-import static io.quarkus.test.services.quarkus.model.QuarkusProperties.isNativePackageType;
+import static io.quarkus.test.services.quarkus.model.QuarkusProperties.isNativeEnabled;
 
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
@@ -25,7 +25,7 @@ public class DisableDevModeTestsInNativeExecutionCondition implements QuarkusSce
     }
 
     private static ConditionEvaluationResult evaluate(Class<?> testClass) {
-        if (isNativePackageType() && isDevModeTest(testClass)) {
+        if (isNativeEnabled() && isDevModeTest(testClass)) {
             return ConditionEvaluationResult.disabled("DEV mode tests can't be run when native mode is enabled");
         } else {
             return ConditionEvaluationResult.enabled("Not a DEV mode test in native mode");

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/ProdQuarkusApplicationManagedResourceBuilder.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/ProdQuarkusApplicationManagedResourceBuilder.java
@@ -141,7 +141,7 @@ public class ProdQuarkusApplicationManagedResourceBuilder extends ArtifactQuarku
         }
         createSnapshotOfBuildPropertiesIfNotExists();
         if (!buildPropertiesChanged()) {
-            if (QuarkusProperties.isNativePackageType(getContext())) {
+            if (QuarkusProperties.isNativeEnabled(getContext())) {
                 // custom native executable has different name, therefore we can safely re-use it
                 artifactLocation = findNativeBuildExecutable(targetFolder, requiresCustomBuild(), getApplicationFolder());
             } else if (!requiresCustomBuild()) {
@@ -158,7 +158,7 @@ public class ProdQuarkusApplicationManagedResourceBuilder extends ArtifactQuarku
     }
 
     private Path buildArtifact() {
-        if (QuarkusProperties.isNativePackageType(getContext())) {
+        if (QuarkusProperties.isNativeEnabled(getContext())) {
             return new QuarkusMavenPluginBuildHelper(this, getTargetFolderForLocalArtifacts())
                     .buildNativeExecutable()
                     .orElseGet(() -> {

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusManagedResource.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusManagedResource.java
@@ -84,7 +84,7 @@ public abstract class QuarkusManagedResource implements ManagedResource {
 
     private static LaunchMode detectLaunchMode(ServiceContext serviceContext) {
         LaunchMode launchMode = LaunchMode.JVM;
-        if (QuarkusProperties.isNativePackageType(serviceContext)) {
+        if (QuarkusProperties.isNativeEnabled(serviceContext)) {
             launchMode = LaunchMode.NATIVE;
         } else if (QuarkusProperties.isLegacyJarPackageType(serviceContext)) {
             launchMode = LaunchMode.LEGACY_JAR;

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/model/QuarkusProperties.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/model/QuarkusProperties.java
@@ -18,10 +18,7 @@ public final class QuarkusProperties {
     public static final String QUARKUS_ANALYTICS_DISABLED_LOCAL_PROP_KEY = "quarkus.analytics.disabled";
     public static final PropertyLookup QUARKUS_ANALYTICS_DISABLED_LOCAL_PROP = new PropertyLookup(
             QUARKUS_ANALYTICS_DISABLED_LOCAL_PROP_KEY, "true");
-    // TODO: drop ternary operator when Quarkus version is bumped to 3.10
-    public static final String PACKAGE_TYPE_NAME = defaultVersionIfEmpty(PLATFORM_VERSION.get()).startsWith("3.9.")
-            ? "quarkus.package.type"
-            : "quarkus.package.jar.type";
+    public static final String PACKAGE_TYPE_NAME = "quarkus.package.jar.type";
     public static final String MUTABLE_JAR = "mutable-jar";
     public static final PropertyLookup PACKAGE_TYPE = new PropertyLookup(PACKAGE_TYPE_NAME);
     public static final List<String> PACKAGE_TYPE_NATIVE_VALUES = Arrays.asList("native", "native-sources");

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/model/QuarkusProperties.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/model/QuarkusProperties.java
@@ -21,7 +21,6 @@ public final class QuarkusProperties {
     public static final String PACKAGE_TYPE_NAME = "quarkus.package.jar.type";
     public static final String MUTABLE_JAR = "mutable-jar";
     public static final PropertyLookup PACKAGE_TYPE = new PropertyLookup(PACKAGE_TYPE_NAME);
-    public static final List<String> PACKAGE_TYPE_NATIVE_VALUES = Arrays.asList("native", "native-sources");
     public static final List<String> PACKAGE_TYPE_LEGACY_JAR_VALUES = Arrays.asList("legacy-jar", "uber-jar", "mutable-jar");
     public static final List<String> PACKAGE_TYPE_JVM_VALUES = Arrays.asList("fast-jar", "jar");
     public static final PropertyLookup QUARKUS_JVM_S2I = new PropertyLookup("quarkus.s2i.base-jvm-image",
@@ -45,18 +44,12 @@ public final class QuarkusProperties {
         return QUARKUS_ANALYTICS_DISABLED_LOCAL_PROP.getAsBoolean();
     }
 
-    public static boolean isNativePackageType() {
-        // TODO: simplify condition when Quarkus version is bumped to 3.10
-        return isNativeEnabled() || PACKAGE_TYPE_NATIVE_VALUES.contains(PACKAGE_TYPE.get());
-    }
-
-    public static boolean isNativePackageType(ServiceContext context) {
-        // TODO: simplify condition when Quarkus version is bumped to 3.10
-        return isNativeEnabled() || PACKAGE_TYPE_NATIVE_VALUES.contains(PACKAGE_TYPE.get(context));
-    }
-
     public static boolean isNativeEnabled() {
         return Boolean.parseBoolean(NATIVE_ENABLED.get());
+    }
+
+    public static boolean isNativeEnabled(ServiceContext context) {
+        return Boolean.parseBoolean(NATIVE_ENABLED.get(context));
     }
 
     public static boolean isLegacyJarPackageType(ServiceContext context) {

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
@@ -825,7 +825,7 @@ public final class OpenShiftClient {
         deployment.getSpec().getTemplate().getSpec().getVolumes().add(volume);
 
         // $PWD/config/application.properties
-        var pwd = QuarkusProperties.isNativePackageType() ? "/home/quarkus" : "/deployments";
+        var pwd = QuarkusProperties.isNativeEnabled() ? "/home/quarkus" : "/deployments";
 
         // mount volume to each deployment config containers
         var volumeMount = new VolumeMountBuilder()


### PR DESCRIPTION
### Summary

1. Removing quarkus.package.type as 3.10 is out + change `isNativePackageType` method to `isNativeEnabled` as native is not defined by package type property.
2. Updating consul image version to latest and moving it from class to pom. This removing showcase of image property defaulting to some image but the consul was not updated for some time. Maybe this should be just mention in docs.
3. Enable SureFireDebugIT on snapshot
4. Update TODO message 

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)