### PR TITLE
Move RHBQPlatformAppManager to framework

### DIFF
--- a/quarkus-test-cli/src/main/java/io/quarkus/test/util/QuarkusCLIUtils.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/util/QuarkusCLIUtils.java
@@ -50,10 +50,9 @@ public abstract class QuarkusCLIUtils {
     public static IQuarkusCLIAppManager createAppManager(QuarkusCliClient cliClient,
             DefaultArtifactVersion oldVersionStream,
             DefaultArtifactVersion newVersionStream) {
-        String quarkusPropertiesVersion = QuarkusProperties.getVersion();
-        if (quarkusPropertiesVersion != null && quarkusPropertiesVersion.contains("redhat")) {
+        if (QuarkusProperties.isRHBQ()) {
             return new RHBQPlatformAppManager(cliClient, oldVersionStream, newVersionStream,
-                    new DefaultArtifactVersion(quarkusPropertiesVersion));
+                    new DefaultArtifactVersion(QuarkusProperties.getVersion()));
         }
         return new DefaultQuarkusCLIAppManager(cliClient, oldVersionStream, newVersionStream);
     }

--- a/quarkus-test-cli/src/main/java/io/quarkus/test/util/QuarkusCLIUtils.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/util/QuarkusCLIUtils.java
@@ -28,6 +28,7 @@ import org.apache.maven.model.io.xpp3.MavenXpp3Writer;
 import org.codehaus.plexus.util.xml.XmlStreamReader;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 
+import io.quarkus.test.bootstrap.QuarkusCliClient;
 import io.quarkus.test.bootstrap.QuarkusCliRestService;
 import io.quarkus.test.services.quarkus.model.QuarkusProperties;
 import io.smallrye.common.os.OS;
@@ -45,6 +46,17 @@ public abstract class QuarkusCLIUtils {
      * Checkstyle doesn't allow to have a number directly in a code, so this needs to be a constant.
      */
     private static final int GAV_FIELDS_LENGTH = 3;
+
+    public static IQuarkusCLIAppManager createAppManager(QuarkusCliClient cliClient,
+            DefaultArtifactVersion oldVersionStream,
+            DefaultArtifactVersion newVersionStream) {
+        String quarkusPropertiesVersion = QuarkusProperties.getVersion();
+        if (quarkusPropertiesVersion != null && quarkusPropertiesVersion.contains("redhat")) {
+            return new RHBQPlatformAppManager(cliClient, oldVersionStream, newVersionStream,
+                    new DefaultArtifactVersion(quarkusPropertiesVersion));
+        }
+        return new DefaultQuarkusCLIAppManager(cliClient, oldVersionStream, newVersionStream);
+    }
 
     /**
      * Create app, put properties into application.properties file,

--- a/quarkus-test-cli/src/main/java/io/quarkus/test/util/RHBQPlatformAppManager.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/util/RHBQPlatformAppManager.java
@@ -1,0 +1,59 @@
+package io.quarkus.test.util;
+
+import static io.quarkus.test.bootstrap.QuarkusCliClient.UpdateApplicationRequest.defaultUpdate;
+import static io.quarkus.test.util.QuarkusCLIUtils.getQuarkusAppVersion;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+
+import io.quarkus.test.bootstrap.QuarkusCliClient;
+import io.quarkus.test.bootstrap.QuarkusCliRestService;
+import io.quarkus.test.logging.Log;
+
+/**
+ * AppManager designed to update app to specific quarkus-bom version, instead of to stream as DefaultQuarkusCLIAppManager.
+ */
+public class RHBQPlatformAppManager extends DefaultQuarkusCLIAppManager {
+    protected final DefaultArtifactVersion newPlatformVersion;
+
+    public RHBQPlatformAppManager(QuarkusCliClient cliClient, DefaultArtifactVersion oldStreamVersion,
+            DefaultArtifactVersion newStreamVersion, DefaultArtifactVersion newPlatformVersion) {
+        super(cliClient, oldStreamVersion, newStreamVersion);
+        this.newPlatformVersion = newPlatformVersion;
+    }
+
+    @Override
+    public void updateApp(QuarkusCliRestService app) {
+        Log.info("Updating app to version: " + newPlatformVersion);
+        app.update(defaultUpdate()
+                .withPlatformVersion(newPlatformVersion.toString()));
+    }
+
+    @Override
+    public QuarkusCliRestService createApplication() {
+        return assertIsUsingRHBQ(super.createApplication());
+    }
+
+    @Override
+    public QuarkusCliRestService createApplicationWithExtensions(String... extensions) {
+        return assertIsUsingRHBQ(super.createApplicationWithExtensions(extensions));
+    }
+
+    @Override
+    public QuarkusCliRestService createApplicationWithExtraArgs(String... extraArgs) {
+        return assertIsUsingRHBQ(super.createApplicationWithExtraArgs(extraArgs));
+    }
+
+    private QuarkusCliRestService assertIsUsingRHBQ(QuarkusCliRestService app) {
+        try {
+            assertTrue(getQuarkusAppVersion(app).toString().contains("redhat"),
+                    "Created quarkus application does not use redhat version, while should be RHBQ");
+        } catch (IOException | XmlPullParserException e) {
+            throw new RuntimeException(e);
+        }
+        return app;
+    }
+}

--- a/quarkus-test-cli/src/main/java/io/quarkus/test/util/RHBQPlatformAppManager.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/util/RHBQPlatformAppManager.java
@@ -49,8 +49,9 @@ public class RHBQPlatformAppManager extends DefaultQuarkusCLIAppManager {
 
     private QuarkusCliRestService assertIsUsingRHBQ(QuarkusCliRestService app) {
         try {
+            // check that created application uses version with "redhat" suffix.
             assertTrue(getQuarkusAppVersion(app).toString().contains("redhat"),
-                    "Created quarkus application does not use redhat version, while should be RHBQ");
+                    "Created Quarkus application does not use \"redhat\" version, while should be RHBQ");
         } catch (IOException | XmlPullParserException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
### Summary

Move RHBQPlatformAppManager from TS to framework.
Add check that created app is indeed using RHBQ not community build. So we can catch this problem early and not after it tries to update community version to RHBQ or something like it.

Also add a factory method to determine which appManager to use. Since the logic between appManagers is growing more complex IMHO it should be in a framework.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [X] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)