### PR TITLE
[1.3.z] Build extensions profile in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Maven release ${{steps.metadata.outputs.current-version}}
         run: |
           git checkout -b release
-          mvn -B release:prepare -Prelease,framework,examples -DautoVersionSubmodules -DreleaseVersion=${{steps.metadata.outputs.current-version}} -DdevelopmentVersion=${{steps.metadata.outputs.next-version}}-SNAPSHOT
+          mvn -B release:prepare -Prelease,framework,extensions,examples -DautoVersionSubmodules -DreleaseVersion=${{steps.metadata.outputs.current-version}} -DdevelopmentVersion=${{steps.metadata.outputs.next-version}}-SNAPSHOT
           git checkout ${{github.base_ref}}
           git rebase release
           mvn -B release:perform -DskipITs -Prelease,framework


### PR DESCRIPTION
### Summary

Extensions profile was excluded from release workflow in [backport PR](https://github.com/quarkus-qe/quarkus-test-framework/pull/1222). Extensions metrics and tracing modules are still using in 1.3.z branche. Release is not updating artifact snapshot version for these modules, which will cause build error, as was in 1.4.z branch https://github.com/quarkus-qe/quarkus-test-framework/actions/runs/10564888607/job/29269815983?pr=1258

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)