### PR TITLE
[1.5.z] Add DisabledOnAarch64Native annotation

### DIFF
--- a/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/annotations/DisabledOnAarch64Native.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/annotations/DisabledOnAarch64Native.java
@@ -1,0 +1,20 @@
+package io.quarkus.test.scenarios.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Inherited
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(DisabledOnAarch64NativeCondition.class)
+public @interface DisabledOnAarch64Native {
+    /**
+     * Why is the annotated test class or test method disabled.
+     */
+    String reason() default "";
+}

--- a/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/annotations/DisabledOnAarch64NativeCondition.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/annotations/DisabledOnAarch64NativeCondition.java
@@ -1,0 +1,26 @@
+package io.quarkus.test.scenarios.annotations;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import io.quarkus.test.services.quarkus.model.QuarkusProperties;
+
+public class DisabledOnAarch64NativeCondition implements ExecutionCondition {
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+        /*
+         * This only triggers, if test executor is running on aarch64.
+         * e.g. It doesn't work if test executor is amd64 and targeted OCP cluster is aarch.
+         * But for native this should not be a problem, since native images has to be built on aarch and then exectued on aarch.
+         */
+        boolean isAarch64 = System.getProperty("os.arch").toLowerCase().trim().equals("aarch64");
+        boolean isNative = QuarkusProperties.isNativeEnabled();
+
+        if (isAarch64 && isNative) {
+            return ConditionEvaluationResult.disabled("Skipping test as it's not running on aarch64 native");
+        }
+
+        return ConditionEvaluationResult.enabled("Running test as it's running on aarch64 native");
+    }
+}


### PR DESCRIPTION
### Summary

Backports https://github.com/quarkus-qe/quarkus-test-framework/pull/1365.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [x] Backport
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)