### PR TITLE
Update kafka, module executions times and jaeger properties

### DIFF
--- a/examples/funqy-knative-events/pom.xml
+++ b/examples/funqy-knative-events/pom.xml
@@ -10,6 +10,10 @@
     <artifactId>examples-funqy-knative-events</artifactId>
     <packaging>jar</packaging>
     <name>Quarkus - Test Framework - Examples - Funqy - Knative Events</name>
+    <properties>
+        <!-- Skip Quarkus build as this module have only Openshift tests and app have fixed build time properties -->
+        <quarkus.build.skip>true</quarkus.build.skip>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/examples/jaeger/src/main/resources/application.properties
+++ b/examples/jaeger/src/main/resources/application.properties
@@ -1,4 +1,3 @@
-quarkus.jaeger.sampler-type=const
-quarkus.jaeger.sampler-param=1
-quarkus.opentelemetry.enabled=true
+quarkus.otel.traces.sampler=traceidratio
+quarkus.otel.traces.sampler.arg=1
 quarkus.application.name=test-traced-service

--- a/examples/kafka/pom.xml
+++ b/examples/kafka/pom.xml
@@ -48,7 +48,7 @@
                         <configuration>
                             <systemProperties>
                                 <custom.kafka.image>quay.io/strimzi/kafka</custom.kafka.image>
-                                <custom.kafka.version>0.39.0-kafka-3.6.0</custom.kafka.version>
+                                <custom.kafka.version>0.41.0-kafka-3.7.0</custom.kafka.version>
                             </systemProperties>
                         </configuration>
                     </execution>

--- a/examples/management/pom.xml
+++ b/examples/management/pom.xml
@@ -9,10 +9,6 @@
     </parent>
     <artifactId>examples-management</artifactId>
     <name>Quarkus - Test Framework - Examples - Management Interface</name>
-    <properties>
-        <!-- Skip build since our framework will build own executable anyway as it detects build-time properties -->
-        <quarkus.build.skip>true</quarkus.build.skip>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/model/KafkaRegistry.java
+++ b/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/model/KafkaRegistry.java
@@ -2,7 +2,7 @@ package io.quarkus.test.services.containers.model;
 
 public enum KafkaRegistry {
     CONFLUENT("confluentinc/cp-schema-registry", "7.5.3", "/", 8081),
-    APICURIO("quay.io/apicurio/apicurio-registry-mem", "2.5.8.Final", "/apis", 8080);
+    APICURIO("quay.io/apicurio/apicurio-registry-mem", "2.5.11.Final", "/apis", 8080);
 
     private final String image;
     private final String defaultVersion;

--- a/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/model/KafkaRegistry.java
+++ b/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/model/KafkaRegistry.java
@@ -1,7 +1,7 @@
 package io.quarkus.test.services.containers.model;
 
 public enum KafkaRegistry {
-    CONFLUENT("confluentinc/cp-schema-registry", "7.5.3", "/", 8081),
+    CONFLUENT("confluentinc/cp-schema-registry", "7.6.1", "/", 8081),
     APICURIO("quay.io/apicurio/apicurio-registry-mem", "2.5.11.Final", "/apis", 8080);
 
     private final String image;

--- a/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/model/KafkaVendor.java
+++ b/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/model/KafkaVendor.java
@@ -2,7 +2,8 @@ package io.quarkus.test.services.containers.model;
 
 public enum KafkaVendor {
     CONFLUENT("confluentinc/cp-kafka", "7.5.3", 9093, KafkaRegistry.CONFLUENT),
-    STRIMZI("quay.io/strimzi/kafka", "0.39.0-kafka-3.6.1", 9092, KafkaRegistry.APICURIO);
+    // When updating strimzi kafka also update version in examples-kafka pom
+    STRIMZI("quay.io/strimzi/kafka", "0.41.0-kafka-3.7.0", 9092, KafkaRegistry.APICURIO);
 
     private final String image;
     private final String defaultVersion;

--- a/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/model/KafkaVendor.java
+++ b/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/model/KafkaVendor.java
@@ -1,7 +1,7 @@
 package io.quarkus.test.services.containers.model;
 
 public enum KafkaVendor {
-    CONFLUENT("confluentinc/cp-kafka", "7.5.3", 9093, KafkaRegistry.CONFLUENT),
+    CONFLUENT("confluentinc/cp-kafka", "7.6.1", 9093, KafkaRegistry.CONFLUENT),
     // When updating strimzi kafka also update version in examples-kafka pom
     STRIMZI("quay.io/strimzi/kafka", "0.41.0-kafka-3.7.0", 9092, KafkaRegistry.APICURIO);
 


### PR DESCRIPTION
### Summary

Updating kafka images to latest versions

Remove `quarkus.skip.build`  from example/management pom to speed up native builds

Add `quarkus.skip.build` to example/funqy-knative-events as this is only executed on openshift and have fixed build time properties

Update jaeger properties as Quarkus migrate from OpenTracing to OpenTelemetry (see [big-bang-change-from-opentracing-to-opentelemetry](https://quarkus.io/version/main/guides/telemetry-opentracing-to-otel-tutorial#big-bang-change-from-opentracing-to-opentelemetry))

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Dependency update
- [x] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)