### PR TITLE
Set memory limit for Keycloak container

### DIFF
--- a/quarkus-test-service-keycloak/src/main/java/io/quarkus/test/services/KeycloakContainer.java
+++ b/quarkus-test-service-keycloak/src/main/java/io/quarkus/test/services/KeycloakContainer.java
@@ -22,5 +22,7 @@ public @interface KeycloakContainer {
 
     String[] command() default {};
 
+    long memoryLimitMiB() default 1000;
+
     Class<? extends ManagedResourceBuilder> builder() default KeycloakContainerManagedResourceBuilder.class;
 }

--- a/quarkus-test-service-keycloak/src/main/java/io/quarkus/test/services/containers/KeycloakContainerManagedResourceBuilder.java
+++ b/quarkus-test-service-keycloak/src/main/java/io/quarkus/test/services/containers/KeycloakContainerManagedResourceBuilder.java
@@ -18,6 +18,7 @@ public class KeycloakContainerManagedResourceBuilder extends ContainerManagedRes
     private int restPort;
     private String[] command;
     private String expectedLog;
+    private long memoryLimitMiB;
 
     @Override
     protected String getImage() {
@@ -44,6 +45,10 @@ public class KeycloakContainerManagedResourceBuilder extends ContainerManagedRes
         return expectedLog;
     }
 
+    protected Long getMemoryLimitMiB() {
+        return memoryLimitMiB;
+    }
+
     @Override
     public void init(Annotation annotation) {
         KeycloakContainer metadata = (KeycloakContainer) annotation;
@@ -51,6 +56,7 @@ public class KeycloakContainerManagedResourceBuilder extends ContainerManagedRes
         this.restPort = metadata.port();
         this.expectedLog = PropertiesUtils.resolveProperty(metadata.expectedLog());
         this.command = metadata.command();
+        this.memoryLimitMiB = metadata.memoryLimitMiB();
     }
 
     @Override

--- a/quarkus-test-service-keycloak/src/main/java/io/quarkus/test/services/containers/KeycloakGenericDockerContainerManagedResource.java
+++ b/quarkus-test-service-keycloak/src/main/java/io/quarkus/test/services/containers/KeycloakGenericDockerContainerManagedResource.java
@@ -1,5 +1,7 @@
 package io.quarkus.test.services.containers;
 
+import java.util.Optional;
+
 import org.apache.commons.lang3.StringUtils;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
@@ -38,6 +40,8 @@ public class KeycloakGenericDockerContainerManagedResource extends GenericDocker
         }
 
         container.withCreateContainerCmdModifier(cmd -> cmd.withName(DockerUtils.generateDockerContainerName()));
+        container.withCreateContainerCmdModifier(cmd -> Optional.ofNullable(cmd.getHostConfig())
+                .ifPresent(config -> config.withMemory(convertMiBtoBytes(model.getMemoryLimitMiB()))));
 
         if (isReusable()) {
             Log.info(model.getContext().getOwner(), "Running container on Reusable mode");
@@ -65,5 +69,10 @@ public class KeycloakGenericDockerContainerManagedResource extends GenericDocker
 
     private boolean isPrivileged() {
         return model.getContext().getOwner().getConfiguration().isTrue(PRIVILEGED_MODE);
+    }
+
+    static long convertMiBtoBytes(long valueInMiB) {
+        final var exponentMiB = 20;
+        return (long) (valueInMiB * Math.pow(2, exponentMiB));
     }
 }

--- a/quarkus-test-service-keycloak/src/test/java/io/quarkus/test/services/containers/MemoryLimitTest.java
+++ b/quarkus-test-service-keycloak/src/test/java/io/quarkus/test/services/containers/MemoryLimitTest.java
@@ -1,0 +1,40 @@
+package io.quarkus.test.services.containers;
+
+import static io.quarkus.test.services.containers.KeycloakGenericDockerContainerManagedResource.convertMiBtoBytes;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.Test;
+
+public class MemoryLimitTest {
+
+    @Test
+    void convertMiBToBytes() {
+        assertThat(convertMiBtoBytes(0), CoreMatchers.is(0L));
+        assertThat(convertMiBtoBytes(-0), CoreMatchers.is(0L));
+
+        assertThat(convertMiBtoBytes(1000L), CoreMatchers.is(1048576000L));
+        assertThat(convertMiBtoBytes(1000), CoreMatchers.is(1048576000L));
+        assertThat(convertMiBtoBytes(100), CoreMatchers.is(104857600L));
+        assertThat(convertMiBtoBytes(10), CoreMatchers.is(10485760L));
+        assertThat(convertMiBtoBytes(1), CoreMatchers.is(1048576L));
+
+        assertThat(convertMiBtoBytes(-1000L), CoreMatchers.is(-1048576000L));
+        assertThat(convertMiBtoBytes(-1000), CoreMatchers.is(-1048576000L));
+        assertThat(convertMiBtoBytes(-100), CoreMatchers.is(-104857600L));
+        assertThat(convertMiBtoBytes(-10), CoreMatchers.is(-10485760L));
+        assertThat(convertMiBtoBytes(-1), CoreMatchers.is(-1048576L));
+
+        assertThat(convertMiBtoBytes(2000), CoreMatchers.is(2097152000L));
+        assertThat(convertMiBtoBytes(20000), CoreMatchers.is(20971520000L));
+        assertThat(convertMiBtoBytes(200000), CoreMatchers.is(209715200000L));
+
+        assertThat(convertMiBtoBytes(999999999999999999L), CoreMatchers.is(Long.MAX_VALUE));
+
+        assertThat(convertMiBtoBytes(Integer.MAX_VALUE), CoreMatchers.is((long) Integer.MAX_VALUE << 20));
+        assertThat(convertMiBtoBytes(Integer.MIN_VALUE), CoreMatchers.is((long) Integer.MIN_VALUE << 20));
+
+        assertThat(convertMiBtoBytes(Long.MAX_VALUE), CoreMatchers.is(Long.MAX_VALUE));
+        assertThat(convertMiBtoBytes(Long.MIN_VALUE), CoreMatchers.is(Long.MIN_VALUE));
+    }
+}


### PR DESCRIPTION
Closes #1350

### Summary

(Summarize the problem solved by this PR, and how to verify it manually)

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)

----------------------------------------------------------

I'd propose increasing the memory limit (to 1GiB) for Keycloak instance running in a container for the test suite, as it might be more memory-consuming than the Keycloak dev service: https://github.com/quarkusio/quarkus/pull/43601

Container limit is properly used in `quarkus-test-suite` project: 
```
ID            NAME        CPU %       MEM USAGE / LIMIT  MEM %       NET IO        BLOCK IO           PIDS        CPU TIME      AVG CPU %
4521d014fec2  149223041   455.88%     548.9MB / 1.049GB  52.35%      1.5kB / 698B  185.4MB / 1.827MB  56          1m54.708381s  495.01%
```

The solution works as expected for my experiments.

It should close issue: https://github.com/quarkusio/quarkus/issues/43630

But these changes should be probably backported to the `quarkus-test-framework:1.5.x` (or not sure what approach is used in such scenarios).

cc: @jcarranzan


