### PR TITLE
Fix file separator used by Quarkus Maven Plugin build strategy when custom files are added to be platform independent

### DIFF
--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusMavenPluginBuildHelper.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusMavenPluginBuildHelper.java
@@ -9,6 +9,7 @@ import static io.quarkus.test.services.quarkus.model.QuarkusProperties.PLUGIN_VE
 import static io.quarkus.test.services.quarkus.model.QuarkusProperties.getPluginVersion;
 import static io.quarkus.test.services.quarkus.model.QuarkusProperties.getVersion;
 import static io.quarkus.test.utils.FileUtils.findTargetFile;
+import static io.quarkus.test.utils.PropertiesUtils.SLASH;
 import static io.quarkus.test.utils.PropertiesUtils.toMvnSystemProperty;
 import static java.util.stream.Collectors.toSet;
 import static java.util.stream.Collectors.toUnmodifiableSet;
@@ -357,9 +358,9 @@ class QuarkusMavenPluginBuildHelper {
             // 2. copy them to the new source dir
             if (!testDirAppClassesPaths.isEmpty()) {
                 String normalizedTestSourceDirPath = testSourceDir.toAbsolutePath().normalize().toString();
-                if (!normalizedTestSourceDirPath.endsWith("/")) {
+                if (!normalizedTestSourceDirPath.endsWith(SLASH)) {
                     // this prevents situation when test app file sub-path starts with a '/'
-                    normalizedTestSourceDirPath += "/";
+                    normalizedTestSourceDirPath += SLASH;
                 }
                 for (Path appFilePath : testDirAppClassesPaths) {
                     String normalizedAppFileDirPath = appFilePath.getParent().toAbsolutePath().normalize().toString();


### PR DESCRIPTION
### Summary

Hibernate Validator tests are failing as after we always use Quarkus Maven plugin build strategy for tests with forced dependencies, but file separator was hardcoded to the forward slash.

See failure: https://github.com/quarkus-qe/quarkus-test-suite/pull/2074

I didn't test it on Windows, it would be more work than gain. This FW already runs tests on Windows with this strategy, because it was introduced exactly to fix race on Windows, so I hope there is reasonable expectation it will help.

```
2024-10-09T12:48:29.4819745Z java.lang.IllegalStateException: Merging algorithm doesn't work correctly. Java test file 'D:\a\quarkus-test-suite\quarkus-test-suite\http\hibernate-validator\src\test\java\io\quarkus\ts\http\hibernate\validator\sources' does not belong to the 'D:\a\quarkus-test-suite\quarkus-test-suite\http\hibernate-validator\src\test\java/' folder.
2024-10-09T12:48:29.4833600Z 	at io.quarkus.test.services.quarkus.QuarkusMavenPluginBuildHelper.addAppClassesToSrcMain(QuarkusMavenPluginBuildHelper.java:367)
2024-10-09T12:48:29.4836040Z 	at io.quarkus.test.services.quarkus.QuarkusMavenPluginBuildHelper.prepareMavenProject(QuarkusMavenPluginBuildHelper.java:143)
2024-10-09T12:48:29.4838635Z 	at io.quarkus.test.services.quarkus.QuarkusMavenPluginBuildHelper.buildArtifact(QuarkusMavenPluginBuildHelper.java:164)
2024-10-09T12:48:29.5018165Z 	at io.quarkus.test.services.quarkus.QuarkusMavenPluginBuildHelper.jvmModeBuild(QuarkusMavenPluginBuildHelper.java:152)
2024-10-09T12:48:29.5020782Z 	at io.quarkus.test.services.quarkus.ProdQuarkusApplicationManagedResourceBuilder.buildArtifact(ProdQuarkusApplicationManagedResourceBuilder.java:140)
2024-10-09T12:48:29.5022736Z 	at java.base/java.util.Optional.orElseGet(Optional.java:364)
2024-10-09T12:48:29.5025114Z 	at io.quarkus.test.services.quarkus.ProdQuarkusApplicationManagedResourceBuilder.tryToReuseOrBuildArtifact(ProdQuarkusApplicationManagedResourceBuilder.java:123)
2024-10-09T12:48:29.5027959Z 	at io.quarkus.test.services.quarkus.ProdQuarkusApplicationManagedResourceBuilder.build(ProdQuarkusApplicationManagedResourceBuilder.java:83)
2024-10-09T12:48:29.5030650Z 	at io.quarkus.test.services.quarkus.ProdQuarkusApplicationManagedResourceBuilder.build(ProdQuarkusApplicationManagedResourceBuilder.java:74)
2024-10-09T12:48:29.5032465Z 	at io.quarkus.test.bootstrap.BaseService.init(BaseService.java:323)
2024-10-09T12:48:29.5033846Z 	at io.quarkus.test.bootstrap.QuarkusScenarioBootstrap.initService(QuarkusScenarioBootstrap.java:235)
2024-10-09T12:48:29.5035651Z 	at io.quarkus.test.bootstrap.QuarkusScenarioBootstrap.initResourceFromField(QuarkusScenarioBootstrap.java:202)
2024-10-09T12:48:29.5074158Z 	at io.quarkus.test.bootstrap.QuarkusScenarioBootstrap.lambda$beforeAll$1(QuarkusScenarioBootstrap.java:64)
2024-10-09T12:48:29.5075637Z 	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
2024-10-09T12:48:29.5076959Z 	at io.quarkus.test.bootstrap.QuarkusScenarioBootstrap.beforeAll(QuarkusScenarioBootstrap.java:64)
2024-10-09T12:48:29.5078621Z 	at io.quarkus.test.bootstrap.QuarkusScenarioBootstrap.beforeAll(QuarkusScenarioBootstrap.java:50)
2024-10-09T12:48:29.5079942Z 	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
```

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)