### PR TITLE
[1.5.z] Backports for PRs before September 13th 2024

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -401,7 +401,7 @@ jobs:
       - name: Build in Native mode
         shell: bash
         run: |
-          mvn -B --no-transfer-progress -fae -s .github/mvn-settings.xml clean install -Pframework,examples,native -Dquarkus.native.container-build=false -Dquarkus.platform.version="${{ matrix.quarkus-version }}" -Denable-win-race-debug=true
+          mvn -B --no-transfer-progress -fae -s .github/mvn-settings.xml clean install -Pframework,examples,native -Dquarkus.native.container-build=false -Dquarkus.platform.version="${{ matrix.quarkus-version }}"
       - name: Zip Artifacts
         shell: bash
         if: failure()

--- a/examples/https/src/test/java/io/quarkus/qe/OpenShiftServingCertificatesIT.java
+++ b/examples/https/src/test/java/io/quarkus/qe/OpenShiftServingCertificatesIT.java
@@ -15,7 +15,6 @@ import io.quarkus.test.scenarios.OpenShiftScenario;
 import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 import io.quarkus.test.services.Certificate;
 import io.quarkus.test.services.QuarkusApplication;
-import io.quarkus.test.utils.AwaitilityUtils;
 
 /**
  * Test OpenShift serving certificate support provided by our framework.
@@ -43,20 +42,17 @@ public class OpenShiftServingCertificatesIT {
     public void testSecuredCommunicationBetweenClientAndServer() {
         // REST client use OpenShift internal CA
         // server is configured with OpenShift serving certificates
-        // ad "untilAsserted": hopefully it's not necessary, but once I experienced unknown SAN,
-        // so to avoid flakiness I am adding here retry:
-        AwaitilityUtils.untilAsserted(() -> {
-            var hero = client.given()
-                    .get("hero-client-resource")
-                    .then()
-                    .statusCode(200)
-                    .extract()
-                    .as(Hero.class);
-            assertNotNull(hero);
-            assertNotNull(hero.name());
-            assertTrue(hero.name().startsWith("Name-"));
-            assertTrue(hero.otherName().startsWith("Other-"));
-        });
+        var hero = client.given()
+                .get("hero-client-resource")
+                .then()
+                .statusCode(200)
+                .extract()
+                .as(Hero.class);
+        assertNotNull(hero);
+        assertNotNull(hero.name());
+        assertTrue(hero.name().startsWith("Name-"));
+        assertNotNull(hero.otherName());
+        assertTrue(hero.otherName().startsWith("Other-"));
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <impsort-maven-plugin.version>1.11.0</impsort-maven-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>3.14.2</quarkus.platform.version>
+        <quarkus.platform.version>3.14.3</quarkus.platform.version>
         <exclude.tests.with.tags>quarkus-cli</exclude.tests.with.tags>
         <include.tests>**/*IT.java</include.tests>
         <exclude.openshift.tests>**/OpenShift*IT.java</exclude.openshift.tests>

--- a/quarkus-test-core/src/main/java/io/quarkus/test/logging/Log.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/logging/Log.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Random;
+import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogManager;
 import java.util.logging.Logger;
@@ -20,6 +21,7 @@ import org.jboss.logmanager.formatters.PatternFormatter;
 import org.jboss.logmanager.handlers.ConsoleHandler;
 import org.jboss.logmanager.handlers.FileHandler;
 
+import io.quarkus.bootstrap.logging.QuarkusDelayedHandler;
 import io.quarkus.test.bootstrap.QuarkusScenarioBootstrap;
 import io.quarkus.test.bootstrap.ScenarioContext;
 import io.quarkus.test.bootstrap.Service;
@@ -104,6 +106,17 @@ public final class Log {
         // Configure logger handlers
         Logger logger = LogManager.getLogManager().getLogger("");
         logger.setLevel(level);
+
+        // Remove existing handlers
+        for (Handler handler : logger.getHandlers()) {
+            // we don't need QuarkusDelayedHandler,
+            // and it leads to log duplication when the 'java.util.logging.manager'
+            // system property is set to the 'org.jboss.logmanager.LogManager'
+            if (handler instanceof QuarkusDelayedHandler) {
+                logger.removeHandler(handler);
+                break;
+            }
+        }
 
         // - Console
         ConsoleHandler console = new ConsoleHandler(

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/Certificate.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/Certificate.java
@@ -140,6 +140,7 @@ public @interface Certificate {
 
     /**
      * OpenShift serving certificates configuration. This only works when internal service is used as URL.
+     * Support for management interface is not implemented.
      */
     @interface ServingCertificates {
 

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
@@ -64,6 +64,7 @@ import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.fabric8.kubernetes.client.dsl.NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable;
+import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
 import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.utils.Serialization;
@@ -235,7 +236,7 @@ public final class OpenShiftClient {
         deployment.getSpec().getTemplate().getSpec().getContainers().forEach(container -> {
             enrichProperties.forEach((key, value) -> container.getEnv().add(new EnvVar(key, value, null)));
         });
-        client.apps().deployments().resource(deployment).createOrReplace();
+        client.apps().deployments().resource(deployment).unlock().createOr(NonDeletingOperation::patch);
     }
 
     private void updateAnnotationsIfNecessary(Service service, String serviceName) {
@@ -536,8 +537,8 @@ public final class OpenShiftClient {
         groupModel.getMetadata().setName(service.getName());
         groupModel.setSpec(new OperatorGroupSpec());
         groupModel.getSpec().setTargetNamespaces(Arrays.asList(currentNamespace));
-        // call createOrReplace
-        client.resource(groupModel).createOrReplace();
+        // call createOr and if it exists the update will be done
+        client.resource(groupModel).unlock().createOr(NonDeletingOperation::update);
 
         // Install the subscription
         Subscription subscriptionModel = new Subscription();
@@ -839,8 +840,8 @@ public final class OpenShiftClient {
         list.setItems(objs);
         try {
             ByteArrayOutputStream os = new ByteArrayOutputStream();
-            Serialization.yamlMapper().writeValue(os, list);
-            template = new String(os.toByteArray());
+            os.write(Serialization.asYaml(list).getBytes());
+            template = os.toString();
         } catch (IOException e) {
             fail("Failed adding properties into OpenShift template. Caused by " + e.getMessage());
         }
@@ -1072,7 +1073,7 @@ public final class OpenShiftClient {
         } else {
             // create new one
             configMaps.resource(new ConfigMapBuilder().withNewMetadata().withName(configMapName).endMetadata()
-                    .addToData(key, value).build()).createOrReplace();
+                    .addToData(key, value).build()).unlock().create();
         }
     }
 

--- a/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/PostgresqlService.java
+++ b/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/PostgresqlService.java
@@ -2,6 +2,13 @@ package io.quarkus.test.bootstrap;
 
 public class PostgresqlService extends DatabaseService<PostgresqlService> {
 
+    /**
+     * Red Hat PostgreSQL container image at certain point redirects logs to a file.
+     * This is name of property that determines destination.
+     * More info here:
+     * https://github.com/sclorg/postgresql-container/blob/master/16/root/usr/share/container-scripts/postgresql/README.md
+     */
+    static final String LOG_DESTINATION = "POSTGRESQL_LOG_DESTINATION";
     static final String USER_PROPERTY = "POSTGRESQL_USER";
     static final String PASSWORD_PROPERTY = "POSTGRESQL_PASSWORD";
     static final String DATABASE_PROPERTY = "POSTGRESQL_DATABASE";
@@ -23,6 +30,7 @@ public class PostgresqlService extends DatabaseService<PostgresqlService> {
         withProperty(USER_PROPERTY, getUser());
         withProperty(PASSWORD_PROPERTY, getPassword());
         withProperty(DATABASE_PROPERTY, getDatabase());
+        withProperty(LOG_DESTINATION, "/dev/stdout");
 
         // DockerHub environment variables
         withProperty(DH_USER_PROPERTY, getUser());


### PR DESCRIPTION
### Summary

This PR backports following PRs to 1.5.z branch.

- https://github.com/quarkus-qe/quarkus-test-framework/pull/1305
- https://github.com/quarkus-qe/quarkus-test-framework/pull/1302
- https://github.com/quarkus-qe/quarkus-test-framework/pull/1299
- https://github.com/quarkus-qe/quarkus-test-framework/pull/1298
- https://github.com/quarkus-qe/quarkus-test-framework/pull/1297
- https://github.com/quarkus-qe/quarkus-test-framework/pull/1296
- https://github.com/quarkus-qe/quarkus-test-framework/pull/1208


Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [x] Backports
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)