### PR TITLE
Automatically publish release notes

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -22,6 +22,6 @@ categories:
     label: 'chore'
 change-template: '- #$NUMBER: $TITLE (@$AUTHOR)'
 template: |
-  ## 1.0.z Changes
+  ## Changes
   $CHANGES
   All contributors: $CONTRIBUTORS

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -13,5 +13,6 @@ jobs:
       - uses: release-drafter/release-drafter@v6
         with:
           config-name: upstream-release-drafter.yml
+          tag: release-draft
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,3 +60,10 @@ jobs:
           branch: ${{github.base_ref}}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           tags: true
+      - name: Publish release notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          gh release edit release-draft --verify-tag --latest --draft=false --target ${{github.sha}} -t ${{steps.metadata.outputs.current-version}} --tag ${{steps.metadata.outputs.current-version}}
+          gh api --method DELETE -H "Accept: application/vnd.github+json" repos/{owner}/{repo}/git/refs/tags/release-draft


### PR DESCRIPTION
### Summary

closes: #414

I used GH CLI to test deletion of API tag (so that we can identify the latest draft), but I didn't try release itself for I don't want to release things. It seems clear enough from docs reference https://cli.github.com/manual/gh_release_edit. I'll try to do actual release and find a way to debug it locally if it fails.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)