### PR TITLE
Fix PostgreSQL waiting strategy for image from Red Hat container registry

### DIFF
--- a/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/PostgresqlService.java
+++ b/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/PostgresqlService.java
@@ -2,6 +2,13 @@ package io.quarkus.test.bootstrap;
 
 public class PostgresqlService extends DatabaseService<PostgresqlService> {
 
+    /**
+     * Red Hat PostgreSQL container image at certain point redirects logs to a file.
+     * This is name of property that determines destination.
+     * More info here:
+     * https://github.com/sclorg/postgresql-container/blob/master/16/root/usr/share/container-scripts/postgresql/README.md
+     */
+    static final String LOG_DESTINATION = "POSTGRESQL_LOG_DESTINATION";
     static final String USER_PROPERTY = "POSTGRESQL_USER";
     static final String PASSWORD_PROPERTY = "POSTGRESQL_PASSWORD";
     static final String DATABASE_PROPERTY = "POSTGRESQL_DATABASE";
@@ -23,6 +30,7 @@ public class PostgresqlService extends DatabaseService<PostgresqlService> {
         withProperty(USER_PROPERTY, getUser());
         withProperty(PASSWORD_PROPERTY, getPassword());
         withProperty(DATABASE_PROPERTY, getDatabase());
+        withProperty(LOG_DESTINATION, "/dev/stdout");
 
         // DockerHub environment variables
         withProperty(DH_USER_PROPERTY, getUser());


### PR DESCRIPTION
### Summary

- Closes: https://github.com/quarkus-qe/quarkus-test-framework/issues/1183

Here https://github.com/sclorg/postgresql-container/blob/master/16/root/usr/share/container-scripts/postgresql/README.md?plain=1#L74 they say it's for errors but I think it's just strange terminology of PG or something else I don't understand. Logged messages IMHO belongs to STD OUT, let's see:

```
21:01:27,390 INFO  [database] 2024-09-12 19:01:25.709 UTC [1] LOG:  redirecting log output to logging collector process
21:01:27,391 INFO  [database] 2024-09-12 19:01:25.709 UTC [1] HINT:  Future log output will appear in directory "/dev".
21:01:27,391 INFO  [database] 2024-09-12 19:01:25.709 UTC [1] LOG:  starting PostgreSQL 16.4 on x86_64-redhat-linux-gnu, compiled by gcc (GCC) 11.4.1 20231218 (Red Hat 11.4.1-3), 64-bit
21:01:27,391 INFO  [database] 2024-09-12 19:01:25.710 UTC [1] LOG:  listening on IPv4 address "0.0.0.0", port 5432
21:01:27,391 INFO  [database] 2024-09-12 19:01:25.710 UTC [1] LOG:  listening on IPv6 address "::", port 5432
21:01:27,391 INFO  [database] 2024-09-12 19:01:25.710 UTC [1] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
21:01:27,392 INFO  [database] 2024-09-12 19:01:25.710 UTC [1] LOG:  listening on Unix socket "/tmp/.s.PGSQL.5432"
21:01:27,392 INFO  [database] 2024-09-12 19:01:25.713 UTC [64] LOG:  database system was shut down at 2024-09-12 19:01:25 UTC
21:01:27,392 INFO  [database] 2024-09-12 19:01:25.717 UTC [1] LOG:  database system is ready to accept connections
```

These log messages go to STD OUT with property I am adding in this PR.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)