### PR TITLE
[1.4.z] Remove check of wrong tag name for the first release in the branch

### DIFF
--- a/.github/workflows/check-release-version.yml
+++ b/.github/workflows/check-release-version.yml
@@ -14,106 +14,41 @@ jobs:
       - name: Check release version
         run: |
           releases=$(curl -sSL "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases")
+          next_release=$(grep -E 'current-version:\s*' .github/project.yml | awk '{print $2}')
+          
+          branch_version=$(echo "$GITHUB_BASE_REF" | cut -d. -f1,2)
+          latest_branch_tag_patch_version=$(echo "$releases" | jq -r --arg version "$branch_version" '
+            .[] 
+            | select(.tag_name | contains($version)) 
+            | .tag_name' | grep -v "Beta" | head -1 | cut -d. -f3)
+          
+          branch_minor_version=$(echo "$GITHUB_BASE_REF" | cut -d. -f2,2)
+          next_release_minor_version=$(echo "$next_release" | cut -d"." -f2,2)
+          next_release_patch_version=$(echo "$next_release" | cut -d"." -f3,3)
+          beta_tag_exists=$(echo "$next_release" | cut -d"." -f4,4 || true)
+          
+          if [ -n "$beta_tag_exists" ]; then
+            echo "Error: releases cannot consist any qualifier after version"
+            exit 1;
+          fi
 
-          if [[ "$GITHUB_BASE_REF" == "main" ]]; then
-            latest_prerelease=$(echo "$releases" | jq -r '.[] | select(.prerelease) | .tag_name' | head -n 1)
-            latest_prerelease_beta_number=$(echo "$latest_prerelease" | cut -d"." -f4,4 | grep -o '[0-9]\+' || true)
+          if [[ "$branch_minor_version" != "$next_release_minor_version" ]]; then
+            echo "Error: minor versions cannot be changed"
+            exit 1;
+          fi
           
-            next_prerelease=$(grep -E 'current-version:\s*' .github/project.yml | awk '{print $2}')
-            next_prerelease_minor_version=$(echo "$next_prerelease" | cut -d"." -f2,2)
-            next_prerelease_patch_version=$(echo "$next_prerelease" | cut -d"." -f3,3)
-            next_prerelease_beta_number=$(echo "$next_prerelease" | cut -d"." -f4,4 | grep -o '[0-9]\+' || true)
-            prerelease_minor_version_bump=false
+          if [[ $(("$latest_branch_tag_patch_version" + 1)) != "$next_release_patch_version" ]]; then
+            echo "Error: release patch versions should be bumped one by one as sequence"
+            exit 1;
+          fi
           
-            current_release=$(curl -sSL "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/latest" | jq -r .tag_name)
-            current_release_minor_version=$(echo "$current_release" | cut -d"." -f2,2)
+          project_next_version=$(grep -E 'next-version:\s*' .github/project.yml | awk '{print $2}')
+          project_next_base=$(echo "$project_next_version" | cut -d"." -f1,2)
           
-            # Check if can change minor version after creating new branch 
-            if [[ "$current_release_minor_version" == "$next_prerelease_minor_version" ]]; then
-              echo "Error: next LTS release branch is out, bump version to 1."$(("$next_prerelease_minor_version" + 1))".0.Beta1" 
-              exit 1;
-            elif [[ "$next_prerelease_beta_number" == 1 ]]; then
-              prerelease_minor_version_bump=true
-            fi
+          project_current_patch_version="$next_release_patch_version"
+          project_next_patch_version=$(echo "$project_next_version" | awk -F. '{print $3}')
           
-            if [[ $(("$current_release_minor_version" + 1)) != "$next_prerelease_minor_version" ]]; then
-              echo "Error: pre-releases should have minor version one upper than last release"
-              exit 1;
-            fi
-          
-            if [[ "$next_prerelease_patch_version" != 0 || -z "$next_prerelease_beta_number" ]]; then
-              echo "Error: new releases are not allowed from development branch, use .Beta\D+ qualifier"
-              exit 1;
-            fi
-          
-            if (! "$prerelease_minor_version_bump") && [[ ("$next_prerelease_beta_number" != $(("$latest_prerelease_beta_number" + 1))) ]]; then
-              echo "Error: pre-release version should go one by one as sequence"
-              correct_version=$(echo "$latest_prerelease" | cut -d"." -f1,2,3)
-              correct_prerelease_number=$(("$latest_prerelease_beta_number" + 1))
-              echo "After" $latest_prerelease "should go "$correct_version".Beta"$correct_prerelease_number
-              exit 1;
-            fi
-          
-            project_current_base=$(echo "$next_prerelease" | grep -oP '^.*Beta')
-            project_next_version=$(grep -E 'next-version:\s*' .github/project.yml | awk '{print $2}')
-            project_next_base=$(echo "$project_next_version" | grep -oP '^.*Beta')
-          
-            project_current_beta_number="$next_prerelease_beta_number"
-            project_next_beta_number=$(echo "$project_next_version" | grep -oP 'Beta\K[0-9]+')
-          
-            if [[ "$project_current_base" != "$project_next_base" ]] || [[ $(("$project_current_beta_number" + 1)) != "$project_next_beta_number" ]]; then
-              echo "Error: the next-version in project.yaml is not valid. Next pre-release Beta version must be one upper that current"
-              exit 1;
-            fi  
-          else 
-            expected_release_version=$(echo "$GITHUB_BASE_REF" | sed 's/z/0/')
-          
-            first_release_tag_exists=$(echo "$releases" | jq -r '.[] | .tag_name' | grep "^$expected_release_version$" || true)
-            next_release=$(grep -E 'current-version:\s*' .github/project.yml | awk '{print $2}')
-          
-            if [ -z "$first_release_tag_exists" ]; then
-              if [[ "$next_release" != "$expected_release_version" ]]; then
-                echo "Error: wrong tag name for the first release in new branch"
-                exit 1;
-              else
-                exit 0;
-              fi
-            fi
-          
-            branch_version=$(echo "$GITHUB_BASE_REF" | cut -d. -f1,2)
-            latest_branch_tag_patch_version=$(echo "$releases" | jq -r --arg version "$branch_version" '
-              .[] 
-              | select(.tag_name | contains($version)) 
-              | .tag_name' | grep -v "Beta" | head -1 | cut -d. -f3)
-          
-            branch_minor_version=$(echo "$GITHUB_BASE_REF" | cut -d. -f2,2)
-            next_release_minor_version=$(echo "$next_release" | cut -d"." -f2,2)
-            next_release_patch_version=$(echo "$next_release" | cut -d"." -f3,3)
-            beta_tag_exists=$(echo "$next_release" | cut -d"." -f4,4 || true)
-          
-            if [ -n "$beta_tag_exists" ]; then
-              echo "Error: releases cannot consist any qualifier after version"
-              exit 1;
-            fi
-
-            if [[ "$branch_minor_version" != "$next_release_minor_version" ]]; then
-              echo "Error: minor versions cannot be changed"
-              exit 1;
-            fi
-          
-            if [[ $(("$latest_branch_tag_patch_version" + 1)) != "$next_release_patch_version" ]]; then
-              echo "Error: release patch versions should be bumped one by one as sequence"
-              exit 1;
-            fi
-          
-            project_next_version=$(grep -E 'next-version:\s*' .github/project.yml | awk '{print $2}')
-            project_next_base=$(echo "$project_next_version" | cut -d"." -f1,2)
-          
-            project_current_patch_version="$next_release_patch_version"
-            project_next_patch_version=$(echo "$project_next_version" | awk -F. '{print $3}')
-          
-            if [[ "$branch_version" != "$project_next_base" ]] || [[ $(("$project_current_patch_version" + 1)) != "$project_next_patch_version" ]]; then
-              echo "Error: the next-version in project.yaml is not valid. Patch version of the next release must be one upper than the latest"
-              exit 1;
-            fi
+          if [[ "$branch_version" != "$project_next_base" ]] || [[ $(("$project_current_patch_version" + 1)) != "$project_next_patch_version" ]]; then
+            echo "Error: the next-version in project.yaml is not valid. Patch version of the next release must be one upper than the latest"
+            exit 1;
           fi


### PR DESCRIPTION
### Summary

Removed check is good for new created branches and checking first release tag, but not for already released ones

Detected in https://github.com/quarkus-qe/quarkus-test-framework/actions/runs/10402595107/job/28807376815

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)