### PR TITLE
Fix OpenShift certificate serving flakiness

### DIFF
--- a/examples/https/src/test/java/io/quarkus/qe/OpenShiftServingCertificatesIT.java
+++ b/examples/https/src/test/java/io/quarkus/qe/OpenShiftServingCertificatesIT.java
@@ -15,7 +15,6 @@ import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 import io.quarkus.test.services.Certificate;
 import io.quarkus.test.services.QuarkusApplication;
-import io.quarkus.test.utils.AwaitilityUtils;
 
 /**
  * Test OpenShift serving certificate support provided by our framework.
@@ -43,20 +42,17 @@ public class OpenShiftServingCertificatesIT {
     public void testSecuredCommunicationBetweenClientAndServer() {
         // REST client use OpenShift internal CA
         // server is configured with OpenShift serving certificates
-        // ad "untilAsserted": hopefully it's not necessary, but once I experienced unknown SAN,
-        // so to avoid flakiness I am adding here retry:
-        AwaitilityUtils.untilAsserted(() -> {
-            var hero = client.given()
-                    .get("hero-client-resource")
-                    .then()
-                    .statusCode(200)
-                    .extract()
-                    .as(Hero.class);
-            assertNotNull(hero);
-            assertNotNull(hero.name());
-            assertTrue(hero.name().startsWith("Name-"));
-            assertTrue(hero.otherName().startsWith("Other-"));
-        });
+        var hero = client.given()
+                .get("hero-client-resource")
+                .then()
+                .statusCode(200)
+                .extract()
+                .as(Hero.class);
+        assertNotNull(hero);
+        assertNotNull(hero.name());
+        assertTrue(hero.name().startsWith("Name-"));
+        assertNotNull(hero.otherName());
+        assertTrue(hero.otherName().startsWith("Other-"));
     }
 
 }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/Certificate.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/Certificate.java
@@ -140,6 +140,7 @@ public @interface Certificate {
 
     /**
      * OpenShift serving certificates configuration. This only works when internal service is used as URL.
+     * Support for management interface is not implemented.
      */
     @interface ServingCertificates {
 

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
@@ -849,11 +849,24 @@ public final class OpenShiftClient {
     }
 
     private static List<OpenShiftPropertiesUtils.PropertyToValue> collectAnnotations(Service service) {
+        if (isManagementInterfaceService(service)) {
+            // Subject Alternative Name (SAN) must match service DNS name,
+            // and injected certificates will have SAN set to one of OpenShift services,
+            // but we can have 2 services created for one application,
+            // one for HTTP server, one for management interface
+            // so far, we don't support management interface,
+            // which allows mount exactly one secret created for the HTTP server
+            return List.of();
+        }
         return service.getProperties().values()
                 .stream()
                 .filter(OpenShiftPropertiesUtils::isAnnotation)
                 .map(OpenShiftPropertiesUtils::getServiceAnnotation)
                 .toList();
+    }
+
+    private static boolean isManagementInterfaceService(Service service) {
+        return service.getName().endsWith("-management");
     }
 
     private String createAppPropsForPropsThatRequireDottedFormat(Map<String, String> configProperties) {


### PR DESCRIPTION
### Summary

reported here: https://github.com/quarkus-qe/quarkus-test-suite/pull/1987#issuecomment-2337303385

OpenShift certificate serving sometimes failed because served certificate was created for OpenShift service of the management interface, but we only test HTTP server ATM, not management interface. We can extend it in the future if we need to.

So what happened is that `tls.crt` had SAN with `DNS:server-management.ts-tjyivhmpxs.svc, DNS:server-management.ts-tjyivhmpxs.svc.cluster.local` but tested pods were created for `server.ts-tjyivhmpxs.svc` and so SSL handshake failed with `No subject alternative DNS name matching server.ts-tjyivhmpxs.svc.cluster.local found.`.

I didn't realize management interface is always there when default build template is used https://github.com/quarkus-qe/quarkus-test-framework/blob/7413aff64c3b31bc0db16e63d61a334d575ec7f9/quarkus-test-openshift/src/main/resources/quarkus-build-openshift-template.yml#L23.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)