### PR TITLE
Update deprecated method in OpenShiftClient

### DIFF
--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
@@ -64,6 +64,7 @@ import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.fabric8.kubernetes.client.dsl.NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable;
+import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
 import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.utils.Serialization;
@@ -235,7 +236,7 @@ public final class OpenShiftClient {
         deployment.getSpec().getTemplate().getSpec().getContainers().forEach(container -> {
             enrichProperties.forEach((key, value) -> container.getEnv().add(new EnvVar(key, value, null)));
         });
-        client.apps().deployments().resource(deployment).createOrReplace();
+        client.apps().deployments().resource(deployment).unlock().createOr(NonDeletingOperation::patch);
     }
 
     private void updateAnnotationsIfNecessary(Service service, String serviceName) {
@@ -536,8 +537,8 @@ public final class OpenShiftClient {
         groupModel.getMetadata().setName(service.getName());
         groupModel.setSpec(new OperatorGroupSpec());
         groupModel.getSpec().setTargetNamespaces(Arrays.asList(currentNamespace));
-        // call createOrReplace
-        client.resource(groupModel).createOrReplace();
+        // call createOr and if it exists the update will be done
+        client.resource(groupModel).unlock().createOr(NonDeletingOperation::update);
 
         // Install the subscription
         Subscription subscriptionModel = new Subscription();
@@ -839,8 +840,8 @@ public final class OpenShiftClient {
         list.setItems(objs);
         try {
             ByteArrayOutputStream os = new ByteArrayOutputStream();
-            Serialization.yamlMapper().writeValue(os, list);
-            template = new String(os.toByteArray());
+            os.write(Serialization.asYaml(list).getBytes());
+            template = os.toString();
         } catch (IOException e) {
             fail("Failed adding properties into OpenShift template. Caused by " + e.getMessage());
         }
@@ -1072,7 +1073,7 @@ public final class OpenShiftClient {
         } else {
             // create new one
             configMaps.resource(new ConfigMapBuilder().withNewMetadata().withName(configMapName).endMetadata()
-                    .addToData(key, value).build()).createOrReplace();
+                    .addToData(key, value).build()).unlock().create();
         }
     }
 


### PR DESCRIPTION
### Summary

Removing deprecated methods `createOrReplace()` and `yamlMapper()` from OpenShiftClient

Tested this version with testsuite weekly stable ocp and test was passing except know issues.

The `createOrReplace` was replaced by `createOr` and update is now provided by `NonDeletingOperation::update` or `NonDeletingOperation::patch`. This was recomnded by [official FAQ](https://github.com/fabric8io/kubernetes-client/blob/main/doc/FAQ.md#alternatives-to-createorreplace-and-replace). 
I decided to use the unlock even as it's optional as per explanation it's needed if the `resourceVersion` has value. 
`The use of the unlock function is optional and is only needed if you are starting with a item that has the resourceVersion populated.`

For `applyServicePropertiesToDeployment` method I using patch as I encounter few problem when testing it. Sometime it throw that resources are outdated when applying update. In this case patch is more safe. The problem was only in `configMapEndToEnd` but it's used in multiple tests. If you want to use update insted of patch we probably need to implement some kind of retry mechanism for it



The `yamlMapper` was updated similar as they done it when removing they usage [here](https://github.com/fabric8io/kubernetes-client/commit/3f08f6e0cebb04b582f97f7dba696678dfb96929#diff-a3fe9ad62627d61c56873f8741e5816d6fac34bc887c0cbfd0440305aedc86c3L161)

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)