### PR TITLE
Reduce log size in CI runs

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -25,7 +25,7 @@ jobs:
           cache: 'maven'
       - name: Build Quarkus main
         run: |
-          git clone https://github.com/quarkusio/quarkus.git && cd quarkus && ./mvnw -B -s .github/mvn-settings.xml clean install -Dquickly -Dno-test-modules -Prelocations
+          git clone https://github.com/quarkusio/quarkus.git && cd quarkus && ./mvnw -B --no-transfer-progress -s .github/mvn-settings.xml clean install -Dquickly -Dno-test-modules -Prelocations
       - name: Tar Maven Repo
         shell: bash
         run: tar -I 'pigz -9' -cf maven-repo.tgz -C ~ .m2/repository
@@ -61,7 +61,7 @@ jobs:
              QUARKUS_VERSION="-Dquarkus.platform.version=${{ matrix.quarkus-version }}"
           fi
 
-          mvn -B -fae -s .github/mvn-settings.xml clean install  -Dvalidate-format $QUARKUS_VERSION $EXCLUDE_MODULES
+          mvn -B --no-transfer-progress -fae -s .github/mvn-settings.xml clean install  -Dvalidate-format $QUARKUS_VERSION $EXCLUDE_MODULES
       - name: Zip Artifacts
         if: failure()
         run: |
@@ -102,7 +102,7 @@ jobs:
         run: tar -xzf maven-repo.tgz -C ~
       - name: Build Quarkus CLI
         run: |
-          git clone https://github.com/quarkusio/quarkus.git && cd quarkus/devtools/cli && mvn -B -s ../../../.github/mvn-settings.xml clean install -Dquickly -Dno-test-modules -Prelocations
+          git clone https://github.com/quarkusio/quarkus.git && cd quarkus/devtools/cli && mvn -B --no-transfer-progress -s ../../../.github/mvn-settings.xml clean install -Dquickly -Dno-test-modules -Prelocations
       - name: Install Quarkus CLI
         run: |
           cat <<EOF > ./quarkus-dev-cli
@@ -113,7 +113,7 @@ jobs:
           ./quarkus-dev-cli version
       - name: Build
         run: |
-          mvn -B -fae -s .github/mvn-settings.xml clean install -Pframework,examples,coverage -Dvalidate-format -Drun-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli" -Dquarkus.platform.version="${{ matrix.quarkus-version }}"
+          mvn -B --no-transfer-progress -fae -s .github/mvn-settings.xml clean install -Pframework,examples,coverage -Dvalidate-format -Drun-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli" -Dquarkus.platform.version="${{ matrix.quarkus-version }}"
       - name: Generate Jacoco Report
         run: |
           cd coverage-report
@@ -195,7 +195,7 @@ jobs:
              QUARKUS_VERSION="-Dquarkus.platform.version=${{ matrix.quarkus-version }}"
           fi
 
-          mvn -B -fae -s .github/mvn-settings.xml clean install -Pframework,examples,native $QUARKUS_VERSION $EXCLUDE_MODULES
+          mvn -B --no-transfer-progress -fae -s .github/mvn-settings.xml clean install -Pframework,examples,native $QUARKUS_VERSION $EXCLUDE_MODULES
       - name: Zip Artifacts
         if: failure()
         run: |
@@ -247,7 +247,7 @@ jobs:
           password: ${{ secrets.CI_REGISTRY_PASSWORD }}
       - name: Build
         run: |
-          mvn -B -fae -s .github/mvn-settings.xml clean install -Pframework,examples,kubernetes -Dquarkus.platform.version="${{ matrix.quarkus-version }}" -Dts.container.registry-url=${{ secrets.CI_REGISTRY }}
+          mvn -B --no-transfer-progress -fae -s .github/mvn-settings.xml clean install -Pframework,examples,kubernetes -Dquarkus.platform.version="${{ matrix.quarkus-version }}" -Dts.container.registry-url=${{ secrets.CI_REGISTRY }}
       - name: Zip Artifacts
         if: failure()
         run: |
@@ -299,7 +299,7 @@ jobs:
           password: ${{ secrets.CI_REGISTRY_PASSWORD }}
       - name: Build
         run: |
-          mvn -B -fae -s .github/mvn-settings.xml clean install -Pframework,examples,native,kubernetes -Dquarkus.platform.version="${{ matrix.quarkus-version }}" -Dts.container.registry-url=${{ secrets.CI_REGISTRY }}
+          mvn -B --no-transfer-progress -fae -s .github/mvn-settings.xml clean install -Pframework,examples,native,kubernetes -Dquarkus.platform.version="${{ matrix.quarkus-version }}" -Dts.container.registry-url=${{ secrets.CI_REGISTRY }}
       - name: Zip Artifacts
         if: failure()
         run: |
@@ -338,7 +338,7 @@ jobs:
       - name: Build in JVM mode
         shell: bash
         run: |
-          mvn -B -fae -s .github/mvn-settings.xml clean install -Pframework,examples -Dquarkus.platform.version="${{ matrix.quarkus-version }}"
+          mvn -B --no-transfer-progress -fae -s .github/mvn-settings.xml clean install -Pframework,examples -Dquarkus.platform.version="${{ matrix.quarkus-version }}"
       - name: Zip Artifacts
         shell: bash
         if: failure()
@@ -401,7 +401,7 @@ jobs:
       - name: Build in Native mode
         shell: bash
         run: |
-          mvn -B -fae -s .github/mvn-settings.xml clean install -Pframework,examples,native -Dquarkus.native.container-build=false -Dquarkus.platform.version="${{ matrix.quarkus-version }}" -Denable-win-race-debug=true
+          mvn -B --no-transfer-progress -fae -s .github/mvn-settings.xml clean install -Pframework,examples,native -Dquarkus.native.container-build=false -Dquarkus.platform.version="${{ matrix.quarkus-version }}" -Denable-win-race-debug=true
       - name: Zip Artifacts
         shell: bash
         if: failure()

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -23,7 +23,7 @@ jobs:
           cache: 'maven'
       - name: Build with Maven
         run: |
-          mvn -V -B -s .github/mvn-settings.xml clean install -Pframework,examples -Dvalidate-format -DskipTests -DskipITs
+          mvn -V -B --no-transfer-progress -s .github/mvn-settings.xml clean install -Pframework,examples -Dvalidate-format -DskipTests -DskipITs
       - name: Tar Maven Repo
         shell: bash
         run: tar -I 'pigz -9' -cf maven-repo-current-fw.tgz -C ~ .m2/repository
@@ -55,7 +55,7 @@ jobs:
           cache: 'maven'
       - name: Build Quarkus main
         run: |
-          git clone https://github.com/quarkusio/quarkus.git && cd quarkus && ./mvnw -B -s .github/mvn-settings.xml clean install -Dquickly -Dno-test-modules -Prelocations
+          git clone https://github.com/quarkusio/quarkus.git && cd quarkus && ./mvnw -B --no-transfer-progress -s .github/mvn-settings.xml clean install -Dquickly -Dno-test-modules -Prelocations
       - name: Tar Maven Repo
         shell: bash
         run: tar -I 'pigz -9' -cf maven-repo.tgz -C ~ .m2/repository
@@ -96,7 +96,7 @@ jobs:
         run: tar -xzf maven-repo-current-fw.tgz -C ~
       - name: Build in JVM mode
         run: |
-          mvn -B -fae -s .github/mvn-settings.xml clean install -Pexamples
+          mvn -B --no-transfer-progress -fae -s .github/mvn-settings.xml clean install -Pexamples
       - name: Detect flaky tests
         id: flaky-test-detector
         shell: bash
@@ -141,7 +141,7 @@ jobs:
         run: tar -xzf maven-repo.tgz -C ~
       - name: Build Quarkus CLI
         run: |
-          git clone https://github.com/quarkusio/quarkus.git && cd quarkus/devtools/cli && mvn -B -s ../../../.github/mvn-settings.xml clean install -Dquickly -Dno-test-modules -Prelocations
+          git clone https://github.com/quarkusio/quarkus.git && cd quarkus/devtools/cli && mvn -B --no-transfer-progress -s ../../../.github/mvn-settings.xml clean install -Dquickly -Dno-test-modules -Prelocations
       - name: Install Quarkus CLI
         run: |
           cat <<EOF > ./quarkus-dev-cli
@@ -152,7 +152,7 @@ jobs:
           ./quarkus-dev-cli version
       - name: Build in JVM mode
         run: |
-          mvn -B -fae -s .github/mvn-settings.xml clean install -Pframework,examples -Drun-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli" -Dquarkus.platform.version="${{ matrix.quarkus-version }}"
+          mvn -B --no-transfer-progress -fae -s .github/mvn-settings.xml clean install -Pframework,examples -Drun-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli" -Dquarkus.platform.version="${{ matrix.quarkus-version }}"
       - name: Detect flaky tests
         id: flaky-test-detector
         shell: bash
@@ -201,7 +201,7 @@ jobs:
         run: tar -xzf maven-repo-current-fw.tgz -C ~
       - name: Build
         run: |
-          mvn -B -fae -s .github/mvn-settings.xml clean install -Pexamples,native -pl '${{ matrix.examples }}'
+          mvn -B --no-transfer-progress -fae -s .github/mvn-settings.xml clean install -Pexamples,native -pl '${{ matrix.examples }}'
       - name: Detect flaky tests
         id: flaky-test-detector
         shell: bash
@@ -247,7 +247,7 @@ jobs:
       - name: Build in JVM mode
         shell: bash
         run: |
-          mvn -B -fae -s .github/mvn-settings.xml clean install -Pframework,examples -Dquarkus.platform.version="${{ matrix.quarkus-version }}"
+          mvn -B --no-transfer-progress -fae -s .github/mvn-settings.xml clean install -Pframework,examples -Dquarkus.platform.version="${{ matrix.quarkus-version }}"
       - name: Detect flaky tests
         shell: bash
         id: flaky-test-detector

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusMavenPluginBuildHelper.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusMavenPluginBuildHelper.java
@@ -199,8 +199,8 @@ class QuarkusMavenPluginBuildHelper {
     }
 
     private String[] getBuildNativeExecutableCmd() {
-        Stream<String> cmdStream = Stream.of(mvnCmd(), "clean", "install", "-Dquarkus.build.skip=false",
-                "-Dnative", "-DskipTests", "-DskipITs", "-Dcheckstyle.skip",
+        Stream<String> cmdStream = Stream.of(mvnCmd(), "-B", "--no-transfer-progress", "clean", "install",
+                "-Dquarkus.build.skip=false", "-Dnative", "-DskipTests", "-DskipITs", "-Dcheckstyle.skip",
                 toMvnSystemProperty(PLATFORM_VERSION.getPropertyKey(), getVersion()),
                 toMvnSystemProperty(PLATFORM_GROUP_ID.getPropertyKey(), PLATFORM_GROUP_ID.get()),
                 toMvnSystemProperty(PLUGIN_VERSION.getPropertyKey(), getPluginVersion()));

--- a/quarkus-test-core/src/main/java/io/quarkus/test/utils/MavenUtils.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/utils/MavenUtils.java
@@ -32,6 +32,7 @@ public final class MavenUtils {
     public static final String DISPLAY_ERRORS = "-e";
     public static final String BATCH_MODE = "-B";
     public static final String DISPLAY_VERSION = "-V";
+    public static final String SKIP_PROGRESS = "--no-transfer-progress";
     public static final String SKIP_CHECKSTYLE = "-Dcheckstyle.skip";
     public static final String QUARKUS_PROFILE = "quarkus.profile";
     public static final String QUARKUS_PROPERTY_PREFIX = "quarkus";
@@ -54,7 +55,9 @@ public final class MavenUtils {
         List<String> command = mvnCommand(serviceContext);
         command.addAll(extraMavenArgs);
         command.add(DISPLAY_ERRORS);
+        command.add(BATCH_MODE);
         command.add(DISPLAY_VERSION);
+        command.add(SKIP_PROGRESS);
         command.add(PACKAGE_GOAL);
         try {
             new Command(command)
@@ -70,6 +73,7 @@ public final class MavenUtils {
     public static List<String> devModeMavenCommand(ServiceContext serviceContext, List<String> systemProperties) {
         List<String> command = mvnCommand(serviceContext);
         command.addAll(Arrays.asList(SKIP_CHECKSTYLE, SKIP_ITS));
+        command.addAll(Arrays.asList(BATCH_MODE, SKIP_PROGRESS));
         command.addAll(systemProperties);
         command.add(withProperty("debug", "false"));
         command.add("quarkus:dev");
@@ -81,6 +85,8 @@ public final class MavenUtils {
         List<String> args = new ArrayList<>();
         args.add(MVN_COMMAND);
         args.add(DISPLAY_ERRORS);
+        args.add(SKIP_PROGRESS);
+        args.add(BATCH_MODE);
         args.add(withQuarkusProfile(serviceContext));
         withMavenRepositoryLocalIfSet(args);
         withProperties(args);
@@ -109,7 +115,8 @@ public final class MavenUtils {
 
     private static void installParentPom(Path relativePath) {
         List<String> args = new ArrayList<>();
-        args.addAll(asList(MVN_COMMAND, DISPLAY_ERRORS, INSTALL_GOAL, SKIP_CHECKSTYLE, SKIP_TESTS, SKIP_ITS, "-pl", "."));
+        args.addAll(asList(MVN_COMMAND, DISPLAY_ERRORS, BATCH_MODE, SKIP_PROGRESS, INSTALL_GOAL, SKIP_CHECKSTYLE, SKIP_TESTS,
+                SKIP_ITS, "-pl", "."));
         withMavenRepositoryLocalIfSet(args);
         withProperties(args);
 


### PR DESCRIPTION
### Summary

Reduces log heaviness by 30% for CI. Excludes log reduction optimalization for Quarkus CLI as there is no option how to propagate `--no-transfer-progress` inside quarkus command.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)