### PR TITLE
Added isRHBQ method to check if the version contain string redhat

### DIFF
--- a/quarkus-test-cli/src/main/java/io/quarkus/test/util/QuarkusCLIUtils.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/util/QuarkusCLIUtils.java
@@ -279,7 +279,7 @@ public abstract class QuarkusCLIUtils {
      */
     public static void setCommunityBomIfNotRunningRHBQ(QuarkusCliRestService app, String communityQuarkusVersion)
             throws XmlPullParserException, IOException {
-        if (!QuarkusProperties.getVersion().contains("redhat")) {
+        if (!QuarkusProperties.isRHBQ()) {
             Properties communityBomProperties = new Properties();
             communityBomProperties.put("quarkus.platform.group-id", "io.quarkus.platform");
             communityBomProperties.put("quarkus.platform.version", communityQuarkusVersion);

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/model/QuarkusProperties.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/model/QuarkusProperties.java
@@ -34,6 +34,10 @@ public final class QuarkusProperties {
 
     }
 
+    public static boolean isRHBQ() {
+        return QuarkusProperties.getVersion().contains("redhat");
+    }
+
     public static String getVersion() {
         return defaultVersionIfEmpty(PLATFORM_VERSION.get());
     }


### PR DESCRIPTION
### Summary

Added a new method called is isRHBQ that replaces `QuarkusProperties.getVersion().contains("redhat")` and replaces it's usage

Fixes :#1215

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)