### PR TITLE
Workaround Groovy conflicts in Debug examples as daily build is failing

### DIFF
--- a/examples/debug/src/test/resources-filtered/project/classic/src/test/java/io/quarkus/qe/debug/HelloIT.java
+++ b/examples/debug/src/test/resources-filtered/project/classic/src/test/java/io/quarkus/qe/debug/HelloIT.java
@@ -1,20 +1,30 @@
 package io.quarkus.qe.debug;
 
+import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.restassured.RestAssured;
-import org.hamcrest.Matchers;
+import io.quarkus.test.services.QuarkusApplication;
+import io.vertx.mutiny.ext.web.client.HttpResponse;
+import io.vertx.mutiny.ext.web.client.predicate.ResponsePredicate;
 import org.junit.jupiter.api.Test;
+
+import java.net.HttpURLConnection;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @QuarkusScenario
 public class HelloIT {
 
+    @QuarkusApplication
+    static final RestService app = new RestService(false);
+
     @Test
     public void test() {
-        RestAssured
-                .get("/hello")
-                .then()
-                .statusCode(200)
-                .body(Matchers.is("hello"));
+        String response = app.mutiny().get("/hello")
+                .expect(ResponsePredicate.status(HttpURLConnection.HTTP_OK))
+                .send()
+                .map(HttpResponse::bodyAsString)
+                .await().indefinitely();
+        assertEquals("hello", response);
     }
 
 }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/RestService.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/RestService.java
@@ -23,7 +23,22 @@ public class RestService extends BaseService<RestService> {
     private static final int BUFFER_SIZE = 1024;
     private static final String BASE_PATH = "/";
 
+    private final boolean setupRestAssured;
     private WebClient webClient;
+
+    public RestService() {
+        this(true);
+    }
+
+    /**
+     * @param setupRestAssured whether RestAssured base URI, path and port should be configured;
+     *        usually you don't mind as setting up RestAssured doesn't hurt you, but it can be useful
+     *        when you want to avoid Groovy which RestAssured relies on (like when this framework
+     *        is build with a different Quarkus version than it is tested in Maven invoker tests).
+     */
+    public RestService(boolean setupRestAssured) {
+        this.setupRestAssured = setupRestAssured;
+    }
 
     public RequestSpecification given() {
         var host = getURI(Protocol.HTTP);
@@ -154,9 +169,11 @@ public class RestService extends BaseService<RestService> {
     public void start() {
         super.start();
         var host = getURI(Protocol.HTTP);
-        RestAssured.baseURI = host.getRestAssuredStyleUri();
-        RestAssured.basePath = BASE_PATH;
-        RestAssured.port = host.getPort();
+        if (setupRestAssured) {
+            RestAssured.baseURI = host.getRestAssuredStyleUri();
+            RestAssured.basePath = BASE_PATH;
+            RestAssured.port = host.getPort();
+        }
     }
 
     private static byte[] getFileContent(String path) {


### PR DESCRIPTION
### Summary

Fixes 2 things that are causing daily build failing, both are related:

- `Caused by: groovy.lang.GroovyRuntimeException: Conflicting module versions. Module [groovy-xml is loaded in version 4.0.22 and you are trying to load version 4.0.16`

Every now and then we run into a situation when Groovy version is conflicting. It cannot be avoided when Quarkus QE Test Framework is build with a different version than used in tests. In past it happened as well and I simply disabled tests, but lately they were enabled here https://github.com/quarkus-qe/quarkus-test-framework/pull/1134 because the test worked. We are likely to run into this again so I suggest to avoid Groovy

- `[ERROR] Failed to execute goal org.apache.maven.plugins:maven-failsafe-plugin:3.3.0:integration-test (default) on project examples-debug: Execution default of goal org.apache.maven.plugins:maven-failsafe-plugin:3.3.0:integration-test failed: A required class was missing while executing org.apache.maven.plugins:maven-failsafe-plugin:3.3.0:integration-test: org/apache/commons/io/FileUtils`

No idea why it sometimes happen (happened to me thrice when I tried to fix the Groovy thingy), but it's easy to avoid by simply dropping Apache Utils from surefire debug provider

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)