### PR TITLE
Use snapshot in builds with snapshot CLI

### DIFF
--- a/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/QuarkusCliClient.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/QuarkusCliClient.java
@@ -30,6 +30,7 @@ public class QuarkusCliClient {
     public static final String COMMAND_LOG_FILE = "quarkus-cli-command.out";
     public static final String DEV_MODE_LOG_FILE = "quarkus-cli-dev.out";
 
+    private static final String QUARKUS_VERSION_PROPERTY_NAME = "quarkus.version";
     private static final String QUARKUS_UPSTREAM_VERSION = "999-SNAPSHOT";
     private static final String BUILD = "build";
     private static final PropertyLookup COMMAND = new PropertyLookup("ts.quarkus.cli.cmd", "quarkus");
@@ -52,6 +53,9 @@ public class QuarkusCliClient {
     public Result buildApplicationOnJvm(Path serviceFolder, String... extraArgs) {
         List<String> args = new ArrayList<>();
         args.add(BUILD);
+        if (isUpstream()) {
+            args.add("-D" + QUARKUS_VERSION_PROPERTY_NAME + "=" + QuarkusProperties.getVersion());
+        }
         args.addAll(Arrays.asList(extraArgs));
         return runCliAndWait(serviceFolder, args.toArray(new String[args.size()]));
     }
@@ -60,6 +64,9 @@ public class QuarkusCliClient {
         List<String> args = new ArrayList<>();
         args.add(BUILD);
         args.add("--native");
+        if (isUpstream()) {
+            args.add("-D" + QUARKUS_VERSION_PROPERTY_NAME + "=" + QuarkusProperties.getVersion());
+        }
         args.addAll(Arrays.asList(extraArgs));
         return runCliAndWait(serviceFolder, args.toArray(new String[args.size()]));
     }


### PR DESCRIPTION
### Summary

* When snapshot version of Quarkus is used, the quarkus.version property should be set to Quarkus version set in the execution with build CLI command

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)