### PR TITLE
Add check for same repo PR origin for releases

### DIFF
--- a/.github/workflows/check-release-version.yml
+++ b/.github/workflows/check-release-version.yml
@@ -1,4 +1,4 @@
-name: Check release version
+name: "Release check"
 on:
   pull_request:
     types:

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -1,0 +1,22 @@
+name: "Release check"
+
+on:
+  pull_request:
+    types: [opened]
+    paths:
+      - '.github/project.yml'
+jobs:
+  check-source-repo-is-not-a-fork:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Fail if source repo is a fork"
+        env:
+          SRC_REPO_NAME: ${{ github.event.pull_request.head.repo.full_name }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          echo "PR src repo full name $SRC_REPO_NAME"
+          echo "This GH repo name $GH_REPO"
+          if [ $SRC_REPO_NAME != $GH_REPO ]; then
+            exit 1
+          fi
+


### PR DESCRIPTION
### Summary

closes: #1179 

Release PRs can only be executed if source branch is in same repo, because of GH secrets. This adds a check to verify that it is so. 

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)