### PR TITLE
Change resteasy to rest in some examples

### DIFF
--- a/examples/consul/pom.xml
+++ b/examples/consul/pom.xml
@@ -12,7 +12,7 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy</artifactId>
+            <artifactId>quarkus-rest</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkiverse.config</groupId>

--- a/examples/consul/src/main/java/io/quarkus/qe/GreetingResource.java
+++ b/examples/consul/src/main/java/io/quarkus/qe/GreetingResource.java
@@ -7,6 +7,8 @@ import jakarta.ws.rs.core.MediaType;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
+import io.smallrye.mutiny.Uni;
+
 @Path("/api")
 public class GreetingResource {
 
@@ -18,8 +20,8 @@ public class GreetingResource {
 
     @GET
     @Produces(MediaType.TEXT_PLAIN)
-    public String hello() {
-        return "Hello " + property;
+    public Uni<String> hello() {
+        return Uni.createFrom().item("Hello " + property);
     }
 
     @GET

--- a/examples/external-applications/pom.xml
+++ b/examples/external-applications/pom.xml
@@ -11,10 +11,6 @@
     <name>Quarkus - Test Framework - Examples - External Applications</name>
     <dependencies>
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.quarkus.qe</groupId>
             <artifactId>quarkus-test-core</artifactId>
             <scope>test</scope>

--- a/examples/pingpong/pom.xml
+++ b/examples/pingpong/pom.xml
@@ -12,7 +12,7 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy</artifactId>
+            <artifactId>quarkus-rest</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus.qe</groupId>

--- a/examples/pingpong/src/main/java/io/quarkus/qe/PingResource.java
+++ b/examples/pingpong/src/main/java/io/quarkus/qe/PingResource.java
@@ -5,12 +5,14 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
+import io.smallrye.mutiny.Uni;
+
 @Path("/ping")
 public class PingResource {
 
     @GET
     @Produces(MediaType.TEXT_PLAIN)
-    public String ping() {
-        return "ping";
+    public Uni<String> ping() {
+        return Uni.createFrom().item("ping");
     }
 }


### PR DESCRIPTION
### Summary

Updating PingPong and Consule example to use `quarkus-rest`.

Removing `quarkus-resteasy` from external aplication as it work without it.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)