### PR TITLE
Fix Picocli warnings and startup and native execution

### DIFF
--- a/examples/picocli/src/test/java/io/quarkus/qe/picocli/HelloWorldIT.java
+++ b/examples/picocli/src/test/java/io/quarkus/qe/picocli/HelloWorldIT.java
@@ -1,7 +1,5 @@
 package io.quarkus.qe.picocli;
 
-import static java.util.concurrent.CompletableFuture.runAsync;
-
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.RestService;
@@ -15,12 +13,10 @@ public class HelloWorldIT {
 
     @QuarkusApplication
     static final RestService app = new RestService()
-            .withProperty("quarkus.args", "helloWorld -n " + NAME)
-            .setAutoStart(false);
+            .withProperty("quarkus.args", "helloWorld -n " + NAME);
 
     @Test
     public void verifyHelloWorldFormatted() {
-        runAsync(app::start);
         String expectedOutput = String.format("Hello %s!", NAME);
         app.logs().assertContains(expectedOutput);
     }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/ProdLocalhostQuarkusApplicationManagedResource.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/ProdLocalhostQuarkusApplicationManagedResource.java
@@ -1,5 +1,7 @@
 package io.quarkus.test.services.quarkus;
 
+import static io.quarkus.test.utils.TestExecutionProperties.rememberThisIsCliApp;
+
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -57,6 +59,7 @@ public class ProdLocalhostQuarkusApplicationManagedResource extends LocalhostQua
             if (property.contains(QUARKUS_ARGS_PROPERTY_NAME)) {
                 propertiesIt.remove();
                 args = property.replace("-D" + QUARKUS_ARGS_PROPERTY_NAME + "=", "").split(" ");
+                rememberThisIsCliApp(this.getContext());
                 break;
             }
         }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/utils/TestExecutionProperties.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/utils/TestExecutionProperties.java
@@ -1,6 +1,7 @@
 package io.quarkus.test.utils;
 
 import io.quarkus.test.bootstrap.Service;
+import io.quarkus.test.bootstrap.ServiceContext;
 import io.quarkus.test.configuration.PropertyLookup;
 import io.quarkus.test.services.quarkus.model.QuarkusProperties;
 
@@ -14,6 +15,8 @@ public final class TestExecutionProperties {
     private static final String DEFAULT_SERVICE_NAME = "quarkus_test_framework";
     private static final String DEFAULT_BUILD_NUMBER = "777-default";
     private static final TestExecutionProperties INSTANCE = new TestExecutionProperties();
+    private static final String CLI_APP_PROPERTY_KEY = "ts-internal.is-cli-app";
+    private static final String APP_STARTED_KEY = "ts-internal.app-started";
 
     private final String serviceName;
     private final String buildNumber;
@@ -56,4 +59,21 @@ public final class TestExecutionProperties {
     public static boolean useManagementSsl(Service service) {
         return service.getProperty(MANAGEMENT_INTERFACE_ENABLED).map(Boolean::parseBoolean).orElse(false);
     }
+
+    public static void rememberThisIsCliApp(ServiceContext context) {
+        context.put(CLI_APP_PROPERTY_KEY, Boolean.TRUE.toString());
+    }
+
+    public static boolean isThisCliApp(ServiceContext context) {
+        return Boolean.parseBoolean(context.get(CLI_APP_PROPERTY_KEY));
+    }
+
+    public static boolean isThisStartedCliApp(ServiceContext context) {
+        return isThisCliApp(context) && Boolean.parseBoolean(context.get(APP_STARTED_KEY));
+    }
+
+    public static void rememberThisAppStarted(ServiceContext context) {
+        context.put(APP_STARTED_KEY, Boolean.TRUE.toString());
+    }
+
 }


### PR DESCRIPTION
### Summary

So far when we run Picocli apps we have experienced:

- we need to call `BaseService::start` async because the app never gets ready
- there are strange warnings `WARNING Exception reading file log file` because log file doesn't exist
- native execution fails in some cases (like in the QE TS, see daily builds)

This PR fixes that. I have tested it with changes that I pushed into this PR https://github.com/quarkus-qe/quarkus-test-suite/pull/2043.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)