### PR TITLE
[1.4.z] Backports for PRs before September 13th 2024

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -576,7 +576,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>3.2.4</version>
+                        <version>3.2.5</version>
                         <configuration>
                             <gpgArguments>
                                 <arg>--pinentry-mode</arg>

--- a/quarkus-test-cli/src/main/java/io/quarkus/test/util/QuarkusCLIUtils.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/util/QuarkusCLIUtils.java
@@ -26,6 +26,7 @@ import org.apache.maven.model.io.xpp3.MavenXpp3Writer;
 import org.codehaus.plexus.util.xml.XmlStreamReader;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 
+import io.quarkus.test.bootstrap.QuarkusCliClient;
 import io.quarkus.test.bootstrap.QuarkusCliRestService;
 import io.quarkus.test.services.quarkus.model.QuarkusProperties;
 
@@ -40,6 +41,16 @@ public abstract class QuarkusCLIUtils {
      * Checkstyle doesn't allow to have a number directly in a code, so this needs to be a constant.
      */
     private static final int GAV_FIELDS_LENGTH = 3;
+
+    public static IQuarkusCLIAppManager createAppManager(QuarkusCliClient cliClient,
+            DefaultArtifactVersion oldVersionStream,
+            DefaultArtifactVersion newVersionStream) {
+        if (QuarkusProperties.isRHBQ()) {
+            return new RHBQPlatformAppManager(cliClient, oldVersionStream, newVersionStream,
+                    new DefaultArtifactVersion(QuarkusProperties.getVersion()));
+        }
+        return new DefaultQuarkusCLIAppManager(cliClient, oldVersionStream, newVersionStream);
+    }
 
     /**
      * Create app, put properties into application.properties file,

--- a/quarkus-test-cli/src/main/java/io/quarkus/test/util/QuarkusCLIUtils.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/util/QuarkusCLIUtils.java
@@ -27,6 +27,7 @@ import org.codehaus.plexus.util.xml.XmlStreamReader;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 
 import io.quarkus.test.bootstrap.QuarkusCliRestService;
+import io.quarkus.test.services.quarkus.model.QuarkusProperties;
 
 public abstract class QuarkusCLIUtils {
     public static final String RESOURCES_DIR = Paths.get("src", "main", "resources").toString();

--- a/quarkus-test-cli/src/main/java/io/quarkus/test/util/RHBQPlatformAppManager.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/util/RHBQPlatformAppManager.java
@@ -1,0 +1,60 @@
+package io.quarkus.test.util;
+
+import static io.quarkus.test.bootstrap.QuarkusCliClient.UpdateApplicationRequest.defaultUpdate;
+import static io.quarkus.test.util.QuarkusCLIUtils.getQuarkusAppVersion;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+
+import io.quarkus.test.bootstrap.QuarkusCliClient;
+import io.quarkus.test.bootstrap.QuarkusCliRestService;
+import io.quarkus.test.logging.Log;
+
+/**
+ * AppManager designed to update app to specific quarkus-bom version, instead of to stream as DefaultQuarkusCLIAppManager.
+ */
+public class RHBQPlatformAppManager extends DefaultQuarkusCLIAppManager {
+    protected final DefaultArtifactVersion newPlatformVersion;
+
+    public RHBQPlatformAppManager(QuarkusCliClient cliClient, DefaultArtifactVersion oldStreamVersion,
+            DefaultArtifactVersion newStreamVersion, DefaultArtifactVersion newPlatformVersion) {
+        super(cliClient, oldStreamVersion, newStreamVersion);
+        this.newPlatformVersion = newPlatformVersion;
+    }
+
+    @Override
+    public void updateApp(QuarkusCliRestService app) {
+        Log.info("Updating app to version: " + newPlatformVersion);
+        app.update(defaultUpdate()
+                .withPlatformVersion(newPlatformVersion.toString()));
+    }
+
+    @Override
+    public QuarkusCliRestService createApplication() {
+        return assertIsUsingRHBQ(super.createApplication());
+    }
+
+    @Override
+    public QuarkusCliRestService createApplicationWithExtensions(String... extensions) {
+        return assertIsUsingRHBQ(super.createApplicationWithExtensions(extensions));
+    }
+
+    @Override
+    public QuarkusCliRestService createApplicationWithExtraArgs(String... extraArgs) {
+        return assertIsUsingRHBQ(super.createApplicationWithExtraArgs(extraArgs));
+    }
+
+    private QuarkusCliRestService assertIsUsingRHBQ(QuarkusCliRestService app) {
+        try {
+            // check that created application uses version with "redhat" suffix.
+            assertTrue(getQuarkusAppVersion(app).toString().contains("redhat"),
+                    "Created Quarkus application does not use \"redhat\" version, while should be RHBQ");
+        } catch (IOException | XmlPullParserException e) {
+            throw new RuntimeException(e);
+        }
+        return app;
+    }
+}

--- a/quarkus-test-core/src/main/java/io/quarkus/test/logging/Log.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/logging/Log.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Random;
+import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogManager;
 import java.util.logging.Logger;
@@ -20,6 +21,7 @@ import org.jboss.logmanager.formatters.PatternFormatter;
 import org.jboss.logmanager.handlers.ConsoleHandler;
 import org.jboss.logmanager.handlers.FileHandler;
 
+import io.quarkus.bootstrap.logging.QuarkusDelayedHandler;
 import io.quarkus.test.bootstrap.QuarkusScenarioBootstrap;
 import io.quarkus.test.bootstrap.ScenarioContext;
 import io.quarkus.test.bootstrap.Service;
@@ -104,6 +106,17 @@ public final class Log {
         // Configure logger handlers
         Logger logger = LogManager.getLogManager().getLogger("");
         logger.setLevel(level);
+
+        // Remove existing handlers
+        for (Handler handler : logger.getHandlers()) {
+            // we don't need QuarkusDelayedHandler,
+            // and it leads to log duplication when the 'java.util.logging.manager'
+            // system property is set to the 'org.jboss.logmanager.LogManager'
+            if (handler instanceof QuarkusDelayedHandler) {
+                logger.removeHandler(handler);
+                break;
+            }
+        }
 
         // - Console
         ConsoleHandler console = new ConsoleHandler(

--- a/quarkus-test-core/src/main/java/io/quarkus/test/security/certificate/Certificate.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/security/certificate/Certificate.java
@@ -300,9 +300,9 @@ public interface Certificate {
     }
 
     private static String toSecretProperty(String path) {
-        int fileNameSeparatorIdx = path.lastIndexOf(File.separator);
-        String fileName = path.substring(fileNameSeparatorIdx + 1);
-        String pathToFile = path.substring(0, fileNameSeparatorIdx);
+        var file = Path.of(path).toFile();
+        String fileName = file.getName();
+        String pathToFile = file.getParentFile().getAbsolutePath();
         return SECRET_WITH_DESTINATION_PREFIX + pathToFile + DESTINATION_TO_FILENAME_SEPARATOR + fileName;
     }
 

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/ProdQuarkusApplicationManagedResourceBuilder.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/ProdQuarkusApplicationManagedResourceBuilder.java
@@ -4,7 +4,6 @@ import static io.quarkus.test.services.quarkus.QuarkusMavenPluginBuildHelper.fin
 import static io.quarkus.test.utils.FileUtils.findTargetFile;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -12,11 +11,9 @@ import java.util.ArrayList;
 import java.util.Optional;
 import java.util.ServiceLoader;
 
-import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.exporter.ExplodedExporter;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.condition.OS;
 
 import io.quarkus.bootstrap.app.AugmentAction;
 import io.quarkus.bootstrap.app.AugmentResult;
@@ -25,10 +22,10 @@ import io.quarkus.bootstrap.app.QuarkusBootstrap;
 import io.quarkus.test.bootstrap.ManagedResource;
 import io.quarkus.test.bootstrap.ServiceContext;
 import io.quarkus.test.common.PathTestHelper;
+import io.quarkus.test.logging.Log;
 import io.quarkus.test.security.certificate.CertificateBuilder;
 import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.test.services.quarkus.model.QuarkusProperties;
-import io.quarkus.test.utils.Command;
 
 public class ProdQuarkusApplicationManagedResourceBuilder extends ArtifactQuarkusApplicationManagedResourceBuilder {
 
@@ -36,7 +33,6 @@ public class ProdQuarkusApplicationManagedResourceBuilder extends ArtifactQuarku
     static final String EXE = ".exe";
     static final String TARGET = "target";
 
-    private static final Logger LOG = Logger.getLogger(ProdQuarkusApplicationManagedResourceBuilder.class.getName());
     private static final String JVM_RUNNER = "-runner.jar";
     private static final String QUARKUS_APP = "quarkus-app";
     private static final String QUARKUS_RUN = "quarkus-run.jar";
@@ -87,32 +83,10 @@ public class ProdQuarkusApplicationManagedResourceBuilder extends ArtifactQuarku
         managedResource.onPreBuild();
         copyResourcesToAppFolder();
         if (managedResource.needsBuildArtifact()) {
-            try {
-                this.artifact = tryToReuseOrBuildArtifact();
-            } catch (Throwable t) {
-                debugFileAccessRaceOnWindows();
-                throw t;
-            }
+            this.artifact = tryToReuseOrBuildArtifact();
         }
 
         managedResource.onPostBuild();
-    }
-
-    private void debugFileAccessRaceOnWindows() {
-        if (OS.current() == OS.WINDOWS && Boolean.getBoolean("enable-win-race-debug")) {
-            LOG.info("List all running processes:");
-            ProcessHandle.allProcesses().forEach(processHandle -> {
-                LOG.infof("pid - '%s', is alive - '%b', command - '%s', arguments - '%s'", processHandle.pid(),
-                        processHandle.isAlive(), processHandle.info().command().orElse(""),
-                        processHandle.info().arguments());
-            });
-            LOG.info("Print all file open handles:");
-            try {
-                new Command(".\\handle.exe -accepteula").onDirectory(Path.of(System.getenv("GITHUB_WORKSPACE"))).runAndWait();
-            } catch (IOException | InterruptedException e) {
-                throw new RuntimeException("Failed to run 'handle.exe': " + e.getMessage());
-            }
-        }
     }
 
     protected QuarkusManagedResource findManagedResource() {
@@ -162,7 +136,7 @@ public class ProdQuarkusApplicationManagedResourceBuilder extends ArtifactQuarku
             return new QuarkusMavenPluginBuildHelper(this, getTargetFolderForLocalArtifacts())
                     .buildNativeExecutable()
                     .orElseGet(() -> {
-                        LOG.warn("""
+                        Log.warn("""
                                 Quarkus Maven plugin is missing, falling back to Quarkus bootstrap strategy.
                                 Please add 'quarkus-maven-plugin' to your project as the bootstrap strategy will be removed
                                 in the future.

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/model/QuarkusProperties.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/model/QuarkusProperties.java
@@ -32,6 +32,10 @@ public final class QuarkusProperties {
 
     }
 
+    public static boolean isRHBQ() {
+        return QuarkusProperties.getVersion().contains("redhat");
+    }
+
     public static String getVersion() {
         return defaultVersionIfEmpty(PLATFORM_VERSION.get());
     }

--- a/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/PostgresqlService.java
+++ b/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/PostgresqlService.java
@@ -2,6 +2,13 @@ package io.quarkus.test.bootstrap;
 
 public class PostgresqlService extends DatabaseService<PostgresqlService> {
 
+    /**
+     * Red Hat PostgreSQL container image at certain point redirects logs to a file.
+     * This is name of property that determines destination.
+     * More info here:
+     * https://github.com/sclorg/postgresql-container/blob/master/16/root/usr/share/container-scripts/postgresql/README.md
+     */
+    static final String LOG_DESTINATION = "POSTGRESQL_LOG_DESTINATION";
     static final String USER_PROPERTY = "POSTGRESQL_USER";
     static final String PASSWORD_PROPERTY = "POSTGRESQL_PASSWORD";
     static final String DATABASE_PROPERTY = "POSTGRESQL_DATABASE";
@@ -23,6 +30,7 @@ public class PostgresqlService extends DatabaseService<PostgresqlService> {
         withProperty(USER_PROPERTY, getUser());
         withProperty(PASSWORD_PROPERTY, getPassword());
         withProperty(DATABASE_PROPERTY, getDatabase());
+        withProperty(LOG_DESTINATION, "/dev/stdout");
 
         // DockerHub environment variables
         withProperty(DH_USER_PROPERTY, getUser());

--- a/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/SqlServerService.java
+++ b/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/SqlServerService.java
@@ -87,7 +87,7 @@ public class SqlServerService extends DatabaseService<SqlServerService> {
 
     @Override
     public SqlServerService onPreStart(Action action) {
-        withProperty("SA_PASSWORD", getPassword());
+        withProperty("MSSQL_SA_PASSWORD", getPassword());
         withProperty("ACCEPT_EULA", "Y");
         return super.onPreStart(action);
     }


### PR DESCRIPTION
### Summary

Backports:

- https://github.com/quarkus-qe/quarkus-test-framework/pull/1305
- https://github.com/quarkus-qe/quarkus-test-framework/pull/1303
- https://github.com/quarkus-qe/quarkus-test-framework/pull/1298
- https://github.com/quarkus-qe/quarkus-test-framework/pull/1297
- https://github.com/quarkus-qe/quarkus-test-framework/pull/1294
- https://github.com/quarkus-qe/quarkus-test-framework/pull/1245
- https://github.com/quarkus-qe/quarkus-test-framework/pull/1226
- https://github.com/quarkus-qe/quarkus-test-framework/pull/1197


Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Backports
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)