### PR TITLE
Add option to CLI ti set community bom if not running RHBQ

### DIFF
--- a/quarkus-test-cli/src/main/java/io/quarkus/test/util/QuarkusCLIUtils.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/util/QuarkusCLIUtils.java
@@ -29,6 +29,7 @@ import org.codehaus.plexus.util.xml.XmlStreamReader;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 
 import io.quarkus.test.bootstrap.QuarkusCliRestService;
+import io.quarkus.test.services.quarkus.model.QuarkusProperties;
 import io.smallrye.common.os.OS;
 
 public abstract class QuarkusCLIUtils {
@@ -257,6 +258,33 @@ public abstract class QuarkusCLIUtils {
      */
     public static Properties getProperties(QuarkusCliRestService app) throws XmlPullParserException, IOException {
         return getPom(app).getProperties();
+    }
+
+    /**
+     * Change given properties in app's pom.
+     * Other properties are unchanged.
+     */
+    public static void changePropertiesInPom(QuarkusCliRestService app, Properties properties)
+            throws XmlPullParserException, IOException {
+        Model pom = getPom(app);
+        Properties pomProperties = pom.getProperties();
+        pomProperties.putAll(properties);
+        pom.setProperties(pomProperties);
+        savePom(app, pom);
+    }
+
+    /**
+     * If tests are not on RHBQ it will set properties in app's pom to work with community quarkus BOM.
+     * Expects that app is using RHBQ by default.
+     */
+    public static void setCommunityBomIfNotRunningRHBQ(QuarkusCliRestService app, String communityQuarkusVersion)
+            throws XmlPullParserException, IOException {
+        if (!QuarkusProperties.getVersion().contains("redhat")) {
+            Properties communityBomProperties = new Properties();
+            communityBomProperties.put("quarkus.platform.group-id", "io.quarkus.platform");
+            communityBomProperties.put("quarkus.platform.version", communityQuarkusVersion);
+            changePropertiesInPom(app, communityBomProperties);
+        }
     }
 
     /**


### PR DESCRIPTION
### Summary

In tests with CLI we use apps, that have static sources. We need to be able to run it with both community and RHBQ builds. 
Adding method, that will check if we're running with RHBQ and if not, set properties in app to use community BOM.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)