### PR TITLE
[1.5.z] Backport quarkus CLI PRs

### DIFF
--- a/quarkus-test-cli/src/main/java/io/quarkus/test/util/QuarkusCLIUtils.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/util/QuarkusCLIUtils.java
@@ -29,6 +29,7 @@ import org.codehaus.plexus.util.xml.XmlStreamReader;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 
 import io.quarkus.test.bootstrap.QuarkusCliRestService;
+import io.quarkus.test.services.quarkus.model.QuarkusProperties;
 import io.smallrye.common.os.OS;
 import io.quarkus.test.services.quarkus.model.QuarkusProperties;
 
@@ -258,6 +259,33 @@ public abstract class QuarkusCLIUtils {
      */
     public static Properties getProperties(QuarkusCliRestService app) throws XmlPullParserException, IOException {
         return getPom(app).getProperties();
+    }
+
+    /**
+     * Change given properties in app's pom.
+     * Other properties are unchanged.
+     */
+    public static void changePropertiesInPom(QuarkusCliRestService app, Properties properties)
+            throws XmlPullParserException, IOException {
+        Model pom = getPom(app);
+        Properties pomProperties = pom.getProperties();
+        pomProperties.putAll(properties);
+        pom.setProperties(pomProperties);
+        savePom(app, pom);
+    }
+
+    /**
+     * If tests are not on RHBQ it will set properties in app's pom to work with community quarkus BOM.
+     * Expects that app is using RHBQ by default.
+     */
+    public static void setCommunityBomIfNotRunningRHBQ(QuarkusCliRestService app, String communityQuarkusVersion)
+            throws XmlPullParserException, IOException {
+        if (!QuarkusProperties.getVersion().contains("redhat")) {
+            Properties communityBomProperties = new Properties();
+            communityBomProperties.put("quarkus.platform.group-id", "io.quarkus.platform");
+            communityBomProperties.put("quarkus.platform.version", communityQuarkusVersion);
+            changePropertiesInPom(app, communityBomProperties);
+        }
     }
 
     /**

--- a/quarkus-test-cli/src/main/java/io/quarkus/test/util/QuarkusCLIUtils.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/util/QuarkusCLIUtils.java
@@ -32,7 +32,6 @@ import io.quarkus.test.bootstrap.QuarkusCliClient;
 import io.quarkus.test.bootstrap.QuarkusCliRestService;
 import io.quarkus.test.services.quarkus.model.QuarkusProperties;
 import io.smallrye.common.os.OS;
-import io.quarkus.test.services.quarkus.model.QuarkusProperties;
 
 public abstract class QuarkusCLIUtils {
     public static final String RESOURCES_DIR = Paths.get("src", "main", "resources").toString();

--- a/quarkus-test-cli/src/main/java/io/quarkus/test/util/QuarkusCLIUtils.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/util/QuarkusCLIUtils.java
@@ -30,6 +30,7 @@ import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 
 import io.quarkus.test.bootstrap.QuarkusCliRestService;
 import io.smallrye.common.os.OS;
+import io.quarkus.test.services.quarkus.model.QuarkusProperties;
 
 public abstract class QuarkusCLIUtils {
     public static final String RESOURCES_DIR = Paths.get("src", "main", "resources").toString();

--- a/quarkus-test-cli/src/main/java/io/quarkus/test/util/QuarkusCLIUtils.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/util/QuarkusCLIUtils.java
@@ -28,6 +28,7 @@ import org.apache.maven.model.io.xpp3.MavenXpp3Writer;
 import org.codehaus.plexus.util.xml.XmlStreamReader;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 
+import io.quarkus.test.bootstrap.QuarkusCliClient;
 import io.quarkus.test.bootstrap.QuarkusCliRestService;
 import io.quarkus.test.services.quarkus.model.QuarkusProperties;
 import io.smallrye.common.os.OS;
@@ -46,6 +47,16 @@ public abstract class QuarkusCLIUtils {
      * Checkstyle doesn't allow to have a number directly in a code, so this needs to be a constant.
      */
     private static final int GAV_FIELDS_LENGTH = 3;
+
+    public static IQuarkusCLIAppManager createAppManager(QuarkusCliClient cliClient,
+            DefaultArtifactVersion oldVersionStream,
+            DefaultArtifactVersion newVersionStream) {
+        if (QuarkusProperties.isRHBQ()) {
+            return new RHBQPlatformAppManager(cliClient, oldVersionStream, newVersionStream,
+                    new DefaultArtifactVersion(QuarkusProperties.getVersion()));
+        }
+        return new DefaultQuarkusCLIAppManager(cliClient, oldVersionStream, newVersionStream);
+    }
 
     /**
      * Create app, put properties into application.properties file,

--- a/quarkus-test-cli/src/main/java/io/quarkus/test/util/RHBQPlatformAppManager.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/util/RHBQPlatformAppManager.java
@@ -1,0 +1,60 @@
+package io.quarkus.test.util;
+
+import static io.quarkus.test.bootstrap.QuarkusCliClient.UpdateApplicationRequest.defaultUpdate;
+import static io.quarkus.test.util.QuarkusCLIUtils.getQuarkusAppVersion;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+
+import io.quarkus.test.bootstrap.QuarkusCliClient;
+import io.quarkus.test.bootstrap.QuarkusCliRestService;
+import io.quarkus.test.logging.Log;
+
+/**
+ * AppManager designed to update app to specific quarkus-bom version, instead of to stream as DefaultQuarkusCLIAppManager.
+ */
+public class RHBQPlatformAppManager extends DefaultQuarkusCLIAppManager {
+    protected final DefaultArtifactVersion newPlatformVersion;
+
+    public RHBQPlatformAppManager(QuarkusCliClient cliClient, DefaultArtifactVersion oldStreamVersion,
+            DefaultArtifactVersion newStreamVersion, DefaultArtifactVersion newPlatformVersion) {
+        super(cliClient, oldStreamVersion, newStreamVersion);
+        this.newPlatformVersion = newPlatformVersion;
+    }
+
+    @Override
+    public void updateApp(QuarkusCliRestService app) {
+        Log.info("Updating app to version: " + newPlatformVersion);
+        app.update(defaultUpdate()
+                .withPlatformVersion(newPlatformVersion.toString()));
+    }
+
+    @Override
+    public QuarkusCliRestService createApplication() {
+        return assertIsUsingRHBQ(super.createApplication());
+    }
+
+    @Override
+    public QuarkusCliRestService createApplicationWithExtensions(String... extensions) {
+        return assertIsUsingRHBQ(super.createApplicationWithExtensions(extensions));
+    }
+
+    @Override
+    public QuarkusCliRestService createApplicationWithExtraArgs(String... extraArgs) {
+        return assertIsUsingRHBQ(super.createApplicationWithExtraArgs(extraArgs));
+    }
+
+    private QuarkusCliRestService assertIsUsingRHBQ(QuarkusCliRestService app) {
+        try {
+            // check that created application uses version with "redhat" suffix.
+            assertTrue(getQuarkusAppVersion(app).toString().contains("redhat"),
+                    "Created Quarkus application does not use \"redhat\" version, while should be RHBQ");
+        } catch (IOException | XmlPullParserException e) {
+            throw new RuntimeException(e);
+        }
+        return app;
+    }
+}

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/model/QuarkusProperties.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/model/QuarkusProperties.java
@@ -34,6 +34,10 @@ public final class QuarkusProperties {
 
     }
 
+    public static boolean isRHBQ() {
+        return QuarkusProperties.getVersion().contains("redhat");
+    }
+
     public static String getVersion() {
         return defaultVersionIfEmpty(PLATFORM_VERSION.get());
     }


### PR DESCRIPTION
### Summary

This PR backports following PRs to 1.5.z branch.
- [Added isRHBQ method to check if the version contain string redhat #1294](https://github.com/quarkus-qe/quarkus-test-framework/pull/1294)
- [Add option to CLI ti set community bom if not running RHBQ](#1279)
- [Move RHBQPlatformAppManager to framework](#1303 )

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [X] Backports 
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)