### PR TITLE
Fix NPE on Windows during certificate generation as File path separator differs to actual one

### DIFF
--- a/quarkus-test-core/src/main/java/io/quarkus/test/security/certificate/Certificate.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/security/certificate/Certificate.java
@@ -300,9 +300,9 @@ public interface Certificate {
     }
 
     private static String toSecretProperty(String path) {
-        int fileNameSeparatorIdx = path.lastIndexOf(File.separator);
-        String fileName = path.substring(fileNameSeparatorIdx + 1);
-        String pathToFile = path.substring(0, fileNameSeparatorIdx);
+        var file = Path.of(path).toFile();
+        String fileName = file.getName();
+        String pathToFile = file.getParentFile().getAbsolutePath();
         return SECRET_WITH_DESTINATION_PREFIX + pathToFile + DESTINATION_TO_FILENAME_SEPARATOR + fileName;
     }
 


### PR DESCRIPTION
### Summary

On Windows when running `MssqlDatabaseIT` we get:

```
java.lang.RuntimeException: Failed to generate certificate
	at io.quarkus.test.security.certificate.Certificate.of(Certificate.java:153)
	at io.quarkus.test.security.certificate.Certificate.of(Certificate.java:66)
	at io.quarkus.test.services.containers.SqlServerManagedResourceBuilder.build(SqlServerManagedResourceBuilder.java:41)
	at io.quarkus.test.bootstrap.BaseService.init(BaseService.java:295)
	at io.quarkus.test.bootstrap.QuarkusScenarioBootstrap.initService(QuarkusScenarioBootstrap.java:235)
	at io.quarkus.test.bootstrap.QuarkusScenarioBootstrap.initResourceFromField(QuarkusScenarioBootstrap.java:202)
	at io.quarkus.test.bootstrap.QuarkusScenarioBootstrap.lambda$beforeAll$1(QuarkusScenarioBootstrap.java:64)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at io.quarkus.test.bootstrap.QuarkusScenarioBootstrap.beforeAll(QuarkusScenarioBootstrap.java:64)
	at io.quarkus.test.bootstrap.QuarkusScenarioBootstrap.beforeAll(QuarkusScenarioBootstrap.java:50)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
Caused by: java.lang.StringIndexOutOfBoundsException: begin 0, end -1, length 24
	at java.base/java.lang.String.checkBoundsBeginEnd(String.java:4606)
	at java.base/java.lang.String.substring(String.java:2709)
	at io.quarkus.test.security.certificate.Certificate.toSecretProperty(Certificate.java:305)
	at io.quarkus.test.security.certificate.Certificate.of(Certificate.java:128)
	... 10 more
```

That is because on Windows file separator is `\\` but in fact `Path#toString` returns `\`, so here I decided to rely on Java API.

I have tested this both on Linux and Windows and this fixes the issue.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)