### PR TITLE
Allow running CLI in dev mode, without overwriting quarkus version

### DIFF
--- a/examples/quarkus-cli/src/test/java/io/quarkus/qe/QuarkusCliClientIT.java
+++ b/examples/quarkus-cli/src/test/java/io/quarkus/qe/QuarkusCliClientIT.java
@@ -25,7 +25,7 @@ import io.quarkus.test.bootstrap.QuarkusCliRestService;
 import io.quarkus.test.bootstrap.config.QuarkusConfigCommand;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.scenarios.annotations.EnabledOnNative;
-import io.quarkus.test.services.quarkus.CliDevModeVersionLessQuarkusApplicationManagerResource;
+import io.quarkus.test.services.quarkus.CliDevModeVersionLessQuarkusApplicationManagedResource;
 import io.quarkus.test.services.quarkus.model.QuarkusProperties;
 
 @Tag("quarkus-cli")
@@ -116,8 +116,8 @@ public class QuarkusCliClientIT {
         QuarkusCliRestService app = cliClient.createApplication("versionFull:app", defaults()
                 .withStream("3.8")
                 .withPlatformBom(null)
-                .withManagedResourceCreator(
-                        (serviceContext, quarkusCliClient) -> s -> new CliDevModeVersionLessQuarkusApplicationManagerResource(
+                .withManagedResourceCreator((serviceContext,
+                        quarkusCliClient) -> managedResourceBuilder -> new CliDevModeVersionLessQuarkusApplicationManagedResource(
                                 serviceContext, quarkusCliClient)));
 
         app.start();

--- a/examples/quarkus-cli/src/test/java/io/quarkus/qe/QuarkusCliClientIT.java
+++ b/examples/quarkus-cli/src/test/java/io/quarkus/qe/QuarkusCliClientIT.java
@@ -25,6 +25,7 @@ import io.quarkus.test.bootstrap.QuarkusCliRestService;
 import io.quarkus.test.bootstrap.config.QuarkusConfigCommand;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.scenarios.annotations.EnabledOnNative;
+import io.quarkus.test.services.quarkus.CliDevModeVersionLessQuarkusApplicationManagerResource;
 import io.quarkus.test.services.quarkus.model.QuarkusProperties;
 
 @Tag("quarkus-cli")
@@ -108,6 +109,22 @@ public class QuarkusCliClientIT {
 
         QuarkusCliClient.Result result = app.buildOnJvm();
         assertTrue(result.isSuccessful(), "The application didn't build on JVM. Output: " + result.getOutput());
+    }
+
+    @Test
+    public void shouldRunApplicationWithoutOverwritingVersion() {
+        QuarkusCliRestService app = cliClient.createApplication("versionFull:app", defaults()
+                .withStream("3.8")
+                .withPlatformBom(null)
+                .withManagedResourceCreator(
+                        (serviceContext, quarkusCliClient) -> s -> new CliDevModeVersionLessQuarkusApplicationManagerResource(
+                                serviceContext, quarkusCliClient)));
+
+        app.start();
+        String response = app.given().get().getBody().asString();
+        // check that app was indeed running with quarkus 3.8 (it was not overwritten)
+        // version is printed on welcome screen
+        assertTrue(response.contains("3.8"), "Quarkus is not running on 3.8");
     }
 
     @Test

--- a/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/QuarkusCliClient.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/QuarkusCliClient.java
@@ -264,8 +264,8 @@ public class QuarkusCliClient {
         private String[] extensions;
         private String[] extraArgs;
         private ManagedResourceCreator managedResourceCreator = (serviceContext,
-                quarkusCliClient) -> s -> new CliDevModeLocalhostQuarkusApplicationManagedResource(serviceContext,
-                        quarkusCliClient);
+                quarkusCliClient) -> managedResourceBuilder -> new CliDevModeLocalhostQuarkusApplicationManagedResource(
+                        serviceContext, quarkusCliClient);
 
         public CreateApplicationRequest withPlatformBom(String platformBom) {
             this.platformBom = platformBom;

--- a/quarkus-test-cli/src/main/java/io/quarkus/test/services/quarkus/CliDevModeLocalhostQuarkusApplicationManagedResource.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/services/quarkus/CliDevModeLocalhostQuarkusApplicationManagedResource.java
@@ -22,17 +22,17 @@ import io.quarkus.test.utils.SocketUtils;
 
 public class CliDevModeLocalhostQuarkusApplicationManagedResource extends QuarkusManagedResource {
 
-    private static final String QUARKUS_HTTP_PORT_PROPERTY = "quarkus.http.port";
-    private static final String QUARKUS_PLATFORM_ARTIFACT_ID = "quarkus.platform.artifact-id";
-    private static final String QUARKUS_PLATFORM_ARTIFACT_ID_VALUE = "quarkus-bom";
-    private static final String QUARKUS_PLATFORM_VERSION = "quarkus.platform.version";
+    protected static final String QUARKUS_HTTP_PORT_PROPERTY = "quarkus.http.port";
+    protected static final String QUARKUS_PLATFORM_ARTIFACT_ID = "quarkus.platform.artifact-id";
+    protected static final String QUARKUS_PLATFORM_ARTIFACT_ID_VALUE = "quarkus-bom";
+    protected static final String QUARKUS_PLATFORM_VERSION = "quarkus.platform.version";
 
-    private final ServiceContext serviceContext;
-    private final QuarkusCliClient client;
+    protected final ServiceContext serviceContext;
+    protected final QuarkusCliClient client;
 
+    protected int assignedHttpPort;
     private Process process;
     private LoggingHandler loggingHandler;
-    private int assignedHttpPort;
 
     public CliDevModeLocalhostQuarkusApplicationManagedResource(ServiceContext serviceContext,
             QuarkusCliClient client) {
@@ -101,7 +101,7 @@ public class CliDevModeLocalhostQuarkusApplicationManagedResource extends Quarku
         return loggingHandler;
     }
 
-    private Map<String, String> getPropertiesForCommand() {
+    protected Map<String, String> getPropertiesForCommand() {
         Map<String, String> runtimeProperties = new HashMap<>(serviceContext.getOwner().getProperties());
         runtimeProperties.putIfAbsent(QUARKUS_HTTP_PORT_PROPERTY, "" + assignedHttpPort);
         runtimeProperties.putIfAbsent(QUARKUS_PLATFORM_VERSION, QuarkusProperties.getVersion());

--- a/quarkus-test-cli/src/main/java/io/quarkus/test/services/quarkus/CliDevModeVersionLessQuarkusApplicationManagedResource.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/services/quarkus/CliDevModeVersionLessQuarkusApplicationManagedResource.java
@@ -6,9 +6,9 @@ import java.util.Map;
 import io.quarkus.test.bootstrap.QuarkusCliClient;
 import io.quarkus.test.bootstrap.ServiceContext;
 
-public class CliDevModeVersionLessQuarkusApplicationManagerResource
+public class CliDevModeVersionLessQuarkusApplicationManagedResource
         extends CliDevModeLocalhostQuarkusApplicationManagedResource {
-    public CliDevModeVersionLessQuarkusApplicationManagerResource(ServiceContext serviceContext, QuarkusCliClient client) {
+    public CliDevModeVersionLessQuarkusApplicationManagedResource(ServiceContext serviceContext, QuarkusCliClient client) {
         super(serviceContext, client);
     }
 

--- a/quarkus-test-cli/src/main/java/io/quarkus/test/services/quarkus/CliDevModeVersionLessQuarkusApplicationManagerResource.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/services/quarkus/CliDevModeVersionLessQuarkusApplicationManagerResource.java
@@ -1,0 +1,21 @@
+package io.quarkus.test.services.quarkus;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.quarkus.test.bootstrap.QuarkusCliClient;
+import io.quarkus.test.bootstrap.ServiceContext;
+
+public class CliDevModeVersionLessQuarkusApplicationManagerResource
+        extends CliDevModeLocalhostQuarkusApplicationManagedResource {
+    public CliDevModeVersionLessQuarkusApplicationManagerResource(ServiceContext serviceContext, QuarkusCliClient client) {
+        super(serviceContext, client);
+    }
+
+    @Override
+    protected Map<String, String> getPropertiesForCommand() {
+        Map<String, String> runtimeProperties = new HashMap<>(serviceContext.getOwner().getProperties());
+        runtimeProperties.putIfAbsent(QUARKUS_HTTP_PORT_PROPERTY, "" + assignedHttpPort);
+        return runtimeProperties;
+    }
+}


### PR DESCRIPTION
### Summary

Create an option for CLI based application to run and not have their quarkus version overwritten. Using up-to-date quarkus is usually a good thing, but for testing CLI stuff like `--stream=3.x` and `quarkus update` I want to run the app with the version that is specified in the pom and not overwrite it.

This PR should cause no problem to existing stuff, as defaults are the same. It just allows to change this behaviour to run quarkus apps without setting quarkus version as their parameter. Example how to use it is new test.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [X] Example scenarios has been updated / added
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)