### PR TITLE
Fix intermittent issue with test OpenShiftS2iQuickstartUsingDefaultsIT on OCP

### DIFF
--- a/examples/external-applications/src/test/java/io/quarkus/qe/BareMetalQuickstartUsingDefaultsIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/BareMetalQuickstartUsingDefaultsIT.java
@@ -1,11 +1,15 @@
 package io.quarkus.qe;
 
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
 import io.quarkus.test.bootstrap.RestService;
-import io.quarkus.test.scenarios.OpenShiftScenario;
+import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 
-@OpenShiftScenario
-public class OpenShiftS2iQuickstartUsingDefaultsIT extends QuickstartUsingDefaultsIT {
+@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Windows does not support long file paths")
+@QuarkusScenario
+public class BareMetalQuickstartUsingDefaultsIT extends QuickstartUsingDefaultsIT {
 
     @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", contextDir = "getting-started")
     static final RestService app = new RestService();

--- a/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftContainerRegistryQuickstartUsingDefaultsIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftContainerRegistryQuickstartUsingDefaultsIT.java
@@ -1,9 +1,17 @@
 package io.quarkus.qe;
 
+import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
 import io.quarkus.test.scenarios.OpenShiftScenario;
+import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingContainerRegistry)
 public class OpenShiftContainerRegistryQuickstartUsingDefaultsIT extends QuickstartUsingDefaultsIT {
+    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", contextDir = "getting-started")
+    static final RestService app = new RestService();
 
+    @Override
+    protected RestService getApp() {
+        return app;
+    }
 }

--- a/examples/external-applications/src/test/java/io/quarkus/qe/QuickstartUsingDefaultsIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/QuickstartUsingDefaultsIT.java
@@ -2,23 +2,16 @@ package io.quarkus.qe;
 
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 
 import io.quarkus.test.bootstrap.RestService;
-import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 
-@QuarkusScenario
-@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Windows does not support long file paths")
-public class QuickstartUsingDefaultsIT {
+public abstract class QuickstartUsingDefaultsIT {
 
-    @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git", contextDir = "getting-started")
-    static final RestService app = new RestService();
+    protected abstract RestService getApp();
 
     @Test
     public void test() {
-        app.given()
+        getApp().given()
                 .get("/hello")
                 .then()
                 .statusCode(HttpStatus.SC_OK);


### PR DESCRIPTION
### Summary

I think I found the cause of the intermittent issues in jenkins job, it seems there are 2 tests running concurrently: `OpenShiftContainerRegistryQuickstartUsingDefaultsIT` and `OpenShiftS2iQuickstartUsingDefaultsIT`, both using `QuickstartUsingDefaultsIT` and they are sharing or overwriting the same container image in the OpenShift image registry, labeled as app:latest.

Reviewing the logs, I noticed that the timestamps of the two tests overlap.

This overlapping of both tests is likely trying to pull or push the same image. 

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)