### PR TITLE
[1.3.z] Backport of Strimzi Kafka testcontainer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <quarkus.build.skip>${skipTests}</quarkus.build.skip>
         <!-- Oracle image - we aim to use same version as Dev Services for Oracle so that we only download one image -->
         <oracle.image>docker.io/gvenzl/oracle-free:23-slim-faststart</oracle.image>
-        <strimzi.testcontainers.version>0.106.0</strimzi.testcontainers.version>
+        <strimzi.testcontainers.version>0.107.0</strimzi.testcontainers.version>
     </properties>
     <distributionManagement>
         <snapshotRepository>

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
         <quarkus.build.skip>${skipTests}</quarkus.build.skip>
         <!-- Oracle image - we aim to use same version as Dev Services for Oracle so that we only download one image -->
         <oracle.image>docker.io/gvenzl/oracle-free:23-slim-faststart</oracle.image>
+        <strimzi.testcontainers.version>0.106.0</strimzi.testcontainers.version>
     </properties>
     <distributionManagement>
         <snapshotRepository>
@@ -83,6 +84,22 @@
                 <version>${quarkus.platform.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <!-- The import above brings older version of this dependency, so we need to override it manually -->
+                <groupId>io.strimzi</groupId>
+                <artifactId>strimzi-test-container</artifactId>
+                <version>${strimzi.testcontainers.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.logging.log4j</groupId>
+                        <artifactId>log4j-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.logging.log4j</groupId>
+                        <artifactId>log4j-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>io.quarkus.qe</groupId>

--- a/quarkus-test-service-kafka/pom.xml
+++ b/quarkus-test-service-kafka/pom.xml
@@ -9,7 +9,6 @@
     <artifactId>quarkus-test-service-kafka</artifactId>
     <name>Quarkus - Test Framework - Service - Kafka</name>
     <properties>
-        <strimzi.testcontainers.version>0.104.0</strimzi.testcontainers.version>
         <log4j.version>2.20.0</log4j.version>
     </properties>
     <dependencies>
@@ -24,17 +23,6 @@
         <dependency>
             <groupId>io.strimzi</groupId>
             <artifactId>strimzi-test-container</artifactId>
-            <version>${strimzi.testcontainers.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.logging.log4j</groupId>
-                    <artifactId>log4j-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.logging.log4j</groupId>
-                    <artifactId>log4j-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/strimzi/ExtendedStrimziKafkaContainer.java
+++ b/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/strimzi/ExtendedStrimziKafkaContainer.java
@@ -35,6 +35,7 @@ public class ExtendedStrimziKafkaContainer extends StrimziKafkaContainer {
     protected void containerIsStarting(InspectContainerResponse containerInfo, boolean reused) {
         Log.info("Starting container using custom server properties");
         if (useCustomServerProperties) {
+            Log.info("Starting container using custom server properties");
             List<String> script = new ArrayList<>();
             script.add("#!/bin/bash");
             script.add("set -euv");
@@ -43,7 +44,7 @@ public class ExtendedStrimziKafkaContainer extends StrimziKafkaContainer {
                     + "config/kraft/server.properties  > /tmp/effective_server.properties");
             script.add("KAFKA_CLUSTER_ID=\"$(bin/kafka-storage.sh random-uuid)\"");
             String storageFormat = "/opt/kafka/bin/kafka-storage.sh format"
-                    + " -t ${KAFKA_CLUSTER_ID}"
+                    + " -t=${KAFKA_CLUSTER_ID}"
                     + " -c /tmp/effective_server.properties";
             script.add(storageFormat);
             script.add("bin/kafka-server-start.sh /tmp/effective_server.properties");
@@ -53,6 +54,7 @@ public class ExtendedStrimziKafkaContainer extends StrimziKafkaContainer {
             // we do not process credentials here, since SASL always used together with custom properties
             // see StrimziKafkaContainerManagedResource#getServerProperties
             super.containerIsStarting(containerInfo, reused);
+            Log.info("Starting container using standard server properties and cluster id " + super.getClusterId());
             // if that is to change, we will need to copy script from test containers, modify it and copy back again
         }
     }

--- a/quarkus-test-service-kafka/src/main/resources/strimzi-deployment-template.yml
+++ b/quarkus-test-service-kafka/src/main/resources/strimzi-deployment-template.yml
@@ -29,7 +29,7 @@ items:
         #!/bin/bash
         set -euv
         KAFKA_CLUSTER_ID="$(/opt/kafka/bin/kafka-storage.sh random-uuid)"
-        /opt/kafka/bin/kafka-storage.sh format -t ${KAFKA_CLUSTER_ID} -c config/kraft/server.properties
+        /opt/kafka/bin/kafka-storage.sh format -t=${KAFKA_CLUSTER_ID} -c config/kraft/server.properties
         /opt/kafka/bin/kafka-server-start.sh config/kraft/server.properties --override listeners=PLAINTEXT://0.0.0.0:${KAFKA_PORT},CONTROLLER://localhost:9093 --override advertised.listeners=PLAINTEXT://${SERVICE_NAME}:${KAFKA_PORT}
   - apiVersion: "apps.openshift.io/v1"
     kind: "DeploymentConfig"


### PR DESCRIPTION
### Summary

Backport of strimzi update

- https://github.com/quarkus-qe/quarkus-test-framework/pull/1207
- https://github.com/quarkus-qe/quarkus-test-framework/pull/1191

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Backport 
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)