### PR TITLE
Always use dependency version managed by BOM when forced dependency version is not specified

### DIFF
--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/Dependency.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/Dependency.java
@@ -8,6 +8,7 @@ import java.lang.annotation.Target;
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Dependency {
+
     String groupId() default "";
 
     String artifactId();

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/ProdQuarkusApplicationManagedResourceBuilder.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/ProdQuarkusApplicationManagedResourceBuilder.java
@@ -1,5 +1,6 @@
 package io.quarkus.test.services.quarkus;
 
+import static io.quarkus.test.services.quarkus.QuarkusMavenPluginBuildHelper.findJvmArtifact;
 import static io.quarkus.test.services.quarkus.QuarkusMavenPluginBuildHelper.findNativeBuildExecutable;
 import static io.quarkus.test.utils.FileUtils.findTargetFile;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -32,10 +33,6 @@ public class ProdQuarkusApplicationManagedResourceBuilder extends ArtifactQuarku
     static final String NATIVE_RUNNER = "-runner";
     static final String EXE = ".exe";
     static final String TARGET = "target";
-
-    private static final String JVM_RUNNER = "-runner.jar";
-    private static final String QUARKUS_APP = "quarkus-app";
-    private static final String QUARKUS_RUN = "quarkus-run.jar";
 
     private final ServiceLoader<QuarkusApplicationManagedResourceBinding> managedResourceBindingsRegistry = ServiceLoader
             .load(QuarkusApplicationManagedResourceBinding.class);
@@ -119,8 +116,7 @@ public class ProdQuarkusApplicationManagedResourceBuilder extends ArtifactQuarku
                 // custom native executable has different name, therefore we can safely re-use it
                 artifactLocation = findNativeBuildExecutable(targetFolder, requiresCustomBuild(), getApplicationFolder());
             } else if (!requiresCustomBuild()) {
-                artifactLocation = findTargetFile(targetFolder, JVM_RUNNER)
-                        .or(() -> findTargetFile(targetFolder.resolve(QUARKUS_APP), QUARKUS_RUN));
+                artifactLocation = findJvmArtifact(targetFolder);
             }
         }
 
@@ -139,6 +135,9 @@ public class ProdQuarkusApplicationManagedResourceBuilder extends ArtifactQuarku
                                 """);
                         return buildArtifactUsingQuarkusBootstrap();
                     });
+        }
+        if (!getForcedDependencies().isEmpty()) {
+            return new QuarkusMavenPluginBuildHelper(this, getTargetFolderForLocalArtifacts()).jvmModeBuild();
         }
         return buildArtifactUsingQuarkusBootstrap();
     }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusApplicationManagedResourceBuilder.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusApplicationManagedResourceBuilder.java
@@ -25,7 +25,6 @@ import java.util.stream.Stream;
 
 import org.apache.commons.lang3.StringUtils;
 
-import io.quarkus.builder.Version;
 import io.quarkus.deployment.configuration.BuildTimeConfigurationReader;
 import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.maven.dependency.ArtifactDependency;
@@ -217,11 +216,18 @@ public abstract class QuarkusApplicationManagedResourceBuilder implements Manage
             requiresCustomBuild = true;
             this.forcedDependencies = Stream.of(forcedDependencies).map(d -> {
                 String groupId = StringUtils.defaultIfEmpty(resolveProperty(d.groupId()), QUARKUS_GROUP_ID_DEFAULT);
-                String version = StringUtils.defaultIfEmpty(resolveProperty(d.version()), Version.getVersion());
+                String version = getVersion(d);
                 ArtifactCoords artifactCoords = ArtifactCoords.jar(groupId, d.artifactId(), version);
                 return new ArtifactDependency(artifactCoords, DEPENDENCY_SCOPE_DEFAULT, DEPENDENCY_DIRECT_FLAG);
             }).collect(Collectors.toList());
         }
+    }
+
+    private static String getVersion(Dependency dependency) {
+        if (dependency.version() == null || dependency.version().isEmpty()) {
+            return null;
+        }
+        return resolveProperty(dependency.version());
     }
 
     protected void configureLogging() {


### PR DESCRIPTION
### Summary

Fixes CI in the https://github.com/quarkus-qe/quarkus-test-suite/pull/2072. So far when a dependency version is empty we set there Quarkus version. That I think is less desirable then using managed version and we know that Quarkus extensions are managed by the BOM, so for our use cases shouldn't be breaking change. Additionally, this change allows to use managed version of forced dependencies that are not Quarkus extensions.

Changes in this PR:

- when forced dependencies were detected, always use Quarkus Maven plugin build strategy
- when version is not specified, always use dependency version managed by BOM

I have tested successfully this PR with all the tests that use this feature (`io.quarkus.test.services.QuarkusApplication#dependencies`).

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)