### PR TITLE
Allow CLI utils to work with dependencies in CSV

### DIFF
--- a/examples/quarkus-cli/src/test/java/io/quarkus/qe/QuarkusCliUtilsExampleIT.java
+++ b/examples/quarkus-cli/src/test/java/io/quarkus/qe/QuarkusCliUtilsExampleIT.java
@@ -1,6 +1,10 @@
 package io.quarkus.qe;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -8,6 +12,7 @@ import jakarta.inject.Inject;
 
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 import org.apache.maven.model.Dependency;
+import org.apache.maven.surefire.shared.lang3.tuple.Pair;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -27,6 +32,7 @@ import io.quarkus.test.util.QuarkusCLIUtils;
 public class QuarkusCliUtilsExampleIT {
     private static final DefaultArtifactVersion oldVersion = new DefaultArtifactVersion("3.2");
     private static final DefaultArtifactVersion newVersion = new DefaultArtifactVersion("3.8");
+    private static final Path DEPENDENCIES_CSV = Paths.get("src/test/resources/dependenciesToUpdate.csv");
     private final IQuarkusCLIAppManager appManager;
     @Inject
     static QuarkusCliClient cliClient;
@@ -44,5 +50,19 @@ public class QuarkusCliUtilsExampleIT {
         newDependencies.add(new QuarkusCLIUtils.QuarkusDependency("io.quarkus:quarkus-resteasy-client"));
 
         QuarkusCLIUtils.checkDependenciesUpdate(appManager, oldDependencies, newDependencies);
+    }
+
+    @Test
+    public void csvParserTest() throws IOException {
+        List<Pair<Dependency, Dependency>> dependencyPairs = QuarkusCLIUtils.loadDependencyPairsFromCSV(DEPENDENCIES_CSV);
+        // check artifactId in first line
+        assertEquals("quarkus-resteasy-reactive", dependencyPairs.get(0).getKey().getArtifactId());
+        assertEquals("quarkus-rest", dependencyPairs.get(0).getValue().getArtifactId());
+
+        // check entire object on last line
+        assertEquals(new QuarkusCLIUtils.QuarkusDependency("org.graalvm.sdk:graal-sdk:24.0.2"),
+                dependencyPairs.get(dependencyPairs.size() - 1).getKey());
+        assertEquals(new QuarkusCLIUtils.QuarkusDependency("org.graalvm.sdk:nativeimage:24.0.2"),
+                dependencyPairs.get(dependencyPairs.size() - 1).getValue());
     }
 }

--- a/examples/quarkus-cli/src/test/resources/dependenciesToUpdate.csv
+++ b/examples/quarkus-cli/src/test/resources/dependenciesToUpdate.csv
@@ -1,0 +1,7 @@
+# Example comment
+# https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.9#resteasy-reactive-extensions-renamed-to-quarkus-rest-gear-white_check_mark
+io.quarkus:quarkus-resteasy-reactive,io.quarkus:quarkus-rest
+io.quarkus:quarkus-resteasy-reactive-jackson,io.quarkus:quarkus-rest-jackson
+
+# https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.9#graalvm-sdk-update-gear-white_check_mark
+org.graalvm.sdk:graal-sdk:24.0.2,org.graalvm.sdk:nativeimage:24.0.2


### PR DESCRIPTION
### Summary

While testing big amounts of dependencies to update, it is bad to store them all in code. Allow for storing these in CSV.

I intentionally didn't add support for properties (which we test in similar way) since those are not simple pairs like dependencies and would require more complex solution.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [X] Example scenarios has been updated / added
- [X] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)