### PR TITLE
[1.4.z] Build extensions profile in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Maven release ${{steps.metadata.outputs.current-version}}
         run: |
           git checkout -b release
-          mvn -B release:prepare -Prelease,framework,examples -DautoVersionSubmodules -DreleaseVersion=${{steps.metadata.outputs.current-version}} -DdevelopmentVersion=${{steps.metadata.outputs.next-version}}-SNAPSHOT
+          mvn -B release:prepare -Prelease,framework,extensions,examples -DautoVersionSubmodules -DreleaseVersion=${{steps.metadata.outputs.current-version}} -DdevelopmentVersion=${{steps.metadata.outputs.next-version}}-SNAPSHOT
           git checkout ${{github.base_ref}}
           git rebase release
           mvn -B release:perform -DskipITs -Prelease,framework

--- a/extensions/metrics/pom.xml
+++ b/extensions/metrics/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-test-parent</artifactId>
-        <version>1.4.9-SNAPSHOT</version>
+        <version>1.4.10-SNAPSHOT</version>
         <relativePath>../../</relativePath>
     </parent>
     <artifactId>extension-metrics</artifactId>

--- a/extensions/tracing/pom.xml
+++ b/extensions/tracing/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-test-parent</artifactId>
-        <version>1.4.9-SNAPSHOT</version>
+        <version>1.4.10-SNAPSHOT</version>
         <relativePath>../../</relativePath>
     </parent>
     <artifactId>extension-tracing</artifactId>


### PR DESCRIPTION
### Summary

Extensions profile was excluded from release workflow in [backport PR](https://github.com/quarkus-qe/quarkus-test-framework/pull/1221/files). This Extensions metrics and tracing modules are still using in both 1.4.z and 1.3.z branches. Release is not updating artifact snapshot version for these modules, which causes build error, https://github.com/quarkus-qe/quarkus-test-framework/actions/runs/10564888607/job/29269815983?pr=1258

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)