### PR TITLE
Replace deprecated app-model methods in QuarkusApplicationManagedResourceBuilder

### DIFF
--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusApplicationManagedResourceBuilder.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusApplicationManagedResourceBuilder.java
@@ -22,10 +22,10 @@ import java.util.stream.Stream;
 
 import org.apache.commons.lang3.StringUtils;
 
-import io.quarkus.bootstrap.model.AppArtifact;
-import io.quarkus.bootstrap.model.AppDependency;
 import io.quarkus.builder.Version;
 import io.quarkus.deployment.configuration.BuildTimeConfigurationReader;
+import io.quarkus.maven.dependency.ArtifactCoords;
+import io.quarkus.maven.dependency.ArtifactDependency;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.test.bootstrap.ManagedResourceBuilder;
 import io.quarkus.test.bootstrap.ServiceContext;
@@ -59,7 +59,7 @@ public abstract class QuarkusApplicationManagedResourceBuilder implements Manage
      * Whether build consist of all source classes or only some of them.
      */
     private boolean buildWithAllClasses = true;
-    private List<AppDependency> forcedDependencies = Collections.emptyList();
+    private List<ArtifactDependency> forcedDependencies = Collections.emptyList();
     private boolean requiresCustomBuild = false;
     private ServiceContext context;
     private String propertiesFile = APPLICATION_PROPERTIES;
@@ -107,7 +107,7 @@ public abstract class QuarkusApplicationManagedResourceBuilder implements Manage
         return buildWithAllClasses;
     }
 
-    protected List<AppDependency> getForcedDependencies() {
+    protected List<ArtifactDependency> getForcedDependencies() {
         return forcedDependencies;
     }
 
@@ -209,8 +209,8 @@ public abstract class QuarkusApplicationManagedResourceBuilder implements Manage
             this.forcedDependencies = Stream.of(forcedDependencies).map(d -> {
                 String groupId = StringUtils.defaultIfEmpty(resolveProperty(d.groupId()), QUARKUS_GROUP_ID_DEFAULT);
                 String version = StringUtils.defaultIfEmpty(resolveProperty(d.version()), Version.getVersion());
-                AppArtifact artifact = new AppArtifact(groupId, d.artifactId(), version);
-                return new AppDependency(artifact, DEPENDENCY_SCOPE_DEFAULT, DEPENDENCY_DIRECT_FLAG);
+                ArtifactCoords artifactCoords = ArtifactCoords.jar(groupId, d.artifactId(), version);
+                return new ArtifactDependency(artifactCoords, DEPENDENCY_SCOPE_DEFAULT, DEPENDENCY_DIRECT_FLAG);
             }).collect(Collectors.toList());
         }
     }


### PR DESCRIPTION
### Summary

Since Quarkus 3.11.0  some `io.quarkus.bootstrap.model.*` methods planned to be removed, that was [done yesterday](https://github.com/quarkusio/quarkus/pull/41939).  This PR provides fix with its replacement.

Single test in FW that forces dependencies is [GreetingResourceIT](https://github.com/quarkus-qe/quarkus-test-framework/blob/b081665c0289c1555447de6c56fc6b1c3db10d9b/examples/blocking-reactive-model/src/test/java/io/quarkus/qe/GreetingResourceIT.java#L15) from blocking-reactive-model module 

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)