### PR TITLE
Add method for creating CLI apps from existing sources

### DIFF
--- a/examples/quarkus-cli/src/test/java/io/quarkus/qe/QuarkusCliClientIT.java
+++ b/examples/quarkus-cli/src/test/java/io/quarkus/qe/QuarkusCliClientIT.java
@@ -9,13 +9,17 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
 import jakarta.inject.Inject;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.http.HttpStatus;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -197,6 +201,16 @@ public class QuarkusCliClientIT {
                 .name(propertyName)
                 .executeCommand()
                 .assertApplicationPropertiesDoesNotContain(propertyName);
+    }
+
+    @Test
+    public void testCreateApplicationFromExistingSources() {
+        Path srcPath = Paths.get("src/test/resources/existingSourcesApp");
+        QuarkusCliRestService app = cliClient.createApplicationFromExistingSources("app", null, srcPath);
+
+        app.start();
+        Awaitility.await().timeout(15, TimeUnit.SECONDS)
+                .untilAsserted(() -> app.given().get("/hello").then().statusCode(HttpStatus.SC_OK));
     }
 
     private void assertInstalledExtensions(QuarkusCliRestService app, String... expectedExtensions) {

--- a/examples/quarkus-cli/src/test/resources/existingSourcesApp/pom.xml
+++ b/examples/quarkus-cli/src/test/resources/existingSourcesApp/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.acme</groupId>
+    <artifactId>existingSourcesApp</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+
+    <properties>
+        <compiler-plugin.version>3.13.0</compiler-plugin.version>
+        <maven.compiler.release>17</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.12.3</quarkus.platform.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>${quarkus.platform.group-id}</groupId>
+                <artifactId>${quarkus.platform.artifact-id}</artifactId>
+                <version>${quarkus.platform.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>${quarkus.platform.group-id}</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <version>${quarkus.platform.version}</version>
+                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                            <goal>generate-code</goal>
+                            <goal>generate-code-tests</goal>
+                            <goal>native-image-agent</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${compiler-plugin.version}</version>
+                <configuration>
+                    <compilerArgs>
+                        <arg>-parameters</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/quarkus-cli/src/test/resources/existingSourcesApp/src/main/java/org/acme/GreetingResource.java
+++ b/examples/quarkus-cli/src/test/resources/existingSourcesApp/src/main/java/org/acme/GreetingResource.java
@@ -1,0 +1,16 @@
+package org.acme;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/hello")
+public class GreetingResource {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return "Hello from Quarkus REST";
+    }
+}

--- a/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/QuarkusCliClient.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/QuarkusCliClient.java
@@ -20,6 +20,7 @@ import io.quarkus.test.configuration.PropertyLookup;
 import io.quarkus.test.logging.FileLoggingHandler;
 import io.quarkus.test.logging.Log;
 import io.quarkus.test.services.quarkus.CliDevModeLocalhostQuarkusApplicationManagedResource;
+import io.quarkus.test.services.quarkus.CliDevModeVersionLessQuarkusApplicationManagedResource;
 import io.quarkus.test.services.quarkus.model.QuarkusProperties;
 import io.quarkus.test.utils.FileUtils;
 import io.quarkus.test.utils.ProcessBuilderProvider;
@@ -116,6 +117,21 @@ public class QuarkusCliClient {
 
         Result result = runCliAndWait(serviceContext.getServiceFolder().getParent(), args.toArray(new String[args.size()]));
         assertTrue(result.isSuccessful(), "The application was not created. Output: " + result.getOutput());
+
+        return service;
+    }
+
+    public QuarkusCliRestService createApplicationFromExistingSources(String name, String targetFolderName, Path sourcesDir) {
+        Path serviceFolder = isNotEmpty(targetFolderName) ? TARGET.resolve(targetFolderName).resolve(name) : null;
+        QuarkusCliRestService service = new QuarkusCliRestService(this, serviceFolder);
+        ServiceContext serviceContext = service.register(name, context);
+
+        service.init(s -> new CliDevModeVersionLessQuarkusApplicationManagedResource(serviceContext, this));
+
+        // We need the service folder to be emptied before generating the project
+        FileUtils.deletePath(serviceContext.getServiceFolder());
+
+        FileUtils.copyDirectoryTo(sourcesDir, serviceContext.getServiceFolder());
 
         return service;
     }

--- a/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/QuarkusCliClient.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/QuarkusCliClient.java
@@ -124,7 +124,7 @@ public class QuarkusCliClient {
     public QuarkusCliRestService createApplicationFromExistingSources(String name, String targetFolderName, Path sourcesDir) {
         return createApplicationFromExistingSources(name, targetFolderName, sourcesDir,
                 ((serviceContext,
-                        quarkusCliClient) -> managedResourceCreator -> new CliDevModeVersionLessQuarkusApplicationManagedResource(
+                        quarkusCliClient) -> managedResCreator -> new CliDevModeVersionLessQuarkusApplicationManagedResource(
                                 serviceContext, quarkusCliClient)));
     }
 

--- a/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/QuarkusCliClient.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/QuarkusCliClient.java
@@ -122,11 +122,19 @@ public class QuarkusCliClient {
     }
 
     public QuarkusCliRestService createApplicationFromExistingSources(String name, String targetFolderName, Path sourcesDir) {
+        return createApplicationFromExistingSources(name, targetFolderName, sourcesDir,
+                ((serviceContext,
+                        quarkusCliClient) -> managedResourceCreator -> new CliDevModeVersionLessQuarkusApplicationManagedResource(
+                                serviceContext, quarkusCliClient)));
+    }
+
+    public QuarkusCliRestService createApplicationFromExistingSources(String name, String targetFolderName, Path sourcesDir,
+            ManagedResourceCreator managedResourceCreator) {
         Path serviceFolder = isNotEmpty(targetFolderName) ? TARGET.resolve(targetFolderName).resolve(name) : null;
         QuarkusCliRestService service = new QuarkusCliRestService(this, serviceFolder);
         ServiceContext serviceContext = service.register(name, context);
 
-        service.init(s -> new CliDevModeVersionLessQuarkusApplicationManagedResource(serviceContext, this));
+        service.init(managedResourceCreator.initBuilder(serviceContext, this));
 
         // We need the service folder to be emptied before generating the project
         FileUtils.deletePath(serviceContext.getServiceFolder());


### PR DESCRIPTION
### Summary

This PR adds a method to create QuarkusCliRestService from existing sources. It should do similar job as already existing "createApplication" methods.
This feature is important for "quarkus update" testing. For testing advanced scenarios (such as updating entire app with business logic) we need to have prepared app, which we can then update and start. It is not feasible to construct entire app from scratch in tests.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [X] Example scenarios has been updated / added
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)