### PR TITLE
Add default platform-bom for snapshots when creating the app with cli

### DIFF
--- a/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/QuarkusCliClient.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/QuarkusCliClient.java
@@ -216,6 +216,9 @@ public class QuarkusCliClient {
         }
 
         public static CreateApplicationRequest defaults() {
+            if (QuarkusProperties.getVersion().contains("SNAPSHOT")) {
+                return new CreateApplicationRequest().withPlatformBom("io.quarkus::" + QuarkusProperties.getVersion());
+            }
             return new CreateApplicationRequest();
         }
     }


### PR DESCRIPTION
### Summary

This fixing the daily CLI failure + now it testing CLI againts main (SNAPSHOT) not latest release.

Even when using SNAPSHOT build the platform-bom can be overwritten inside the test.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)