### PR TITLE
[1.3.z] Propagate quarkus OPTS to openshift deployment

### DIFF
--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/BuildOpenShiftQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/BuildOpenShiftQuarkusApplicationManagedResource.java
@@ -6,10 +6,16 @@ import static io.quarkus.test.services.quarkus.model.QuarkusProperties.QUARKUS_N
 import static java.util.regex.Pattern.quote;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
 import org.apache.commons.lang3.StringUtils;
 
 import io.quarkus.test.configuration.PropertyLookup;
+import io.quarkus.test.logging.Log;
 import io.quarkus.test.utils.Command;
+import io.quarkus.test.utils.PropertiesUtils;
 
 public class BuildOpenShiftQuarkusApplicationManagedResource
         extends TemplateOpenShiftQuarkusApplicationManagedResource<ArtifactQuarkusApplicationManagedResourceBuilder> {
@@ -18,6 +24,7 @@ public class BuildOpenShiftQuarkusApplicationManagedResource
 
     private static final String QUARKUS_OPENSHIFT_TEMPLATE = "/quarkus-build-openshift-template.yml";
     private static final String IMAGE_TAG_SEPARATOR = ":";
+    private static final String QUARKUS_OPENSHIFT_OPTS_PROPERTY = "quarkus.openshift.env.vars.quarkus-opts";
 
     public BuildOpenShiftQuarkusApplicationManagedResource(ArtifactQuarkusApplicationManagedResourceBuilder model) {
         super(model);
@@ -38,11 +45,17 @@ public class BuildOpenShiftQuarkusApplicationManagedResource
     protected String replaceDeploymentContent(String content) {
         String s2iImage = getS2iImage();
         String s2iVersion = getS2iImageVersion(s2iImage);
+        String quarkusOpts = getQuarkusOpts();
+
+        if (!quarkusOpts.isEmpty()) {
+            Log.info("Setting QUARKUS_OPTS, based on " + QUARKUS_OPENSHIFT_OPTS_PROPERTY + " to " + quarkusOpts);
+        }
 
         return content.replaceAll(quote("${QUARKUS_S2I_IMAGE_BUILDER}"),
                 StringUtils.substringBeforeLast(s2iImage, IMAGE_TAG_SEPARATOR))
                 .replaceAll(quote("${QUARKUS_S2I_IMAGE_BUILDER_VERSION}"), s2iVersion)
-                .replaceAll(quote("${ARTIFACT}"), model.getArtifact().getFileName().toString());
+                .replaceAll(quote("${ARTIFACT}"), model.getArtifact().getFileName().toString())
+                .replaceAll(quote("${QUARKUS_OPTS}"), quarkusOpts);
     }
 
     private void exposeServices() {
@@ -76,5 +89,16 @@ public class BuildOpenShiftQuarkusApplicationManagedResource
         PropertyLookup s2iImageProperty = isNativeTest() ? QUARKUS_NATIVE_S2I : QUARKUS_JVM_S2I;
         return model.getContext().getOwner().getProperty(s2iImageProperty.getPropertyKey())
                 .orElseGet(() -> s2iImageProperty.get(model.getContext()));
+    }
+
+    private String getQuarkusOpts() {
+        Path applicationProperties = model.getComputedApplicationProperties();
+        if (Files.exists(applicationProperties)) {
+            Map<String, String> properties = PropertiesUtils.toMap(applicationProperties);
+            if (properties.containsKey(QUARKUS_OPENSHIFT_OPTS_PROPERTY)) {
+                return properties.get(QUARKUS_OPENSHIFT_OPTS_PROPERTY);
+            }
+        }
+        return "";
     }
 }

--- a/quarkus-test-openshift/src/main/resources/quarkus-build-openshift-template.yml
+++ b/quarkus-test-openshift/src/main/resources/quarkus-build-openshift-template.yml
@@ -91,7 +91,7 @@ items:
                 - name: "QUARKUS_HOME"
                   value: "/home/quarkus/"
                 - name: "QUARKUS_OPTS"
-                  value: ""
+                  value: "${QUARKUS_OPTS}"
                 - name: "JAVA_APP_JAR"
                   value: "/deployments/${ARTIFACT}"
               image: "${SERVICE_NAME}:0.0.1-SNAPSHOT"


### PR DESCRIPTION
### Summary

Backports https://github.com/quarkus-qe/quarkus-test-framework/pull/1047, it is needed to fix `OpenShiftExecutionModelIT` test in TS 3.2 branch

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [x] Backport
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)