### PR TITLE
Only disable analytics for Quarkus CLI dev or build command

### DIFF
--- a/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/tls/QuarkusTlsCommand.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/tls/QuarkusTlsCommand.java
@@ -1,8 +1,5 @@
 package io.quarkus.test.bootstrap.tls;
 
-import static io.quarkus.test.services.quarkus.model.QuarkusProperties.QUARKUS_ANALYTICS_DISABLED_LOCAL_PROP_KEY;
-
-import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -11,7 +8,6 @@ import java.util.List;
 import io.quarkus.test.bootstrap.AbstractCliCommand;
 import io.quarkus.test.bootstrap.QuarkusCliClient;
 import io.quarkus.test.bootstrap.QuarkusCliCommandResult;
-import io.quarkus.test.services.quarkus.model.QuarkusProperties;
 import io.quarkus.test.utils.FileUtils;
 
 public final class QuarkusTlsCommand extends AbstractCliCommand {
@@ -38,31 +34,13 @@ public final class QuarkusTlsCommand extends AbstractCliCommand {
     }
 
     QuarkusCliCommandResult runTlsCommand(List<String> subCmdArgs) {
-        // TLS config command doesn't support -Dquarkus.analytics.disabled option
-        // this forces QuarkusCliClient to don't set it
-        try (var ignored = dontDisableAnalyticsWithProp()) {
-            return runCommand("tls", subCmdArgs);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+        return runCommand("tls", subCmdArgs);
     }
 
     private static QuarkusCliClient.CreateApplicationRequest getCreateAppReq() {
         return QuarkusCliClient.CreateApplicationRequest.defaults()
                 // TODO: we can drop 'tls-registry' when https://github.com/quarkusio/quarkus/issues/42751 is fixed
                 .withExtensions("tls-registry", "quarkus-rest");
-    }
-
-    private static Closeable dontDisableAnalyticsWithProp() {
-        // TODO: QE tracker for this workaround: https://issues.redhat.com/browse/QQE-935
-        if (QuarkusProperties.disableBuildAnalytics()) {
-            System.setProperty(QUARKUS_ANALYTICS_DISABLED_LOCAL_PROP_KEY, Boolean.FALSE.toString());
-            return () -> System.setProperty(QUARKUS_ANALYTICS_DISABLED_LOCAL_PROP_KEY, Boolean.TRUE.toString());
-        } else {
-            // NOOP
-            return () -> {
-            };
-        }
     }
 
     private static File createTempDir() {

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/DevModeQuarkusApplicationManagedResourceBuilder.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/DevModeQuarkusApplicationManagedResourceBuilder.java
@@ -1,7 +1,5 @@
 package io.quarkus.test.services.quarkus;
 
-import static io.quarkus.test.services.quarkus.model.QuarkusProperties.QUARKUS_ANALYTICS_DISABLED_LOCAL_PROP_KEY;
-
 import java.lang.annotation.Annotation;
 import java.nio.file.Path;
 
@@ -9,7 +7,6 @@ import io.quarkus.test.bootstrap.ManagedResource;
 import io.quarkus.test.bootstrap.ServiceContext;
 import io.quarkus.test.security.certificate.CertificateBuilder;
 import io.quarkus.test.services.DevModeQuarkusApplication;
-import io.quarkus.test.services.quarkus.model.QuarkusProperties;
 
 public class DevModeQuarkusApplicationManagedResourceBuilder extends QuarkusApplicationManagedResourceBuilder {
 
@@ -33,11 +30,6 @@ public class DevModeQuarkusApplicationManagedResourceBuilder extends QuarkusAppl
         setContext(context);
         configureLogging();
         configureCertificates();
-        if (QuarkusProperties.disableBuildAnalytics()) {
-            getContext()
-                    .getOwner()
-                    .withProperty(QUARKUS_ANALYTICS_DISABLED_LOCAL_PROP_KEY, Boolean.TRUE.toString());
-        }
         build();
         return new DevModeLocalhostQuarkusApplicationManagedResource(this);
     }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/RemoteDevModeQuarkusApplicationManagedResourceBuilder.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/RemoteDevModeQuarkusApplicationManagedResourceBuilder.java
@@ -1,5 +1,6 @@
 package io.quarkus.test.services.quarkus;
 
+import static io.quarkus.test.services.quarkus.model.QuarkusProperties.createDisableBuildAnalyticsProperty;
 import static io.quarkus.test.utils.FileUtils.findTargetFile;
 import static io.quarkus.test.utils.MavenUtils.ENSURE_QUARKUS_BUILD;
 import static io.quarkus.test.utils.MavenUtils.SKIP_CHECKSTYLE;
@@ -123,6 +124,9 @@ public class RemoteDevModeQuarkusApplicationManagedResourceBuilder extends Artif
         command.add(withProperty(QUARKUS_LIVE_RELOAD_URL,
                 managedResource.getURI(Protocol.HTTP).toString()));
         command.add("quarkus:remote-dev");
+        if (QuarkusProperties.disableBuildAnalytics()) {
+            command.add(createDisableBuildAnalyticsProperty());
+        }
 
         Log.info("Running command: %s", String.join(" ", command));
 

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/model/QuarkusProperties.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/model/QuarkusProperties.java
@@ -1,5 +1,7 @@
 package io.quarkus.test.services.quarkus.model;
 
+import static java.lang.String.format;
+
 import java.util.Arrays;
 import java.util.List;
 
@@ -48,6 +50,10 @@ public final class QuarkusProperties {
 
     public static boolean disableBuildAnalytics() {
         return QUARKUS_ANALYTICS_DISABLED_LOCAL_PROP.getAsBoolean();
+    }
+
+    public static String createDisableBuildAnalyticsProperty() {
+        return format("-D%s=%s", QUARKUS_ANALYTICS_DISABLED_LOCAL_PROP_KEY, Boolean.TRUE);
     }
 
     public static boolean isNativeEnabled() {

--- a/quarkus-test-core/src/main/java/io/quarkus/test/utils/MavenUtils.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/utils/MavenUtils.java
@@ -19,6 +19,7 @@ import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 
 import io.quarkus.test.bootstrap.ServiceContext;
 import io.quarkus.test.configuration.PropertyLookup;
+import io.quarkus.test.services.quarkus.model.QuarkusProperties;
 
 public final class MavenUtils {
 
@@ -76,6 +77,9 @@ public final class MavenUtils {
         command.addAll(Arrays.asList(BATCH_MODE, SKIP_PROGRESS));
         command.addAll(systemProperties);
         command.add(withProperty("debug", "false"));
+        if (QuarkusProperties.disableBuildAnalytics()) {
+            command.add(QuarkusProperties.createDisableBuildAnalyticsProperty());
+        }
         command.add("quarkus:dev");
 
         return command;


### PR DESCRIPTION
### Summary

This PR does 2 things:

- disables analytics for remote dev mode as we waste time there (10 seconds, see daily builds)
- refactors workaround for TLS command that disables analytics just for itself

Right now analytics are send during build and DEV mode. In https://quarkus.io/usage/ and https://quarkus.io/version/main/guides/build-analytics#show-me-the-code Quarkus explicitly documents that:

- analytics are send in DEV mode
- you can look when analytics are send in `io.quarkus.analytics.AnalyticsService#sendAnalytics`:
  - I checked an they are also send for `quarkus build` command

This can change in the future and noone from QE team will check every one and then if that has changed. So until now we always set `-Dquarkus.analytics.disabled=true` unless explicitly disabled. Now it does matter when Quarkus CLI TLS command is used because that command reports unknown option for setting this system property.

What are our options:

- report this inconsistency in Quarkus project and do nothing till it's addressed (if it is addressed)
  - but that means reporting something that is not clear bug, just our incovenience; for example, Quarkus supports "CI" environment variable that allows to disable this behavior, but we would have to change all our Jenkins jobs / GH workflows
- only exclude TLS command
  - that is my favorite, because it isolates scenario that clearly doesn't need analytics but doesn't break anything
- do what this PR does - only disable analytics when really needed

Honestly, not sure what is best, I think one day someone will report that I slowed down CI, but on the other hand, doing what this PR does, we won't always disable analytics when not needed. Why should users always do that? It feels stupid to expect users to always add it and I don't believe they will. So closer to user case.

Update: I rerun related tests and this seems to disable analytics as expected.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)