### PR TITLE
Update Keycloak version to 24 as Quarkus move to this version

### DIFF
--- a/examples/keycloak/src/test/resources/keycloak-custom-template.yaml
+++ b/examples/keycloak/src/test/resources/keycloak-custom-template.yaml
@@ -13,7 +13,7 @@ items:
         from:
           kind: DockerImage
           # Hardcoded image is used only here, tests use one from KeycloakContainer
-          name: quay.io/keycloak/keycloak:23.0
+          name: quay.io/keycloak/keycloak:24.0
 - apiVersion: apps/v1
   kind: Deployment
   metadata:

--- a/examples/keycloak/src/test/resources/keycloak-realm.json
+++ b/examples/keycloak/src/test/resources/keycloak-realm.json
@@ -16,6 +16,9 @@
   "users": [
     {
       "username": "test-normal-user",
+      "email": "test-normal-user@localhost",
+      "firstName": "test-normal-user",
+      "lastName": "test-normal-user",
       "enabled": true,
       "credentials": [
         {
@@ -29,6 +32,9 @@
     },
     {
       "username": "test-admin-user",
+      "email": "test-admin-user@localhost",
+      "firstName": "test-admin-user",
+      "lastName": "test-admin-user",
       "enabled": true,
       "credentials": [
         {

--- a/quarkus-test-service-keycloak/src/main/java/io/quarkus/test/services/KeycloakContainer.java
+++ b/quarkus-test-service-keycloak/src/main/java/io/quarkus/test/services/KeycloakContainer.java
@@ -14,7 +14,7 @@ import io.quarkus.test.services.containers.KeycloakContainerManagedResourceBuild
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface KeycloakContainer {
-    String image() default "quay.io/keycloak/keycloak:23.0";
+    String image() default "quay.io/keycloak/keycloak:24.0";
 
     int port() default 8080;
 


### PR DESCRIPTION
### Summary

Bumping the keycloak to 24.0 as upstream bump also bump it https://github.com/quarkusio/quarkus/pull/40662

The big change is that keycloak now require email and first/last name to be set. The keycloak start without it but fail to token request.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Dependency update
- [x] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)