### PR TITLE
Install JBobss log handlers just once when multiple tests are run inside one test module and JBoss log manager is installed

### DIFF
--- a/quarkus-test-core/src/main/java/io/quarkus/test/logging/Log.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/logging/Log.java
@@ -109,12 +109,13 @@ public final class Log {
 
         // Remove existing handlers
         for (Handler handler : logger.getHandlers()) {
-            // we don't need QuarkusDelayedHandler,
-            // and it leads to log duplication when the 'java.util.logging.manager'
-            // system property is set to the 'org.jboss.logmanager.LogManager'
-            if (handler instanceof QuarkusDelayedHandler) {
+            // JBosss context is saved statically and when more tests are run inside module
+            // while org.jboss.logmanager.LogManager is installed we add a new handlers in addition to previous ones
+            // it's desirable to install only a new handlers according to test configuration
+            // QuarkusDelayedHandler is removed as it duplicates logs when JBoss log manager is installed
+            if (handler instanceof QuarkusDelayedHandler || handler instanceof ConsoleHandler
+                    || handler instanceof FileHandler) {
                 logger.removeHandler(handler);
-                break;
             }
         }
 


### PR DESCRIPTION
### Summary

When JBoss log manager is installed (one of ways to do that is to set `-Djava.util.logging.manager=org.jboss.logmanager.LogManager`) and multiple tests are run, every time we run `io.quarkus.test.logging.Log#configure` new handlers are added to static JBoss log manager context in addition to previous ones. I already removed one installed https://github.com/quarkus-qe/quarkus-test-framework/blob/main/quarkus-test-core/src/main/java/io/quarkus/test/logging/Log.java#L115 but as I didn't run multiple tests inside module (AKA was able to reproduce it running one) I didn't realize our framework install additional ones.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)