### PR TITLE
Revert "Release Beta8 of the framework"

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 name: Quarkus QE Test Framework
 release:
-  current-version: 1.5.0.Beta8
-  next-version: 1.5.0.Beta9
+  current-version: 1.5.0.Beta7
+  next-version: 1.5.0.Beta8


### PR DESCRIPTION
### Summary

PR https://github.com/quarkus-qe/quarkus-test-framework/pull/1177 was made from a fork and so 1.5.0.Beta8 was not released. This PR reverts these changes and also made from a fork, so it will not lead to accidental creation of another Beta7 release. Proper release PR with Beta8 will follow.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)