### PR TITLE
[1.4.z] Release 1.4.7

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 name: Quarkus QE Test Framework
 release:
-  current-version: 1.4.6
-  next-version: 1.4.7
+  current-version: 1.4.7
+  next-version: 1.4.8


### PR DESCRIPTION
### Summary

Release of 1.4.7

Contains only https://github.com/quarkus-qe/quarkus-test-framework/pull/1165

Keycloak 24 should be used while testing 3.8.5. So we need this version of keycloak also in testsuite.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Release
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)