### PR TITLE
Support attaching to process when using TS debug option so that you can debug app step by step in your IDE

### DIFF
--- a/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/TestContext.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/TestContext.java
@@ -17,6 +17,8 @@ public interface TestContext {
 
     Optional<String> getRunningTestMethodName();
 
+    DebugOptions debugOptions();
+
     interface TestStore {
 
         Object get(Object key);
@@ -25,18 +27,23 @@ public interface TestContext {
 
     }
 
+    record DebugOptions(boolean debug, boolean suspend) {
+    }
+
     final class TestContextImpl implements TestContext {
 
         private final TestStore testStore;
         private final Class<?> requiredTestClass;
         private final Set<String> tags;
         private final String runningTestMethodName;
+        private final DebugOptions debugOptions;
 
-        public TestContextImpl(Class<?> requiredTestClass, Set<String> tags) {
+        public TestContextImpl(Class<?> requiredTestClass, Set<String> tags, DebugOptions debugOptions) {
             this.testStore = new MapBackedTestStore();
             this.requiredTestClass = requiredTestClass;
             this.tags = tags;
             this.runningTestMethodName = null;
+            this.debugOptions = debugOptions;
         }
 
         TestContextImpl(Class<?> requiredTestClass, Set<String> tags, ExtensionContext.Store store) {
@@ -54,6 +61,7 @@ public interface TestContext {
             this.requiredTestClass = requiredTestClass;
             this.tags = tags;
             this.runningTestMethodName = null;
+            this.debugOptions = null;
         }
 
         TestContextImpl(TestContext testContext, String runningTestMethodName) {
@@ -61,6 +69,7 @@ public interface TestContext {
             this.requiredTestClass = testContext.getRequiredTestClass();
             this.tags = testContext.getTags();
             this.runningTestMethodName = runningTestMethodName;
+            this.debugOptions = null;
         }
 
         @Override
@@ -81,6 +90,11 @@ public interface TestContext {
         @Override
         public Optional<String> getRunningTestMethodName() {
             return runningTestMethodName == null ? Optional.empty() : Optional.of(runningTestMethodName);
+        }
+
+        @Override
+        public DebugOptions debugOptions() {
+            return debugOptions;
         }
     }
 

--- a/quarkus-test-core/src/main/java/io/quarkus/test/debug/SureFireDebugProvider.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/debug/SureFireDebugProvider.java
@@ -32,11 +32,13 @@ public class SureFireDebugProvider extends AbstractProvider {
     public static final String APP_IS_READ_PRESS_ENTER_TO_EXIT = "Application is ready for debugging. Press enter to exit:";
     public static final String TEST_RUN_SUCCESS = "Run all tests without failure";
     public static final String RUN_TESTS = "ts.debug.run-tests";
+    public static final String SUSPEND = "ts.debug.suspend";
     private static final Logger LOG = Logger.getLogger(SureFireDebugProvider.class);
     private static final int SLEEP_TIMEOUT = 500;
     private final ProviderParameters parameters;
     private final boolean runTests;
     private final boolean skipBeforeAndAfterTestClassMethods;
+    private final boolean suspend;
 
     public SureFireDebugProvider(ProviderParameters parameters) {
         this.parameters = parameters;
@@ -46,6 +48,7 @@ public class SureFireDebugProvider extends AbstractProvider {
         } else {
             runTests = Boolean.parseBoolean(waitingStrategyProp);
         }
+        this.suspend = Boolean.getBoolean(SUSPEND);
         skipBeforeAndAfterTestClassMethods = parseBoolean(System.getProperty("ts.debug.skip-before-and-after-methods"));
     }
 
@@ -58,7 +61,8 @@ public class SureFireDebugProvider extends AbstractProvider {
     public RunResult invoke(Object o) throws TestSetFailedException, ReporterException, InvocationTargetException {
         try {
             var bootstrap = new QuarkusScenarioBootstrap();
-            var testContext = new TestContext.TestContextImpl(findTestClass(), Set.of());
+            var debugOptions = new TestContext.DebugOptions(true, suspend);
+            var testContext = new TestContext.TestContextImpl(findTestClass(), Set.of(), debugOptions);
             var testClassInstance = instantiateTestClass();
 
             bootstrap.beforeAll(testContext);

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/ProdLocalhostQuarkusApplicationManagedResource.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/ProdLocalhostQuarkusApplicationManagedResource.java
@@ -33,6 +33,11 @@ public class ProdLocalhostQuarkusApplicationManagedResource extends LocalhostQua
                 command.add(ENABLE_PREVIEW);
             }
             command.addAll(systemProperties);
+            var debugOptions = model.getContext().getTestContext().debugOptions();
+            if (debugOptions != null && debugOptions.debug()) {
+                var suspend = debugOptions.suspend() ? "y" : "n";
+                command.add("-agentlib:jdwp=transport=dt_socket,address=localhost:5005,server=y,suspend=" + suspend);
+            }
             command.add("-jar");
             command.add(model.getArtifact().toAbsolutePath().toString());
         } else {


### PR DESCRIPTION
### Summary

I use `-Dts.debug` when I need to keep tested application and containers running while I debug what is going on, for example in `quarkus-test-framework/examples/greetings` I do `mvn clean verify -Dts.debug`. It is good if I want to curl the app or inspect containers (like Jaeger UI for traces), but it doesn't allow me to actually attach me IDE and step by step see what is happening in the app. So now, I am adding option to attach the IDE to started Quarkus application in JVM mode on localhost.

Adding same args as Quarkus DEV mode adds https://github.com/quarkusio/quarkus/blob/2b814d3db0338d16d17e97361653b587e6dcc0fb/core/deployment/src/main/java/io/quarkus/deployment/dev/QuarkusDevModeLauncher.java#L420.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)