### PR TITLE
Revert "Release 1.5.1"

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 name: Quarkus QE Test Framework
 release:
-  current-version: 1.5.1
-  next-version: 1.5.2
+  current-version: 1.5.0
+  next-version: 1.5.1


### PR DESCRIPTION
Release https://github.com/quarkus-qe/quarkus-test-framework/pull/1288 failed as project wasn't prepared for next development interation https://github.com/quarkus-qe/quarkus-test-framework/pull/1290.