### PR TITLE
Pom file cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -323,7 +323,6 @@
                 <version>${maven-checkstyle-plugin.version}</version>
                 <configuration>
                     <configLocation>checkstyle.xml</configLocation>
-                    <encoding>UTF-8</encoding>
                     <consoleOutput>true</consoleOutput>
                     <failsOnError>true</failsOnError>
                     <linkXRef>true</linkXRef>

--- a/pom.xml
+++ b/pom.xml
@@ -354,14 +354,14 @@
                             <goal>verify</goal>
                         </goals>
                         <configuration>
-                            <systemProperties>
+                            <systemPropertyVariables>
                                 <oracle.image>${oracle.image}</oracle.image>
                                 <postgresql.image>${postgresql.image}</postgresql.image>
                                 <mysql.image>${mysql.image}</mysql.image>
                                 <infinispan.image>${infinispan.image}</infinispan.image>
                                 <infinispan-legacy.image>${infinispan-legacy.image}</infinispan-legacy.image>
                                 <consul.image>${consul.image}</consul.image>
-                            </systemProperties>
+                            </systemPropertyVariables>
                             <argLine>${jacoco.agent.argLine}</argLine>
                             <excludedGroups>${exclude.tests.with.tags}</excludedGroups>
                             <includes>
@@ -428,12 +428,12 @@
                         <executions>
                             <execution>
                                 <configuration>
-                                    <systemProperties>
+                                    <systemPropertyVariables>
                                         <quarkus.native.enabled>${quarkus.native.enabled}</quarkus.native.enabled>
                                         <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
                                         <quarkus.native.container-build>${quarkus.native.container-build}</quarkus.native.container-build>
                                         <quarkus.native.native-image-xmx>${quarkus.native.native-image-xmx}</quarkus.native.native-image-xmx>
-                                    </systemProperties>
+                                    </systemPropertyVariables>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
### Summary

**Use systemPropertyVariables instead of deprecated systemProperties**
 * Removes [WARNING]  Parameter 'systemProperties' is deprecated: Use systemPropertyVariables instead.

**Remove invalid configuration parameter name for maven-checkstyle-plugin**
 * https://maven.apache.org/plugins/maven-checkstyle-plugin/check-mojo.html#inputEncoding
 * project.build.sourceEncoding is defined so we do not define inputEncoding
 * Removes [WARNING] Parameter 'encoding' is unknown for plugin 'maven-checkstyle-plugin:3.3.1:check (validate)'


Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)