### PR TITLE
Add extraArgs method to CLIAppManager

### DIFF
--- a/quarkus-test-cli/src/main/java/io/quarkus/test/util/DefaultQuarkusCLIAppManager.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/util/DefaultQuarkusCLIAppManager.java
@@ -3,6 +3,8 @@ package io.quarkus.test.util;
 import static io.quarkus.test.bootstrap.QuarkusCliClient.CreateApplicationRequest.defaults;
 import static io.quarkus.test.bootstrap.QuarkusCliClient.UpdateApplicationRequest.defaultUpdate;
 
+import java.util.Arrays;
+
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 
 import io.quarkus.test.bootstrap.QuarkusCliClient;
@@ -41,11 +43,24 @@ public class DefaultQuarkusCLIAppManager implements IQuarkusCLIAppManager {
     }
 
     @Override
-    public QuarkusCliRestService createApplication(String... extensions) {
-        Log.info("Creating app with version stream: " + oldVersion + " and extensions " + extensions);
+    public QuarkusCliRestService createApplicationWithExtensions(String... extensions) {
+        Log.info("Creating app with version stream: " + oldVersion + " and extensions " + Arrays.toString(extensions));
         return cliClient.createApplication("app", defaults()
                 .withPlatformBom(null)
                 .withExtensions(extensions)
+                .withStream(oldVersion.toString())
+                // overwrite managedResource to use quarkus version defined in pom.xml and not overwrite it in CLI command
+                .withManagedResourceCreator((serviceContext,
+                        quarkusCliClient) -> managedResBuilder -> new CliDevModeVersionLessQuarkusApplicationManagedResource(
+                                serviceContext, quarkusCliClient)));
+    }
+
+    @Override
+    public QuarkusCliRestService createApplicationWithExtraArgs(String... extraArgs) {
+        Log.info("Creating app with version stream: " + oldVersion + " and extraArgs " + Arrays.toString(extraArgs));
+        return cliClient.createApplication("app", defaults()
+                .withPlatformBom(null)
+                .withExtraArgs(extraArgs)
                 .withStream(oldVersion.toString())
                 // overwrite managedResource to use quarkus version defined in pom.xml and not overwrite it in CLI command
                 .withManagedResourceCreator((serviceContext,

--- a/quarkus-test-cli/src/main/java/io/quarkus/test/util/IQuarkusCLIAppManager.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/util/IQuarkusCLIAppManager.java
@@ -10,14 +10,16 @@ public interface IQuarkusCLIAppManager {
      * Create an app which can be updated.
      */
     default QuarkusCliRestService createApplication() {
-        return createApplication((String) null);
+        return createApplicationWithExtensions((String) null);
     }
 
     /**
      * @param extensions Pass this parameter to
      *        {@link io.quarkus.test.bootstrap.QuarkusCliClient} createApplication.withExtensions
      */
-    QuarkusCliRestService createApplication(String... extensions);
+    QuarkusCliRestService createApplicationWithExtensions(String... extensions);
+
+    QuarkusCliRestService createApplicationWithExtraArgs(String... extraArgs);
 
     /**
      * Update app to new quarkus version.

--- a/quarkus-test-cli/src/main/java/io/quarkus/test/util/QuarkusCLIUtils.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/util/QuarkusCLIUtils.java
@@ -73,7 +73,7 @@ public abstract class QuarkusCLIUtils {
             Properties oldProperties,
             Properties expectedNewProperties) throws IOException {
         // create app with yaml extension
-        QuarkusCliRestService app = appManager.createApplication("quarkus-config-yaml");
+        QuarkusCliRestService app = appManager.createApplicationWithExtensions("quarkus-config-yaml");
         // write properties to yaml
         writePropertiesToYamlFile(app, oldProperties);
 


### PR DESCRIPTION
### Summary

Add creation method withExtraArgs to quarkusCLIAppManager. This method would otherwise need to be implemented in tests and it fits into defaultAppManager.

Also rename existing methods to avoid confusion.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [X] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)