### PR TITLE
Remove `tls-registry` extension from CLI and update management TLS note

### DIFF
--- a/examples/management/src/test/java/io/quarkus/qe/LocalTLSIT.java
+++ b/examples/management/src/test/java/io/quarkus/qe/LocalTLSIT.java
@@ -11,7 +11,7 @@ import io.quarkus.test.services.QuarkusApplication;
 import io.restassured.response.Response;
 
 @QuarkusScenario
-// todo Merge with LocalIT when https://github.com/quarkusio/quarkus/issues/32225 is fixed
+// todo Merge with LocalIT when framework support SSL/TLS on openshift https://github.com/quarkus-qe/quarkus-test-framework/issues/1052
 public class LocalTLSIT {
 
     @QuarkusApplication(certificates = @Certificate(configureManagementInterface = true, configureKeystore = true, useTlsRegistry = false))

--- a/examples/management/src/test/java/io/quarkus/qe/OpenShiftTLSIT.java
+++ b/examples/management/src/test/java/io/quarkus/qe/OpenShiftTLSIT.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Disabled;
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
 @OpenShiftScenario
-@Disabled
-// todo delete when https://github.com/quarkusio/quarkus/issues/32225 is fixed
+@Disabled("https://github.com/quarkus-qe/quarkus-test-framework/issues/1052")
+// todo delete when framework support SSL/TLS on openshift
 public class OpenShiftTLSIT extends LocalTLSIT {
 }

--- a/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/tls/QuarkusTlsCommand.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/tls/QuarkusTlsCommand.java
@@ -39,8 +39,7 @@ public final class QuarkusTlsCommand extends AbstractCliCommand {
 
     private static QuarkusCliClient.CreateApplicationRequest getCreateAppReq() {
         return QuarkusCliClient.CreateApplicationRequest.defaults()
-                // TODO: we can drop 'tls-registry' when https://github.com/quarkusio/quarkus/issues/42751 is fixed
-                .withExtensions("tls-registry", "quarkus-rest");
+                .withExtensions("quarkus-rest");
     }
 
     private static File createTempDir() {


### PR DESCRIPTION
### Summary

- Updating management TLS TODO note as previous issue is fixed, but our FW not support TLS on Openshift yet (https://github.com/quarkus-qe/quarkus-test-framework/issues/1052)
- Removing `tls-registry` extension from default TLS extension as https://github.com/quarkusio/quarkus/issues/42751 is fixed


Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)