### PR TITLE
Update release version checker

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,6 +8,7 @@ Please check the relevant options
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Dependency update
 - [ ] Refactoring
+- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)
 - [ ] This change requires a documentation update
 - [ ] This change requires execution against OCP (use `run tests` phrase in comment)

--- a/.github/workflows/check-release-version.yml
+++ b/.github/workflows/check-release-version.yml
@@ -13,32 +13,84 @@ jobs:
       - uses: actions/checkout@v4
       - name: Check release version
         run: |
-          current_release=$(curl -sSL "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/latest" | jq -r .tag_name)
-          current_release_patch_version=$(echo "$current_release" | cut -d"." -f3,3)
-          current_release_pre_number=$(echo "$current_release" | cut -d"." -f4,4 | grep -o '[0-9]\+' || true)
+          releases=$(curl -sSL "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases")
 
-          next_release=$(grep -E 'current-version:\s*' .github/project.yml | awk '{print $2}')
-          next_release_patch_version=$(echo "$next_release" | cut -d"." -f3,3)
-          next_release_pre_number=$(echo "$next_release" | cut -d"." -f4,4 | grep -o '[0-9]\+' || true)
+          if [[ "$GITHUB_BASE_REF" == "main" ]]; then
+            latest_prerelease=$(echo "$releases" | jq -r '.[] | select(.prerelease) | .tag_name' | head -n 1)
+            latest_prerelease_beta_number=$(echo "$latest_prerelease" | cut -d"." -f4,4 | grep -o '[0-9]\+' || true)
           
-          if ! [[ $current_release =~ .*Final$ ]]; then
-            if [[ $next_release_patch_version > $current_release_patch_version ]]; then
-              echo "Error: you are bumping the FW patch version when the previous release was not Final"
+            next_prerelease=$(grep -E 'current-version:\s*' .github/project.yml | awk '{print $2}')
+            next_prerelease_minor_version=$(echo "$next_prerelease" | cut -d"." -f2,2)
+            next_prerelease_patch_version=$(echo "$next_prerelease" | cut -d"." -f3,3)
+            next_prerelease_beta_number=$(echo "$next_prerelease" | cut -d"." -f4,4 | grep -o '[0-9]\+' || true)
+            prerelease_minor_version_bump=false
+          
+            current_release=$(curl -sSL "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/latest" | jq -r .tag_name)
+            current_release_minor_version=$(echo "$current_release" | cut -d"." -f2,2)
+          
+            # Check if can change minor version after creating new branch 
+            if [[ $current_release_minor_version == $next_prerelease_minor_version ]]; then
+              echo "Error: next LTS release branch is out, bump version to 1."$((next_prerelease_minor_version+1))".0.Beta1" 
+              exit 1;
+            else
+              prerelease_minor_version_bump=true 
+            fi
+          
+            if [[ $(("$current_release_minor_version" + 1)) != $next_prerelease_minor_version ]]; then
+              echo "Error: pre-releases should have minor version one upper than last release"
               exit 1;
             fi
-            if [[ $next_release_pre_number != $(("$current_release_pre_number" + 1)) ]]; then
+          
+            if [[ $next_prerelease_patch_version != 0 ]]; then
+              echo "Error: new releases are not allowed from development branch, use .Beta\D+ qualifier"
+              exit 1;
+            fi
+          
+            if [[ !($prerelease_minor_version_bump) && ($next_prerelease_beta_number != $(("$latest_prerelease_beta_number" + 1))) ]]; then
               echo "Error: pre-release version should go one by one as sequence"
-              correct_version=$(echo "$current_release" | cut -d"." -f1,2,3)
-              correct_prerelease_number=$(($current_release_pre_number + 1))
-              echo "After" $current_release "should go "$correct_version".Beta"$correct_prerelease_number or Final release
+              correct_version=$(echo "$latest_prerelease" | cut -d"." -f1,2,3)
+              correct_prerelease_number=$(($latest_prerelease_beta_number + 1))
+              echo "After" $latest_prerelease "should go "$correct_version".Beta"$correct_prerelease_number
               exit 1;
             fi
-          else
-            if [[ $(("$current_release_patch_version" + 1)) != $next_release_patch_version || ($next_release_pre_number != 1) ]]; then
-                echo "Error: release patch versions should be bumped one by one as sequence and pre-release version must be Beta1"
-                correct_minor_release=$(echo "$current_release" | cut -d"." -f1,2)
-                correct_patch_version=$(("$current_release_patch_version" + 1))
-                echo "After" $current_release "should go" $correct_minor_release"."$correct_patch_version".Beta1"
+          else 
+            expected_release_version=$(echo "$GITHUB_BASE_REF" | sed 's/z/0/')
+          
+            first_release_tag_exists=$(echo "$releases" | jq -r '.[] | .tag_name' | grep "^$expected_release_version$" || true)
+            next_release=$(grep -E 'current-version:\s*' .github/project.yml | awk '{print $2}')
+          
+            if [ -z "$first_release_tag_exists" ]; then
+              if [[ "$next_release" != "$expected_release_version" ]]; then
+                echo "Error: wrong tag name for the first release in new branch"
                 exit 1;
+              else
+                exit 0;
               fi
+            fi
+          
+            branch_version=$(echo "$GITHUB_BASE_REF" | cut -d. -f1,2)
+            latest_branch_tag_patch_version=$(echo "$releases" | jq -r --arg version "$branch_version" '
+              .[] 
+              | select(.tag_name | contains($version)) 
+              | .tag_name' | grep -v "Beta" | head -1 | cut -d. -f3)
+          
+            branch_minor_version=$(echo "$GITHUB_BASE_REF" | cut -d. -f2,2)
+            next_release_minor_version=$(echo "$next_release" | cut -d"." -f2,2)
+            next_release_patch_version=$(echo "$next_release" | cut -d"." -f3,3)
+            beta_tag_exists=$(echo "$next_release" | cut -d"." -f4,4 || true)
+          
+            if [ -n $beta_tag_exists ]; then
+              echo "Releases cannot consist any qualifier after version"
+              exit 1;
+            fi
+          
+            if [[ $branch_minor_version != $next_release_minor_version ]]; then
+              echo "Error: minor versions cannot be changed"
+              exit 1;
+            fi
+          
+            if [[ $(("$latest_branch_tag_patch_version" + 1)) != "$next_release_patch_version" ]]; then
+              echo "Error: release patch versions should be bumped one by one as sequence"
+              exit 1;
+            fi
           fi


### PR DESCRIPTION
### Summary
PR contains:
- Update release version checker to support both development and RHBQ release branches. Changes should be 
backported to `1.3.z` and `1.4.z` branches. 
- Adds check box to PR template with the note to follow releasing conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md)

**Example runs:**
[main] success 1.5.0.Beta9 -> 1.5.0.Beta10
https://github.com/gtroitsk/quarkus-test-framework/actions/runs/9898569168/job/27345677181


[main] failure 1.5.0.Beta9 -> 1.5.0.Beta11
https://github.com/gtroitsk/quarkus-test-framework/actions/runs/9898590403/job/27345741503


[main] failure 1.5.0.Beta9 -> 1.5.1.Beta9
https://github.com/gtroitsk/quarkus-test-framework/actions/runs/9898619295/job/27345831135

**First release from newely created branch 1.5.z**

[1.5.z] failure - current-version: 1.6.0
https://github.com/gtroitsk/quarkus-test-framework/actions/runs/9921774174/job/27410101327


[1.5.z] success - current-version: 1.5.0
https://github.com/gtroitsk/quarkus-test-framework/actions/runs/9921803883/job/27410163653


**After release 1.5.0**

[main] failure: 1.5.0.Beta9 -> 1.5.0.Beta10
next LTS release branch is out, bump version to 1.6.0.Beta1
https://github.com/gtroitsk/quarkus-test-framework/actions/runs/9921906307/job/27410392342

[main] success 1.5.0.Beta9 -> 1.6.0.Beta1
https://github.com/gtroitsk/quarkus-test-framework/actions/runs/9927245152/job/27421961606

**Set new pre-release to 1.6.0.Beta1**

[main] failure 1.6.0.Beta1 -> 1.7.0.Beta1
https://github.com/gtroitsk/quarkus-test-framework/actions/runs/9928694191/job/27425317889


[1.5.z] failure - 1.5.0 -> 1.6.1
https://github.com/gtroitsk/quarkus-test-framework/actions/runs/9928857770/job/27425685357

[1.5.z] failure - 1.5.0 ->  1.5.2
https://github.com/gtroitsk/quarkus-test-framework/actions/runs/9928877759/job/27425727314

[1.5.z] failure - 1.5.0 -> 1.5.1.Beta1
https://github.com/gtroitsk/quarkus-test-framework/actions/runs/9928923886/job/27425829760


Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)