### PR TITLE
Fix QuarkusCliConfigEncryptIT for Windows OS

### DIFF
--- a/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/config/QuarkusConfigCommandResult.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/config/QuarkusConfigCommandResult.java
@@ -3,6 +3,8 @@ package io.quarkus.test.bootstrap.config;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.smallrye.common.os.OS;
+
 public class QuarkusConfigCommandResult {
 
     final String applicationPropertiesAsString;
@@ -19,8 +21,22 @@ public class QuarkusConfigCommandResult {
     }
 
     public QuarkusConfigCommandResult assertCommandOutputContains(String expected) {
-        assertTrue(output.contains(expected.trim()), "Expected output '" + output + "' does not contain '" + expected + "'");
+        if (OS.WINDOWS.isCurrent()) {
+            String windowsEscapedExpected = normalizeString(expected);
+            String windowsEscapedOutput = normalizeString(output);
+
+            assertTrue(windowsEscapedOutput.contains(windowsEscapedExpected),
+                    "Expected output '" + windowsEscapedExpected + "'does not contain '" + windowsEscapedOutput + "'");
+        } else {
+            assertTrue(output.contains(expected.trim()),
+                    "Expected output '" + output + "' does not contain '" + expected + "'");
+        }
         return this;
+    }
+
+    private String normalizeString(String str) {
+        String noAnsi = str.replaceAll("\\x1B\\[[;\\d]*m", "");
+        return noAnsi.replaceAll("\"", "").replaceAll("\n", " ").trim();
     }
 
     public QuarkusConfigCommandResult assertApplicationPropertiesContains(String str) {

--- a/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/config/QuarkusEncryptConfigCommandBuilder.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/config/QuarkusEncryptConfigCommandBuilder.java
@@ -10,8 +10,10 @@ import javax.crypto.KeyGenerator;
 import org.junit.jupiter.api.Assertions;
 
 import io.quarkus.test.logging.Log;
+import io.quarkus.test.util.QuarkusCLIUtils;
 import io.quarkus.test.utils.Command;
 import io.quarkus.test.utils.FileUtils;
+import io.smallrye.common.os.OS;
 
 public class QuarkusEncryptConfigCommandBuilder {
 
@@ -31,7 +33,12 @@ public class QuarkusEncryptConfigCommandBuilder {
     }
 
     public QuarkusEncryptConfigCommandBuilder secret(String secret) {
-        this.secret = secret;
+        if (OS.WINDOWS.isCurrent()) {
+            this.secret = QuarkusCLIUtils.escapeSecretCharsForWindows(secret);
+        } else {
+            this.secret = secret;
+        }
+
         return this;
     }
 

--- a/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/config/QuarkusEncryptConfigCommandResult.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/config/QuarkusEncryptConfigCommandResult.java
@@ -5,6 +5,8 @@ import static io.quarkus.test.bootstrap.config.QuarkusEncryptConfigCommandBuilde
 import java.util.Objects;
 import java.util.function.Consumer;
 
+import io.quarkus.test.util.QuarkusCLIUtils;
+
 public class QuarkusEncryptConfigCommandResult extends QuarkusConfigCommandResult {
 
     private static final String SECRET_ENCRYPTED_TO = "was encrypted to";
@@ -19,7 +21,11 @@ public class QuarkusEncryptConfigCommandResult extends QuarkusConfigCommandResul
 
     public String getGeneratedEncryptionKey() {
         if (output.contains(WITH_GENERATED_KEY)) {
-            return output.transform(o -> o.substring(o.lastIndexOf(" "))).trim();
+            return output
+                    .transform(o -> o.substring(o.lastIndexOf(" ")))
+                    .transform(QuarkusCLIUtils::toUtf8)
+                    .transform(QuarkusCLIUtils::removeAnsiAndHiddenChars)
+                    .trim();
         }
         return null;
     }
@@ -29,6 +35,8 @@ public class QuarkusEncryptConfigCommandResult extends QuarkusConfigCommandResul
             encryptedSecret = output
                     .transform(o -> o.split(SECRET_ENCRYPTED_TO)[1])
                     .transform(remaining -> remaining.split(WITH_GENERATED_KEY)[0])
+                    .transform(QuarkusCLIUtils::toUtf8)
+                    .transform(QuarkusCLIUtils::removeAnsiAndHiddenChars)
                     .trim();
         }
         return encryptedSecret;

--- a/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/config/QuarkusSetConfigCommandBuilder.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/config/QuarkusSetConfigCommandBuilder.java
@@ -2,6 +2,9 @@ package io.quarkus.test.bootstrap.config;
 
 import java.util.ArrayList;
 
+import io.quarkus.test.util.QuarkusCLIUtils;
+import io.smallrye.common.os.OS;
+
 public class QuarkusSetConfigCommandBuilder {
 
     private final boolean updateScenario;
@@ -23,7 +26,11 @@ public class QuarkusSetConfigCommandBuilder {
     }
 
     public QuarkusSetConfigCommandBuilder value(String value) {
-        this.propertyValue = value;
+        if (OS.WINDOWS.isCurrent()) {
+            this.propertyValue = QuarkusCLIUtils.escapeSecretCharsForWindows(value);
+        } else {
+            this.propertyValue = value;
+        }
         return this;
     }
 

--- a/quarkus-test-cli/src/main/java/io/quarkus/test/util/QuarkusCLIUtils.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/util/QuarkusCLIUtils.java
@@ -375,4 +375,13 @@ public abstract class QuarkusCLIUtils {
             return "Plugin {groupId=" + getGroupId() + ", artifactId=" + getArtifactId() + ", version=" + getVersion() + "}";
         }
     }
+
+    /**
+     * Escapes a command-line secret chars for Windows OS.
+     */
+    public static String escapeSecretCharsForWindows(String secret) {
+        return "\"" + secret
+                .replace("\"", "\\\"")
+                + "\"";
+    }
 }

--- a/quarkus-test-cli/src/main/java/io/quarkus/test/util/QuarkusCLIUtils.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/util/QuarkusCLIUtils.java
@@ -11,6 +11,8 @@ import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
@@ -27,12 +29,15 @@ import org.codehaus.plexus.util.xml.XmlStreamReader;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 
 import io.quarkus.test.bootstrap.QuarkusCliRestService;
+import io.smallrye.common.os.OS;
 
 public abstract class QuarkusCLIUtils {
     public static final String RESOURCES_DIR = Paths.get("src", "main", "resources").toString();
     public static final String PROPERTIES_FILE = "application.properties";
     public static final String PROPERTIES_YAML_FILE = "application.yml";
     public static final String POM_FILE = "pom.xml";
+    private static final String ANSI_BOLD_TEXT_ESCAPE_SEQ = "[1m";
+    private static final char ESCAPE_CHARACTER = 27;
 
     /**
      * This constant stands for number of fields in groupId:artifactId:version string, when separated via ":".
@@ -383,5 +388,37 @@ public abstract class QuarkusCLIUtils {
         return "\"" + secret
                 .replace("\"", "\\\"")
                 + "\"";
+    }
+
+    /**
+     * When Quarkus CLI prints out text, especially by {@code quarkus config encrypt} command,
+     * important parts (like encoded secrets) can be highlighted or there can be hidden chars.
+     * We recognize hidden chars etc. This method handles both situation. It's definitely imperfect,
+     * but we only deal with scenarios (issues) we run on.
+     */
+    public static String removeAnsiAndHiddenChars(String text) {
+        if (OS.current() == OS.WINDOWS) {
+            var result = text
+                    .trim()
+                    .transform(t -> {
+                        if (t.contains(ANSI_BOLD_TEXT_ESCAPE_SEQ)) {
+                            return t.substring(ANSI_BOLD_TEXT_ESCAPE_SEQ.length());
+                        }
+                        return t;
+                    })
+                    .transform(t -> {
+                        int idx = t.indexOf(ESCAPE_CHARACTER);
+                        if (idx >= 0) {
+                            return t.substring(0, idx);
+                        }
+                        return t;
+                    });
+            return result;
+        }
+        return text;
+    }
+
+    public static String toUtf8(String t) {
+        return new String(t.getBytes(Charset.defaultCharset()), StandardCharsets.UTF_8);
     }
 }


### PR DESCRIPTION
### Summary

Currently there are some failures in our win jobs related to QuarkusCliConfigEncryptIT because special characters Strings in QuarkusCliConfigEncryptIT class on Windows OS 

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)