### PR TITLE
Rename SA_PASSWORD to MSSQL_SA_PASSWORD as SA_PASSWORD is deprecated

### DIFF
--- a/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/SqlServerService.java
+++ b/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/SqlServerService.java
@@ -87,7 +87,7 @@ public class SqlServerService extends DatabaseService<SqlServerService> {
 
     @Override
     public SqlServerService onPreStart(Action action) {
-        withProperty("SA_PASSWORD", getPassword());
+        withProperty("MSSQL_SA_PASSWORD", getPassword());
         withProperty("ACCEPT_EULA", "Y");
         return super.onPreStart(action);
     }


### PR DESCRIPTION
### Summary

Updating password env variable for MSSQL as it was deprecated see note https://learn.microsoft.com/en-us/sql/linux/quickstart-install-connect-docker?view=sql-server-ver16&tabs=cli&pivots=cs1-bash#run-the-container-2

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)