### PR TITLE
Support encrypted communication between Quarkus app with MSSQL JDBC extension and SQL Server

### DIFF
--- a/quarkus-test-containers/src/main/java/io/quarkus/test/services/containers/ContainerManagedResourceBuilder.java
+++ b/quarkus-test-containers/src/main/java/io/quarkus/test/services/containers/ContainerManagedResourceBuilder.java
@@ -46,11 +46,16 @@ public class ContainerManagedResourceBuilder implements ManagedResourceBuilder {
     @Override
     public void init(Annotation annotation) {
         Container metadata = (Container) annotation;
-        this.image = PropertiesUtils.resolveProperty(metadata.image());
-        this.command = metadata.command();
-        this.expectedLog = PropertiesUtils.resolveProperty(metadata.expectedLog());
-        this.port = metadata.port();
-        this.portDockerHostToLocalhost = metadata.portDockerHostToLocalhost();
+        init(metadata.image(), metadata.command(), metadata.expectedLog(), metadata.port(),
+                metadata.portDockerHostToLocalhost());
+    }
+
+    protected void init(String image, String[] command, String expectedLog, int port, boolean portDockerHostToLocalhost) {
+        this.image = PropertiesUtils.resolveProperty(image);
+        this.command = command;
+        this.expectedLog = PropertiesUtils.resolveProperty(expectedLog);
+        this.port = port;
+        this.portDockerHostToLocalhost = portDockerHostToLocalhost;
     }
 
     @Override

--- a/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/ServiceContext.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/ServiceContext.java
@@ -70,7 +70,7 @@ public final class ServiceContext {
         return this;
     }
 
-    Map<String, String> getConfigPropertiesWithTestScope() {
+    public Map<String, String> getConfigPropertiesWithTestScope() {
         return configPropertiesWithTestScope;
     }
 

--- a/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/annotations/DisabledOnFipsAndJava17.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/annotations/DisabledOnFipsAndJava17.java
@@ -1,0 +1,20 @@
+package io.quarkus.test.scenarios.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Inherited
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(DisabledOnFipsAndJava17Condition.class)
+public @interface DisabledOnFipsAndJava17 {
+    /**
+     * Why is the annotated test class or test method disabled.
+     */
+    String reason() default "";
+}

--- a/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/annotations/DisabledOnFipsAndJava17Condition.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/annotations/DisabledOnFipsAndJava17Condition.java
@@ -1,0 +1,31 @@
+package io.quarkus.test.scenarios.annotations;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class DisabledOnFipsAndJava17Condition implements ExecutionCondition {
+
+    /**
+     * We set environment variable "FIPS" to "fips" in our Jenkins jobs when FIPS are enabled.
+     */
+    private static final String FIPS_ENABLED = "fips";
+    private static final int JAVA_17 = 17;
+
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+        if (isFipsEnabledEnvironment() && isJava17()) {
+            return ConditionEvaluationResult.disabled("The test is running in FIPS enabled environment with Java 17");
+        }
+
+        return ConditionEvaluationResult.enabled("The test is not running in FIPS enabled environment with Java 17");
+    }
+
+    private static boolean isFipsEnabledEnvironment() {
+        return FIPS_ENABLED.equals(System.getenv().get("FIPS"));
+    }
+
+    private static boolean isJava17() {
+        return JAVA_17 == Runtime.version().feature();
+    }
+}

--- a/quarkus-test-core/src/main/java/io/quarkus/test/security/certificate/Certificate.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/security/certificate/Certificate.java
@@ -3,19 +3,21 @@ package io.quarkus.test.security.certificate;
 import static io.quarkus.test.services.Certificate.Format.PKCS12;
 import static io.quarkus.test.utils.PropertiesUtils.DESTINATION_TO_FILENAME_SEPARATOR;
 import static io.quarkus.test.utils.PropertiesUtils.SECRET_WITH_DESTINATION_PREFIX;
-import static io.quarkus.test.utils.TestExecutionProperties.isKubernetesPlatform;
-import static io.quarkus.test.utils.TestExecutionProperties.isOpenshiftPlatform;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -27,7 +29,6 @@ import java.util.Objects;
 import java.util.Random;
 import java.util.stream.Collectors;
 
-import io.quarkus.test.utils.FileUtils;
 import me.escoffier.certs.CertificateGenerator;
 import me.escoffier.certs.CertificateRequest;
 import me.escoffier.certs.JksCertificateFiles;
@@ -60,27 +61,40 @@ public interface Certificate {
 
     }
 
+    static Certificate of(String prefix, io.quarkus.test.services.Certificate.Format format, String password, Path targetDir,
+            ContainerMountStrategy containerMountStrategy, boolean createPkcs12TsForPem) {
+        return of(new CertificateOptions(prefix, format, password, false, false, false,
+                new io.quarkus.test.services.Certificate.ClientCertificate[0],
+                targetDir, containerMountStrategy, createPkcs12TsForPem));
+    }
+
     static Certificate of(String prefix, io.quarkus.test.services.Certificate.Format format, String password) {
-        return of(prefix, format, password, false, false, false, new io.quarkus.test.services.Certificate.ClientCertificate[0]);
+        return of(prefix, format, password, createCertsTempDir(prefix), new DefaultContainerMountStrategy(prefix), false);
     }
 
     static Certificate of(String prefix, io.quarkus.test.services.Certificate.Format format, String password,
             boolean keystoreProps, boolean truststoreProps, boolean keystoreManagementInterfaceProps,
             io.quarkus.test.services.Certificate.ClientCertificate[] clientCertificates) {
+        return of(new CertificateOptions(prefix, format, password, keystoreProps, truststoreProps,
+                keystoreManagementInterfaceProps,
+                clientCertificates, createCertsTempDir(prefix), new DefaultContainerMountStrategy(prefix), false));
+    }
+
+    private static Certificate of(CertificateOptions o) {
         Map<String, String> props = new HashMap<>();
-        CertificateGenerator generator = new CertificateGenerator(createCertsTempDir(prefix), false);
+        CertificateGenerator generator = new CertificateGenerator(o.localTargetDir(), false);
         String serverTrustStoreLocation = null;
         String serverKeyStoreLocation = null;
         String keyLocation = null;
         String certLocation = null;
         List<ClientCertificate> generatedClientCerts = new ArrayList<>();
-        String[] cnAttrs = collectCommonNames(clientCertificates);
-        var unknownClientCn = getUnknownClientCnAttr(clientCertificates, cnAttrs);
+        String[] cnAttrs = collectCommonNames(o.clientCertificates());
+        var unknownClientCn = getUnknownClientCnAttr(o.clientCertificates(), cnAttrs);
 
         // 1. GENERATE FIRST CERTIFICATE AND SERVER KEYSTORE AND TRUSTSTORE
         boolean withClientCerts = cnAttrs.length > 0;
         String cn = withClientCerts ? cnAttrs[0] : "localhost";
-        final CertificateRequest request = createCertificateRequest(prefix, format, password, withClientCerts, cn);
+        final CertificateRequest request = createCertificateRequest(o.prefix(), o.format(), o.password(), withClientCerts, cn);
         try {
             var certFile = generator.generate(request).get(0);
             if (certFile instanceof Pkcs12CertificateFiles pkcs12CertFile) {
@@ -96,17 +110,32 @@ public interface Certificate {
             } else if (certFile instanceof PemCertificateFiles pemCertsFile) {
                 keyLocation = getPathOrNull(pemCertsFile.keyFile());
                 certLocation = getPathOrNull(pemCertsFile.certFile());
-                if (isOpenshiftPlatform() || isKubernetesPlatform()) {
+                if (o.createPkcs12TsForPem()) {
+                    // PKCS12 truststore
+                    serverTrustStoreLocation = createPkcs12TruststoreForPem(pemCertsFile.trustStore(), o.password(), cn);
+                } else {
+                    // ca-cert
+                    serverTrustStoreLocation = getPathOrNull(pemCertsFile.trustStore());
+                }
+                if (o.containerMountStrategy().mountToContainer()) {
                     if (certLocation != null) {
-                        certLocation = makeFileMountPathUnique(prefix, certLocation);
-                        // mount certificate to the pod
-                        props.put(getRandomPropKey("crt"), toSecretProperty(certLocation));
+                        var containerMountPath = o.containerMountStrategy().certPath(certLocation);
+                        if (o.containerMountStrategy().containerShareMountPathWithApp()) {
+                            certLocation = containerMountPath;
+                        }
+
+                        // mount certificate to the container
+                        props.put(getRandomPropKey("crt"), toSecretProperty(containerMountPath));
                     }
 
                     if (keyLocation != null) {
-                        keyLocation = makeFileMountPathUnique(prefix, keyLocation);
-                        // mount private key to the pod
-                        props.put(getRandomPropKey("key"), toSecretProperty(keyLocation));
+                        var containerMountPath = o.containerMountStrategy().keyPath(keyLocation);
+                        if (o.containerMountStrategy().containerShareMountPathWithApp()) {
+                            keyLocation = containerMountPath;
+                        }
+
+                        // mount private key to the container
+                        props.put(getRandomPropKey("key"), toSecretProperty(containerMountPath));
                     }
                 }
             } else if (certFile instanceof JksCertificateFiles jksCertFile) {
@@ -126,18 +155,18 @@ public interface Certificate {
 
         // 2. IF THERE IS MORE THAN ONE CLIENT CERTIFICATE, GENERATE OTHERS
         if (withClientCerts && cnAttrs.length > 1) {
-            if (format != PKCS12) {
+            if (o.format() != PKCS12) {
                 throw new IllegalArgumentException(
                         "Generation of more than one client certificate is only implemented for PKCS12.");
             }
             var correctClientTruststore = Path.of(generatedClientCerts.get(0).truststorePath()).toFile();
             for (int i = 1; i < cnAttrs.length; i++) {
                 var clientCn = cnAttrs[i];
-                var clientPrefix = clientCn + "-" + prefix;
-                var clientRequest = createCertificateRequest(clientPrefix, format, password, true, clientCn);
+                var clientPrefix = clientCn + "-" + o.prefix();
+                var clientRequest = createCertificateRequest(clientPrefix, o.format(), o.password(), true, clientCn);
                 try {
                     var clientCertFile = (Pkcs12CertificateFiles) generator.generate(clientRequest).get(0);
-                    fixGeneratedClientCerts(clientPrefix, password, clientCertFile, correctClientTruststore,
+                    fixGeneratedClientCerts(clientPrefix, o.password(), clientCertFile, correctClientTruststore,
                             serverTrustStoreLocation, unknownClientCn, clientCn);
                     generatedClientCerts
                             .add(new ClientCertificateImpl(clientCn, getPathOrNull(clientCertFile.clientKeyStoreFile()),
@@ -150,36 +179,45 @@ public interface Certificate {
 
         // 3. PREPARE QUARKUS APPLICATION CONFIGURATION PROPERTIES
         if (serverTrustStoreLocation != null) {
-            if (isOpenshiftPlatform() || isKubernetesPlatform()) {
-                // mount truststore to the pod
-                props.put(getRandomPropKey("truststore"), toSecretProperty(serverTrustStoreLocation));
+            if (o.containerMountStrategy().mountToContainer()) {
+                var containerMountPath = o.containerMountStrategy().truststorePath(serverTrustStoreLocation);
+                if (o.containerMountStrategy().containerShareMountPathWithApp()) {
+                    serverTrustStoreLocation = containerMountPath;
+                }
+
+                // mount truststore to the container
+                props.put(getRandomPropKey("truststore"), toSecretProperty(containerMountPath));
             }
-            if (truststoreProps) {
+            if (o.truststoreProps()) {
                 props.put("quarkus.http.ssl.certificate.trust-store-file", serverTrustStoreLocation);
-                props.put("quarkus.http.ssl.certificate.trust-store-file-type", format.toString());
-                props.put("quarkus.http.ssl.certificate.trust-store-password", password);
+                props.put("quarkus.http.ssl.certificate.trust-store-file-type", o.format().toString());
+                props.put("quarkus.http.ssl.certificate.trust-store-password", o.password());
             }
         }
         if (serverKeyStoreLocation != null) {
-            if (isOpenshiftPlatform() || isKubernetesPlatform()) {
-                serverKeyStoreLocation = makeFileMountPathUnique(prefix, serverKeyStoreLocation);
-                // mount keystore to the pod
-                props.put(getRandomPropKey("keystore"), toSecretProperty(serverKeyStoreLocation));
+            if (o.containerMountStrategy().mountToContainer()) {
+                var containerMountPath = o.containerMountStrategy().keystorePath(serverKeyStoreLocation);
+                if (o.containerMountStrategy().containerShareMountPathWithApp()) {
+                    serverKeyStoreLocation = containerMountPath;
+                }
+
+                // mount keystore to the container
+                props.put(getRandomPropKey("keystore"), toSecretProperty(containerMountPath));
             }
-            if (keystoreProps) {
+            if (o.keystoreProps()) {
                 props.put("quarkus.http.ssl.certificate.key-store-file", serverKeyStoreLocation);
-                props.put("quarkus.http.ssl.certificate.key-store-file-type", format.toString());
-                props.put("quarkus.http.ssl.certificate.key-store-password", password);
+                props.put("quarkus.http.ssl.certificate.key-store-file-type", o.format().toString());
+                props.put("quarkus.http.ssl.certificate.key-store-password", o.password());
             }
-            if (keystoreManagementInterfaceProps) {
+            if (o.keystoreManagementInterfaceProps()) {
                 props.put("quarkus.management.ssl.certificate.key-store-file", serverKeyStoreLocation);
-                props.put("quarkus.management.ssl.certificate.key-store-file-type", format.toString());
-                props.put("quarkus.management.ssl.certificate.key-store-password", password);
+                props.put("quarkus.management.ssl.certificate.key-store-file-type", o.format().toString());
+                props.put("quarkus.management.ssl.certificate.key-store-password", o.password());
             }
         }
 
         return new CertificateImpl(serverKeyStoreLocation, serverTrustStoreLocation, Map.copyOf(props),
-                List.copyOf(generatedClientCerts), password, format.toString(), keyLocation, certLocation, prefix);
+                List.copyOf(generatedClientCerts), o.password(), o.format().toString(), keyLocation, certLocation, o.prefix());
     }
 
     private static String getUnknownClientCnAttr(io.quarkus.test.services.Certificate.ClientCertificate[] clientCertificates,
@@ -275,14 +313,7 @@ public interface Certificate {
         return null;
     }
 
-    private static String makeFileMountPathUnique(String prefix, String storeLocation) {
-        var newTempCertDir = createCertsTempDir(prefix);
-        var storeFile = Path.of(storeLocation).toFile();
-        FileUtils.copyFileTo(storeFile, newTempCertDir);
-        return newTempCertDir.resolve(storeFile.getName()).toAbsolutePath().toString();
-    }
-
-    private static Path createCertsTempDir(String prefix) {
+    static Path createCertsTempDir(String prefix) {
         Path certsDir;
         try {
             certsDir = Files.createTempDirectory(prefix + "-certs");
@@ -290,5 +321,27 @@ public interface Certificate {
             throw new RuntimeException(e);
         }
         return certsDir;
+    }
+
+    private static String createPkcs12TruststoreForPem(Path caCertPath, String password, String alias) {
+        try {
+            CertificateFactory fact = CertificateFactory.getInstance("X.509");
+            try (FileInputStream is = new FileInputStream(caCertPath.toFile())) {
+                X509Certificate cer = (X509Certificate) fact.generateCertificate(is);
+
+                var newTruststorePath = Files.createTempFile("pem-12-truststore", ".p12");
+
+                try (OutputStream truststoreOs = Files.newOutputStream(newTruststorePath)) {
+                    KeyStore truststore = KeyStore.getInstance("PKCS12");
+                    truststore.load(null, password.toCharArray());
+                    truststore.setCertificateEntry(alias, cer);
+                    truststore.store(truststoreOs, password.toCharArray());
+                }
+
+                return newTruststorePath.toAbsolutePath().toString();
+            }
+        } catch (KeyStoreException | CertificateException | IOException | NoSuchAlgorithmException e) {
+            throw new RuntimeException("Failed to create PKCS12 truststore", e);
+        }
     }
 }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/security/certificate/CertificateBuilder.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/security/certificate/CertificateBuilder.java
@@ -13,6 +13,10 @@ public interface CertificateBuilder {
 
     Certificate findCertificateByPrefix(String prefix);
 
+    static CertificateBuilder of(Certificate certificate) {
+        return new CertificateBuilderImp(List.of(certificate));
+    }
+
     static CertificateBuilder of(io.quarkus.test.services.Certificate[] certificates) {
         if (certificates == null || certificates.length == 0) {
             return null;

--- a/quarkus-test-core/src/main/java/io/quarkus/test/security/certificate/CertificateOptions.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/security/certificate/CertificateOptions.java
@@ -1,0 +1,9 @@
+package io.quarkus.test.security.certificate;
+
+import java.nio.file.Path;
+
+record CertificateOptions(String prefix, io.quarkus.test.services.Certificate.Format format, String password,
+        boolean keystoreProps, boolean truststoreProps, boolean keystoreManagementInterfaceProps,
+        io.quarkus.test.services.Certificate.ClientCertificate[] clientCertificates, Path localTargetDir,
+        ContainerMountStrategy containerMountStrategy, boolean createPkcs12TsForPem) {
+}

--- a/quarkus-test-core/src/main/java/io/quarkus/test/security/certificate/ContainerMountStrategy.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/security/certificate/ContainerMountStrategy.java
@@ -1,0 +1,23 @@
+package io.quarkus.test.security.certificate;
+
+public interface ContainerMountStrategy {
+
+    String truststorePath(String currentLocation);
+
+    String keystorePath(String currentLocation);
+
+    String keyPath(String currentLocation);
+
+    String certPath(String currentLocation);
+
+    /**
+     * Whether container destination path is also path used by Quarkus application when accessing these certs.
+     * Simply put it, if 'yes' is returned, we are probably mounting certs to the Quarkus application pod.
+     */
+    boolean containerShareMountPathWithApp();
+
+    /**
+     * Whether certificates should be mounted to the container.
+     */
+    boolean mountToContainer();
+}

--- a/quarkus-test-core/src/main/java/io/quarkus/test/security/certificate/DefaultContainerMountStrategy.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/security/certificate/DefaultContainerMountStrategy.java
@@ -1,0 +1,56 @@
+package io.quarkus.test.security.certificate;
+
+import static io.quarkus.test.security.certificate.Certificate.createCertsTempDir;
+import static io.quarkus.test.utils.TestExecutionProperties.isKubernetesPlatform;
+import static io.quarkus.test.utils.TestExecutionProperties.isOpenshiftPlatform;
+
+import java.nio.file.Path;
+
+import io.quarkus.test.utils.FileUtils;
+
+class DefaultContainerMountStrategy implements ContainerMountStrategy {
+
+    private final String prefix;
+
+    DefaultContainerMountStrategy(String prefix) {
+        this.prefix = prefix;
+    }
+
+    @Override
+    public String truststorePath(String currentLocation) {
+        // no point of making both keystore and truststore unique, one of them is enough
+        return currentLocation;
+    }
+
+    @Override
+    public String keystorePath(String currentLocation) {
+        return makeFileMountPathUnique(prefix, currentLocation);
+    }
+
+    @Override
+    public String keyPath(String currentLocation) {
+        return makeFileMountPathUnique(prefix, currentLocation);
+    }
+
+    @Override
+    public String certPath(String currentLocation) {
+        return makeFileMountPathUnique(prefix, currentLocation);
+    }
+
+    @Override
+    public boolean containerShareMountPathWithApp() {
+        return true;
+    }
+
+    @Override
+    public boolean mountToContainer() {
+        return isOpenshiftPlatform() || isKubernetesPlatform();
+    }
+
+    private static String makeFileMountPathUnique(String prefix, String storeLocation) {
+        var newTempCertDir = createCertsTempDir(prefix);
+        var storeFile = Path.of(storeLocation).toFile();
+        FileUtils.copyFileTo(storeFile, newTempCertDir);
+        return newTempCertDir.resolve(storeFile.getName()).toAbsolutePath().toString();
+    }
+}

--- a/quarkus-test-core/src/main/java/io/quarkus/test/security/certificate/FixedPathContainerMountStrategy.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/security/certificate/FixedPathContainerMountStrategy.java
@@ -1,0 +1,36 @@
+package io.quarkus.test.security.certificate;
+
+public record FixedPathContainerMountStrategy(String truststorePath, String keystorePath, String keyPath,
+        String certPath) implements ContainerMountStrategy {
+
+    @Override
+    public String truststorePath(String currentLocation) {
+        return truststorePath();
+    }
+
+    @Override
+    public String keystorePath(String currentLocation) {
+        return keystorePath();
+    }
+
+    @Override
+    public String keyPath(String currentLocation) {
+        return keyPath();
+    }
+
+    @Override
+    public String certPath(String currentLocation) {
+        return certPath();
+    }
+
+    @Override
+    public boolean containerShareMountPathWithApp() {
+        return false;
+    }
+
+    @Override
+    public boolean mountToContainer() {
+        return true;
+    }
+
+}

--- a/quarkus-test-service-database/pom.xml
+++ b/quarkus-test-service-database/pom.xml
@@ -13,5 +13,9 @@
             <groupId>io.quarkus.qe</groupId>
             <artifactId>quarkus-test-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus.qe</groupId>
+            <artifactId>quarkus-test-containers</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/quarkus-test-service-database/src/main/java/io/quarkus/test/services/SqlServerContainer.java
+++ b/quarkus-test-service-database/src/main/java/io/quarkus/test/services/SqlServerContainer.java
@@ -1,0 +1,22 @@
+package io.quarkus.test.services;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SqlServerContainer {
+
+    String image() default "${mssql.image}";
+
+    int port() default 1433;
+
+    String expectedLog() default "Service Broker manager has started";
+
+    /**
+     * Encrypt connections to SQL Server.
+     */
+    boolean tlsEnabled() default false;
+}

--- a/quarkus-test-service-database/src/main/java/io/quarkus/test/services/containers/SqlServerContainerAnnotationBinding.java
+++ b/quarkus-test-service-database/src/main/java/io/quarkus/test/services/containers/SqlServerContainerAnnotationBinding.java
@@ -1,0 +1,28 @@
+package io.quarkus.test.services.containers;
+
+import java.lang.reflect.Field;
+
+import io.quarkus.test.bootstrap.AnnotationBinding;
+import io.quarkus.test.bootstrap.ManagedResourceBuilder;
+import io.quarkus.test.services.SqlServerContainer;
+
+public class SqlServerContainerAnnotationBinding implements AnnotationBinding {
+
+    @Override
+    public boolean isFor(Field field) {
+        return field.isAnnotationPresent(SqlServerContainer.class);
+    }
+
+    @Override
+    public ManagedResourceBuilder createBuilder(Field field) throws Exception {
+        SqlServerContainer metadata = field.getAnnotation(SqlServerContainer.class);
+        ManagedResourceBuilder builder = new SqlServerManagedResourceBuilder();
+        builder.init(metadata);
+        return builder;
+    }
+
+    @Override
+    public boolean requiresLinuxContainersOnBareMetal() {
+        return true;
+    }
+}

--- a/quarkus-test-service-database/src/main/java/io/quarkus/test/services/containers/SqlServerManagedResourceBuilder.java
+++ b/quarkus-test-service-database/src/main/java/io/quarkus/test/services/containers/SqlServerManagedResourceBuilder.java
@@ -1,0 +1,58 @@
+package io.quarkus.test.services.containers;
+
+import static io.quarkus.test.services.Certificate.Format.PEM;
+import static io.quarkus.test.utils.PropertiesUtils.DESTINATION_TO_FILENAME_SEPARATOR;
+import static io.quarkus.test.utils.PropertiesUtils.RESOURCE_WITH_DESTINATION_PREFIX;
+
+import java.lang.annotation.Annotation;
+import java.nio.file.Path;
+
+import io.quarkus.test.bootstrap.ManagedResource;
+import io.quarkus.test.bootstrap.ServiceContext;
+import io.quarkus.test.security.certificate.Certificate;
+import io.quarkus.test.security.certificate.CertificateBuilder;
+import io.quarkus.test.security.certificate.FixedPathContainerMountStrategy;
+import io.quarkus.test.services.SqlServerContainer;
+
+public final class SqlServerManagedResourceBuilder extends ContainerManagedResourceBuilder {
+
+    public static final String CERTIFICATE_PREFIX = "mssql";
+    private boolean tlsEnabled = false;
+
+    @Override
+    public void init(Annotation annotation) {
+        if (annotation instanceof SqlServerContainer sqlServerContainer) {
+            tlsEnabled = sqlServerContainer.tlsEnabled();
+            init(sqlServerContainer.image(), new String[0], sqlServerContainer.expectedLog(), sqlServerContainer.port(),
+                    tlsEnabled);
+        } else {
+            throw new IllegalStateException("Expected annotation SqlServerContainer, but got: " + annotation);
+        }
+    }
+
+    @Override
+    public ManagedResource build(ServiceContext context) {
+        if (!tlsEnabled) {
+            return super.build(context);
+        }
+
+        var destStrategy = new FixedPathContainerMountStrategy("/etc/ssl/ca-crt/mssql-ca.crt", null,
+                "/etc/ssl/private/mssql.key", "/etc/ssl/certs/mssql.crt");
+        var cert = Certificate.of(CERTIFICATE_PREFIX, PEM, "password", certTargetDir(), destStrategy, true);
+
+        cert.configProperties().forEach(context::withTestScopeConfigProperty);
+        context.withTestScopeConfigProperty("mssql-config", createConfigFileProperty());
+        context.put(CertificateBuilder.INSTANCE_KEY, CertificateBuilder.of(cert));
+
+        return super.build(context);
+    }
+
+    private static String createConfigFileProperty() {
+        return RESOURCE_WITH_DESTINATION_PREFIX + "/var/opt/mssql/" + DESTINATION_TO_FILENAME_SEPARATOR + "mssql.conf";
+    }
+
+    private static Path certTargetDir() {
+        // when mounting to Docker we are not searching for files recursively, so we put certs directly to the target dir
+        return Path.of("target");
+    }
+}

--- a/quarkus-test-service-database/src/main/resources/META-INF/services/io.quarkus.test.bootstrap.AnnotationBinding
+++ b/quarkus-test-service-database/src/main/resources/META-INF/services/io.quarkus.test.bootstrap.AnnotationBinding
@@ -1,0 +1,1 @@
+io.quarkus.test.services.containers.SqlServerContainerAnnotationBinding

--- a/quarkus-test-service-database/src/main/resources/mssql.conf
+++ b/quarkus-test-service-database/src/main/resources/mssql.conf
@@ -1,0 +1,5 @@
+[network]
+tlscert = /etc/ssl/certs/mssql.crt
+tlskey = /etc/ssl/private/mssql.key
+tlsprotocols = 1.2
+forceencryption = 1


### PR DESCRIPTION
### Summary

Adds support for encrypted communication between Quarkus app with JDBC MSSQL extension and SQL Server because Microsoft documentation says in FIPS-enabled environment you should do that: https://learn.microsoft.com/en-us/sql/connect/jdbc/fips-mode?view=sql-server-ver16#appropriate-configuration-parameters

Despite the docs above, it doesn't seem to be required with Red Hat OpenJDK 21 (works both with TLS and without TLS) and never works in FIPS-enabled environment with Red Hat OpenJDK 17.

So my plan in regards of FIPS:

- disable MSSQL tests on OpenJDK 17 in FIPS-enabled environment
- open upstream issue at the very least to have this non-working configuration tracked somewhere
- run at least one of tests with TLS because:
  - that's what official documentation imply is way to go
  - I have no idea why the behavior is different with 21, so having TLS backup seems like a good idea
  - SQL Server driver by default runs everything even in non-FIPS env via encrypted communication channel, only reason it worked for us till now is that we explicitly disable it everywhere, for example here: https://github.com/quarkus-qe/quarkus-test-suite/blob/64932fda5970db8e29081e168337d010ee504f84/sql-db/sql-app/src/test/resources/mssql.properties#L5

This is how I tested it (FIPS/no FIPS): https://github.com/quarkus-qe/quarkus-test-suite/compare/main...michalvavrik:quarkus-test-suite:feature/sql-server-fips

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)