### PR TITLE
[DRAFT] Manage fabric8 client version in framework

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,25 @@
     </distributionManagement>
     <dependencyManagement>
         <dependencies>
+            <!-- This is a workaround for https://github.com/quarkusio/quarkus/issues/42656. Generally, as long as we
+            go on testing upstream Quarkus with versions of framework compiled and based on already released Quarkus,
+            possibility of binary incompatibility is high - at least for fabric8 client. This workaround allows us to
+            bypass using the client managed by Quarkus and just set the client version with the framework.
+
+            To verify that this actually does something, one can build framework with released Quarkus and run OCP tests
+            with snapshot and vice-versa, e.g.:
+
+            mvn clean install -Pframework && mvn clean verify -Popenshift,examples -pl examples/https/ -Dquarkus.platform.version=999-SNAPSHOT
+            mvn clean install -Pframework -Dquarkus.platform.version=999-SNAPSHOT && mvn clean verify -Popenshift,examples -pl examples/https/ -Dquarkus.platform.version=3.13.2
+
+            -->
+            <dependency>
+                <groupId>io.fabric8</groupId>
+                <artifactId>kubernetes-client-bom</artifactId>
+                <version>6.13.3</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>${quarkus.platform.artifact-id}</artifactId>


### PR DESCRIPTION
### Summary

* Due to https://github.com/quarkusio/quarkus/issues/42656, this implements a workaround where we manage fabric8 version ourselves rather than letting Quarkus manage it, as this leads to binary incompatible versions of library.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Dependency update
- [x] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)