### PR TITLE
[1.5.z] Fix file separator used on Windows by Quarkus Mvn plugin strategy

### DIFF
--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusMavenPluginBuildHelper.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusMavenPluginBuildHelper.java
@@ -9,6 +9,7 @@ import static io.quarkus.test.services.quarkus.model.QuarkusProperties.PLUGIN_VE
 import static io.quarkus.test.services.quarkus.model.QuarkusProperties.getPluginVersion;
 import static io.quarkus.test.services.quarkus.model.QuarkusProperties.getVersion;
 import static io.quarkus.test.utils.FileUtils.findTargetFile;
+import static io.quarkus.test.utils.PropertiesUtils.SLASH;
 import static io.quarkus.test.utils.PropertiesUtils.toMvnSystemProperty;
 import static java.util.stream.Collectors.toSet;
 import static java.util.stream.Collectors.toUnmodifiableSet;
@@ -357,9 +358,9 @@ class QuarkusMavenPluginBuildHelper {
             // 2. copy them to the new source dir
             if (!testDirAppClassesPaths.isEmpty()) {
                 String normalizedTestSourceDirPath = testSourceDir.toAbsolutePath().normalize().toString();
-                if (!normalizedTestSourceDirPath.endsWith("/")) {
+                if (!normalizedTestSourceDirPath.endsWith(SLASH)) {
                     // this prevents situation when test app file sub-path starts with a '/'
-                    normalizedTestSourceDirPath += "/";
+                    normalizedTestSourceDirPath += SLASH;
                 }
                 for (Path appFilePath : testDirAppClassesPaths) {
                     String normalizedAppFileDirPath = appFilePath.getParent().toAbsolutePath().normalize().toString();


### PR DESCRIPTION
### Summary

backports https://github.com/quarkus-qe/quarkus-test-framework/pull/1362

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [x] Backports
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)