### PR TITLE
Support TLS registry and certificate reloading

### DIFF
--- a/examples/https/pom.xml
+++ b/examples/https/pom.xml
@@ -19,6 +19,10 @@
             <artifactId>quarkus-security</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-tls-registry</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus.qe</groupId>
             <artifactId>quarkus-test-core</artifactId>
             <scope>test</scope>

--- a/examples/https/src/test/java/io/quarkus/qe/DevModeGreetingResourceIT.java
+++ b/examples/https/src/test/java/io/quarkus/qe/DevModeGreetingResourceIT.java
@@ -10,7 +10,7 @@ import io.quarkus.test.services.DevModeQuarkusApplication;
 
 @QuarkusScenario
 public class DevModeGreetingResourceIT {
-    @DevModeQuarkusApplication(ssl = true, certificates = @Certificate(configureKeystore = true))
+    @DevModeQuarkusApplication(ssl = true, certificates = @Certificate(configureKeystore = true, configureHttpServer = true, useTlsRegistry = false))
     static DevModeQuarkusService app = new DevModeQuarkusService();
 
     @Test

--- a/examples/https/src/test/java/io/quarkus/qe/HttpIT.java
+++ b/examples/https/src/test/java/io/quarkus/qe/HttpIT.java
@@ -19,7 +19,7 @@ public class HttpIT {
 
     private final RequestSpecification spec = given();
 
-    @QuarkusApplication(ssl = true, certificates = @Certificate(configureKeystore = true, format = JKS))
+    @QuarkusApplication(ssl = true, certificates = @Certificate(configureKeystore = true, format = JKS, configureHttpServer = true, useTlsRegistry = false))
     static final RestService app = new RestService();
 
     @Test

--- a/examples/https/src/test/java/io/quarkus/qe/HttpsTlsRegistryNamedConfigIT.java
+++ b/examples/https/src/test/java/io/quarkus/qe/HttpsTlsRegistryNamedConfigIT.java
@@ -12,17 +12,17 @@ import io.quarkus.test.services.Certificate;
 import io.quarkus.test.services.QuarkusApplication;
 
 @QuarkusScenario
-public class HttpsIT {
+public class HttpsTlsRegistryNamedConfigIT {
 
-    private static final String CLIENT_CN_1 = "my-client-1";
-    private static final String CLIENT_CN_2 = "my-client-2";
-    private static final String CLIENT_CN_3 = "my-client-3";
+    static final String CLIENT_CN_1 = "my-client-1";
+    static final String CLIENT_CN_2 = "my-client-2";
+    static final String CLIENT_CN_3 = "my-client-3";
 
-    @QuarkusApplication(ssl = true, certificates = @Certificate(configureKeystore = true, configureTruststore = true, configureHttpServer = true, useTlsRegistry = false, clientCertificates = {
+    @QuarkusApplication(ssl = true, certificates = @Certificate(configureKeystore = true, clientCertificates = {
             @Certificate.ClientCertificate(cnAttribute = CLIENT_CN_1),
             @Certificate.ClientCertificate(cnAttribute = CLIENT_CN_2),
             @Certificate.ClientCertificate(cnAttribute = CLIENT_CN_3, unknownToServer = true)
-    }))
+    }, configureTruststore = true, configureHttpServer = true, tlsConfigName = "my-name"))
     static final RestService app = new RestService()
             .withProperty("quarkus.http.ssl.client-auth", "request")
             .withProperty("quarkus.http.insecure-requests", "DISABLED");

--- a/examples/https/src/test/java/io/quarkus/qe/TlsRegistryCertificateReloadingIT.java
+++ b/examples/https/src/test/java/io/quarkus/qe/TlsRegistryCertificateReloadingIT.java
@@ -1,0 +1,50 @@
+package io.quarkus.qe;
+
+import static io.quarkus.qe.HttpsTlsRegistryNamedConfigIT.CLIENT_CN_1;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.security.certificate.CertificateBuilder;
+import io.quarkus.test.security.certificate.ClientCertificateRequest;
+import io.quarkus.test.services.Certificate;
+import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.test.utils.AwaitilityUtils;
+
+@QuarkusScenario
+public class TlsRegistryCertificateReloadingIT {
+
+    private static final String CERT_PREFIX = "reload-test";
+    private static final String NEW_CLIENT_CN = "my-new-client";
+
+    @QuarkusApplication(ssl = true, certificates = @Certificate(clientCertificates = {
+            @Certificate.ClientCertificate(cnAttribute = CLIENT_CN_1)
+    }, configureTruststore = true, configureHttpServer = true, configureKeystore = true, prefix = CERT_PREFIX))
+    static RestService app = new RestService()
+            .withProperty("quarkus.http.ssl.client-auth", "request")
+            .withProperty("quarkus.http.insecure-requests", "DISABLED")
+            .withProperty("quarkus.tls.reload-period", "2s");
+
+    @Test
+    public void testCertificateReload() {
+        var path = "/greeting/mutual-tls";
+
+        var response = app.mutinyHttps(CLIENT_CN_1).get(path).sendAndAwait();
+        assertEquals(HttpStatus.SC_OK, response.statusCode());
+        assertEquals("Hello CN=%s!".formatted(CLIENT_CN_1), response.bodyAsString());
+
+        var clientReq = new ClientCertificateRequest(NEW_CLIENT_CN, false);
+        app
+                .<CertificateBuilder> getPropertyFromContext(CertificateBuilder.INSTANCE_KEY)
+                .regenerateCertificate(CERT_PREFIX, certReq -> certReq.withClientRequests(clientReq));
+
+        AwaitilityUtils.untilAsserted(() -> {
+            var response1 = app.mutinyHttps(NEW_CLIENT_CN).get(path).sendAndAwait();
+            assertEquals(HttpStatus.SC_OK, response1.statusCode());
+            assertEquals("Hello CN=%s!".formatted(NEW_CLIENT_CN), response1.bodyAsString());
+        });
+    }
+}

--- a/examples/management/pom.xml
+++ b/examples/management/pom.xml
@@ -24,6 +24,10 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-tls-registry</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus.qe</groupId>
             <artifactId>quarkus-test-openshift</artifactId>
             <scope>test</scope>

--- a/examples/management/src/test/java/io/quarkus/qe/LocalTlsRegistryIT.java
+++ b/examples/management/src/test/java/io/quarkus/qe/LocalTlsRegistryIT.java
@@ -11,10 +11,9 @@ import io.quarkus.test.services.QuarkusApplication;
 import io.restassured.response.Response;
 
 @QuarkusScenario
-// todo Merge with LocalIT when https://github.com/quarkusio/quarkus/issues/32225 is fixed
-public class LocalTLSIT {
+public class LocalTlsRegistryIT {
 
-    @QuarkusApplication(certificates = @Certificate(configureManagementInterface = true, configureKeystore = true, useTlsRegistry = false))
+    @QuarkusApplication(certificates = @Certificate(configureManagementInterface = true, configureKeystore = true))
     static final RestService service = new RestService()
             .withProperty("quarkus.management.port", "9003");
 

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,6 @@
         <consul.image>docker.io/bitnami/consul:1.19.1</consul.image>
         <reruns>2</reruns>
         <flaky-run-reporter.version>0.1.2.Beta1</flaky-run-reporter.version>
-        <certificate-generator.version>0.7.1</certificate-generator.version>
     </properties>
     <distributionManagement>
         <snapshotRepository>
@@ -213,11 +212,6 @@
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-test-maven</artifactId>
                 <version>${quarkus.platform.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>me.escoffier.certs</groupId>
-                <artifactId>certificate-generator</artifactId>
-                <version>${certificate-generator.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/quarkus-test-core/pom.xml
+++ b/quarkus-test-core/pom.xml
@@ -46,8 +46,8 @@
             <artifactId>smallrye-mutiny-vertx-web-client</artifactId>
         </dependency>
         <dependency>
-            <groupId>me.escoffier.certs</groupId>
-            <artifactId>certificate-generator</artifactId>
+            <groupId>io.smallrye.certs</groupId>
+            <artifactId>smallrye-certificate-generator</artifactId>
         </dependency>
         <!-- used by our own SureFire debug provider -->
         <dependency>

--- a/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/BaseService.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/BaseService.java
@@ -14,6 +14,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
@@ -132,6 +133,14 @@ public class BaseService<T extends Service> implements Service {
      */
     public T withProperty(String key, Supplier<String> value) {
         futureProperties.add(() -> properties.put(key, value.get()));
+        return (T) this;
+    }
+
+    /**
+     * The runtime configuration property to be configured based on type variable {@code U} from context.
+     */
+    public <U> T withProperty(String configKey, String contextKey, Function<U, String> configValue) {
+        futureProperties.add(() -> properties.put(configKey, configValue.apply(getPropertyFromContext(contextKey))));
         return (T) this;
     }
 

--- a/quarkus-test-core/src/main/java/io/quarkus/test/security/certificate/CertificateBuilder.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/security/certificate/CertificateBuilder.java
@@ -1,5 +1,8 @@
 package io.quarkus.test.security.certificate;
 
+import static io.quarkus.test.security.certificate.Certificate.createCertsTempDir;
+
+import java.util.Arrays;
 import java.util.List;
 
 public interface CertificateBuilder {
@@ -12,6 +15,13 @@ public interface CertificateBuilder {
     List<Certificate> certificates();
 
     Certificate findCertificateByPrefix(String prefix);
+
+    /**
+     * Regenerates certificate with {@code prefix}.
+     * The new certificate will be stored at the same location as the original one.
+     * All generated files will have same name, certificate attributes, password etc.
+     */
+    Certificate regenerateCertificate(String prefix, CertificateRequestCustomizer... customizers);
 
     static CertificateBuilder of(Certificate certificate) {
         return new CertificateBuilderImp(List.of(certificate));
@@ -28,8 +38,14 @@ public interface CertificateBuilder {
         Certificate[] generatedCerts = new Certificate[certificates.length];
         for (int i = 0; i < certificates.length; i++) {
             var cert = certificates[i];
-            generatedCerts[i] = Certificate.of(cert.prefix(), cert.format(), cert.password(), cert.configureKeystore(),
-                    cert.configureTruststore(), cert.configureKeystoreForManagementInterface(), cert.clientCertificates());
+            var clientCertReqs = Arrays.stream(cert.clientCertificates())
+                    .map(cc -> new ClientCertificateRequest(cc.cnAttribute(), cc.unknownToServer()))
+                    .toArray(ClientCertificateRequest[]::new);
+            generatedCerts[i] = Certificate.ofInterchangeable(new CertificateOptions(cert.prefix(), cert.format(),
+                    cert.password(), cert.configureKeystore(), cert.configureTruststore(),
+                    cert.configureManagementInterface(),
+                    clientCertReqs, createCertsTempDir(cert.prefix()), new DefaultContainerMountStrategy(cert.prefix()),
+                    false, null, null, null, null, cert.useTlsRegistry(), cert.tlsConfigName(), cert.configureHttpServer()));
         }
         return new CertificateBuilderImp(List.of(generatedCerts));
     }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/security/certificate/CertificateBuilderImp.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/security/certificate/CertificateBuilderImp.java
@@ -9,4 +9,19 @@ record CertificateBuilderImp(List<Certificate> certificates) implements Certific
         Objects.requireNonNull(prefix);
         return certificates.stream().filter(c -> prefix.equals(c.prefix())).findFirst().orElse(null);
     }
+
+    @Override
+    public Certificate regenerateCertificate(String prefix, CertificateRequestCustomizer... customizers) {
+        if (findCertificateByPrefix(prefix) instanceof InterchangeableCertificate cert) {
+            var req = new CertificateRequestCustomizer.CertificateRequestImpl(cert.getCertRequestOptions());
+            for (CertificateRequestCustomizer customizer : customizers) {
+                customizer.customize(req);
+            }
+            var newCert = Certificate.ofRegeneratedCert(req.createNewOptions());
+            return cert.swapCert(newCert);
+        } else {
+            throw new IllegalStateException("Certificate must be interchangeable when regeneration is required");
+        }
+    }
+
 }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/security/certificate/CertificateOptions.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/security/certificate/CertificateOptions.java
@@ -2,8 +2,11 @@ package io.quarkus.test.security.certificate;
 
 import java.nio.file.Path;
 
-record CertificateOptions(String prefix, io.quarkus.test.services.Certificate.Format format, String password,
-        boolean keystoreProps, boolean truststoreProps, boolean keystoreManagementInterfaceProps,
-        io.quarkus.test.services.Certificate.ClientCertificate[] clientCertificates, Path localTargetDir,
-        ContainerMountStrategy containerMountStrategy, boolean createPkcs12TsForPem) {
+public record CertificateOptions(String prefix, io.quarkus.test.services.Certificate.Format format, String password,
+        boolean keystoreProps, boolean truststoreProps, boolean configureManagementInterface,
+        ClientCertificateRequest[] clientCertificates, Path localTargetDir,
+        ContainerMountStrategy containerMountStrategy, boolean createPkcs12TsForPem,
+        String serverTrustStoreLocation, String serverKeyStoreLocation, String keyLocation, String certLocation,
+        boolean tlsRegistryEnabled, String tlsConfigName, boolean configureHttpServer) {
+
 }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/security/certificate/CertificateRequestCustomizer.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/security/certificate/CertificateRequestCustomizer.java
@@ -1,0 +1,112 @@
+package io.quarkus.test.security.certificate;
+
+import java.nio.file.Path;
+
+public interface CertificateRequestCustomizer {
+
+    void customize(CertificateRequest request);
+
+    interface CertificateRequest {
+        CertificateRequest withPassword(String password);
+
+        CertificateRequest withClientRequests(ClientCertificateRequest... clientRequests);
+
+        CertificateRequest withServerTrustStoreLocation(String serverTrustStoreLocation);
+
+        CertificateRequest withServerKeyStoreLocation(String serverKeyStoreLocation);
+
+        CertificateRequest withPemKeyLocation(String keyLocation);
+
+        CertificateRequest withPemCertLocation(String certLocation);
+
+        CertificateRequest withBaseDirForAllCerts(Path localTargetDir);
+    }
+
+    final class CertificateRequestImpl implements CertificateRequest {
+
+        private CertificateOptions certificateOptions;
+        private String password;
+        private ClientCertificateRequest[] clientRequests;
+        private Path localTargetDir;
+        private String serverTrustStoreLocation = null;
+        private String serverKeyStoreLocation = null;
+        private String keyLocation = null;
+        private String certLocation = null;
+
+        CertificateRequestImpl(CertificateOptions originalOpts) {
+            this.certificateOptions = originalOpts;
+            this.password = originalOpts.password();
+            this.clientRequests = originalOpts.clientCertificates();
+            this.localTargetDir = originalOpts.localTargetDir();
+        }
+
+        CertificateOptions createNewOptions() {
+            certificateOptions = new CertificateOptions(certificateOptions.prefix(), certificateOptions.format(), password,
+                    certificateOptions.keystoreProps(), certificateOptions.truststoreProps(),
+                    certificateOptions.configureManagementInterface(), clientRequests, localTargetDir,
+                    certificateOptions.containerMountStrategy(), certificateOptions.createPkcs12TsForPem(),
+                    serverTrustStoreLocation, serverKeyStoreLocation, keyLocation, certLocation,
+                    certificateOptions.tlsRegistryEnabled(), certificateOptions.tlsConfigName(),
+                    certificateOptions.configureHttpServer());
+            return certificateOptions;
+        }
+
+        @Override
+        public CertificateRequest withPassword(String password) {
+            this.password = password;
+            return this;
+        }
+
+        @Override
+        public CertificateRequest withClientRequests(ClientCertificateRequest... clientRequests) {
+            this.clientRequests = clientRequests;
+            return this;
+        }
+
+        @Override
+        public CertificateRequest withServerTrustStoreLocation(String serverTrustStoreLocation) {
+            this.serverTrustStoreLocation = serverTrustStoreLocation;
+            return this;
+        }
+
+        @Override
+        public CertificateRequest withServerKeyStoreLocation(String serverKeyStoreLocation) {
+            this.serverKeyStoreLocation = serverKeyStoreLocation;
+            return this;
+        }
+
+        @Override
+        public CertificateRequest withPemKeyLocation(String keyLocation) {
+            this.keyLocation = keyLocation;
+            return this;
+        }
+
+        @Override
+        public CertificateRequest withPemCertLocation(String certLocation) {
+            this.certLocation = certLocation;
+            return this;
+        }
+
+        @Override
+        public CertificateRequest withBaseDirForAllCerts(Path localTargetDir) {
+            this.localTargetDir = localTargetDir;
+            return this;
+        }
+
+        String getCertLocation() {
+            return certLocation;
+        }
+
+        String getKeyLocation() {
+            return keyLocation;
+        }
+
+        String getServerKeyStoreLocation() {
+            return serverKeyStoreLocation;
+        }
+
+        String getServerTrustStoreLocation() {
+            return serverTrustStoreLocation;
+        }
+    }
+}

--- a/quarkus-test-core/src/main/java/io/quarkus/test/security/certificate/ClientCertificateRequest.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/security/certificate/ClientCertificateRequest.java
@@ -1,0 +1,4 @@
+package io.quarkus.test.security.certificate;
+
+public record ClientCertificateRequest(String cnAttribute, boolean unknownToServer) {
+}

--- a/quarkus-test-core/src/main/java/io/quarkus/test/security/certificate/InterchangeableCertificate.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/security/certificate/InterchangeableCertificate.java
@@ -1,0 +1,78 @@
+package io.quarkus.test.security.certificate;
+
+import java.util.Collection;
+import java.util.Map;
+
+public final class InterchangeableCertificate implements Certificate.PemCertificate {
+
+    private volatile CertificateOptions certRequestOptions;
+    private volatile Certificate.PemCertificate delegate;
+
+    private InterchangeableCertificate(PemCertificate delegate, CertificateOptions certRequestOptions) {
+        this.delegate = delegate;
+        this.certRequestOptions = certRequestOptions;
+    }
+
+    static InterchangeableCertificate wrapCert(Certificate.PemCertificate certificate, CertificateOptions options) {
+        return new InterchangeableCertificate(certificate, options);
+    }
+
+    InterchangeableCertificate swapCert(Certificate.PemCertificate certificate) {
+        this.delegate = certificate;
+        return this;
+    }
+
+    public CertificateOptions getCertRequestOptions() {
+        return certRequestOptions;
+    }
+
+    @Override
+    public String prefix() {
+        return delegate.prefix();
+    }
+
+    @Override
+    public String format() {
+        return delegate.format();
+    }
+
+    @Override
+    public String password() {
+        return delegate.password();
+    }
+
+    @Override
+    public String keystorePath() {
+        return delegate.keystorePath();
+    }
+
+    @Override
+    public String truststorePath() {
+        return delegate.truststorePath();
+    }
+
+    @Override
+    public Map<String, String> configProperties() {
+        return delegate.configProperties();
+    }
+
+    @Override
+    public ClientCertificate getClientCertificateByCn(String cn) {
+        return delegate.getClientCertificateByCn(cn);
+    }
+
+    @Override
+    public Collection<ClientCertificate> clientCertificates() {
+        return delegate.clientCertificates();
+    }
+
+    @Override
+    public String keyPath() {
+        return delegate.keyPath();
+    }
+
+    @Override
+    public String certPath() {
+        return delegate.certPath();
+    }
+}

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/Certificate.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/Certificate.java
@@ -5,6 +5,12 @@ package io.quarkus.test.services;
  */
 public @interface Certificate {
 
+    /**
+     * Default TLS Registry configuration name.
+     * When set to {@link #tlsConfigName()}, default, and not named TLS configuration will be set for you.
+     */
+    String DEFAULT_CONFIG = "<<default-config>>";
+
     enum Format {
         PEM,
         JKS,
@@ -27,40 +33,84 @@ public @interface Certificate {
     String password() default "password";
 
     /**
-     * Whether following configuration properties should be set for you:
+     * Whether HTTP server should be configured for you.
+     * Effect of this option depends on {@link #configureKeystore()}
+     * and {@link #configureTruststore()} and {@link #useTlsRegistry()}.
+     * That is, if {@link #useTlsRegistry()} is true, following property is configured to {@link #tlsConfigName()}:
      *
-     * - `quarkus.http.ssl.certificate.key-store-file`
-     * - `quarkus.http.ssl.certificate.key-store-file-type`
-     * - `quarkus.http.ssl.certificate.key-store-password`
+     * <pre>
+     * {@code
+     * quarkus.http.tls-configuration-name=<<tls-configuration-name>>
+     * }
+     * </pre>
+     *
+     * While if the {@link #useTlsRegistry()} is false, following properties are configured:
+     *
+     * <pre>
+     * {@code
+     * # if configure keystore is enabled
+     * quarkus.http.ssl.certificate.key-store-file
+     * quarkus.http.ssl.certificate.key-store-file-type
+     * quarkus.http.ssl.certificate.key-store-password
+     * # if configure truststore is enabled
+     * quarkus.http.ssl.certificate.trust-store-file
+     * quarkus.http.ssl.certificate.trust-store-file-type
+     * quarkus.http.ssl.certificate.trust-store-password
+     * }
+     * </pre>
      *
      * You still can set and/or override these properties
      * with {@link io.quarkus.test.bootstrap.BaseService#withProperty(String, String)} service method.
+     */
+    boolean configureHttpServer() default false;
+
+    /**
+     * Whether management interface should be configured.
+     * That is, when {@link #useTlsRegistry()} is set to {@code true}, we set:
+     *
+     * <pre>
+     * {@code
+     * quarkus.management.tls-configuration-name=<<tls-configuration-name>>
+     * }
+     * </pre>
+     *
+     * And when {@link #useTlsRegistry()} is set to {@code false} and {@link #configureKeystore()} is true, we set:
+     *
+     * <pre>
+     * {@code
+     * quarkus.management.ssl.certificate.key-store-file
+     * quarkus.management.ssl.certificate.key-store-file-type
+     * quarkus.management.ssl.certificate.key-store-password
+     * }
+     * </pre>
+     *
+     * You still can set and/or override these properties
+     * with {@link io.quarkus.test.bootstrap.BaseService#withProperty(String, String)} service method.
+     */
+    boolean configureManagementInterface() default false;
+
+    /**
+     * Whether keystore should be generated and configured for you.
      */
     boolean configureKeystore() default false;
 
     /**
-     * Whether following configuration properties should be set for you:
-     *
-     * - `quarkus.http.ssl.certificate.trust-store-file`
-     * - `quarkus.http.ssl.certificate.trust-store-file-type`
-     * - `quarkus.http.ssl.certificate.trust-store-password`
-     *
-     * You still can set and/or override these properties
-     * with {@link io.quarkus.test.bootstrap.BaseService#withProperty(String, String)} service method.
+     * Whether truststore should be generated and configured for you.
      */
     boolean configureTruststore() default false;
 
     /**
-     * Whether following configuration properties should be set for you:
-     *
-     * - `quarkus.management.ssl.certificate.key-store-file`
-     * - `quarkus.management.ssl.certificate.key-store-file-type`
-     * - `quarkus.management.ssl.certificate.key-store-password`
-     *
-     * You still can set and/or override these properties
-     * with {@link io.quarkus.test.bootstrap.BaseService#withProperty(String, String)} service method.
+     * Whether TLS registry should be configured with generated keystore and truststore.
      */
-    boolean configureKeystoreForManagementInterface() default false;
+    boolean useTlsRegistry() default true;
+
+    /**
+     * Way to configure named TLS configuration.
+     * For example, when set to {@code 0}, you can expect the TLS configuration to be named zero:
+     *
+     * - `quarkus.tls.key-store.pem.0.cert`
+     */
+    String tlsConfigName() default DEFAULT_CONFIG;
 
     /**
      * Specify client certificates that should be generated.

--- a/quarkus-test-core/src/main/java/io/quarkus/test/utils/TestExecutionProperties.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/utils/TestExecutionProperties.java
@@ -6,9 +6,13 @@ import io.quarkus.test.services.quarkus.model.QuarkusProperties;
 
 public final class TestExecutionProperties {
 
+    /**
+     * Internal configuration property signalling that Management interface TLS support is enabled.
+     * This is just a way to propagate the information within framework, users don't need to be concern with it.
+     */
+    public static final String MANAGEMENT_INTERFACE_ENABLED = "ts-internal.management.interface";
     private static final String DEFAULT_SERVICE_NAME = "quarkus_test_framework";
     private static final String DEFAULT_BUILD_NUMBER = "777-default";
-
     private static final TestExecutionProperties INSTANCE = new TestExecutionProperties();
 
     private final String serviceName;
@@ -50,6 +54,6 @@ public final class TestExecutionProperties {
     }
 
     public static boolean useManagementSsl(Service service) {
-        return service.getProperty("quarkus.management.ssl.certificate.key-store-file").isPresent();
+        return service.getProperty(MANAGEMENT_INTERFACE_ENABLED).map(Boolean::parseBoolean).orElse(false);
     }
 }


### PR DESCRIPTION
### Summary

This is but a portion of required changes I have in progress. However I think reviews will be easier if we go in smaller chunks. This PR:

- adds support for https://quarkus.io/version/main/guides/tls-registry-reference
- certificate reloading
- original functionality is still supported, however this PR is not backwards compatible and I have prepared Quarkus QE Test Suite commit to accompany FW bump that will keep tests as they were

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)