### PR TITLE
Add propagation of `maven.repo.local` on windows machine

### DIFF
--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusMavenPluginBuildHelper.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusMavenPluginBuildHelper.java
@@ -9,6 +9,7 @@ import static io.quarkus.test.services.quarkus.model.QuarkusProperties.PLUGIN_VE
 import static io.quarkus.test.services.quarkus.model.QuarkusProperties.getPluginVersion;
 import static io.quarkus.test.services.quarkus.model.QuarkusProperties.getVersion;
 import static io.quarkus.test.utils.FileUtils.findTargetFile;
+import static io.quarkus.test.utils.MavenUtils.MVN_REPOSITORY_LOCAL;
 import static io.quarkus.test.utils.PropertiesUtils.SLASH;
 import static io.quarkus.test.utils.PropertiesUtils.toMvnSystemProperty;
 import static java.util.stream.Collectors.toSet;
@@ -237,6 +238,12 @@ class QuarkusMavenPluginBuildHelper {
                 toMvnSystemProperty(PLATFORM_VERSION.getPropertyKey(), getVersion()),
                 toMvnSystemProperty(PLATFORM_GROUP_ID.getPropertyKey(), PLATFORM_GROUP_ID.get()),
                 toMvnSystemProperty(PLUGIN_VERSION.getPropertyKey(), getPluginVersion())));
+
+        // Need to add local maven repo due to differences in `getCmdLineBuildArgs` as by default it's not picked on Windows
+        if (OS.WINDOWS.isCurrent() && System.getProperty(MVN_REPOSITORY_LOCAL) != null) {
+            cmdStream = Stream.concat(cmdStream,
+                    Stream.of(toMvnSystemProperty(MVN_REPOSITORY_LOCAL, System.getProperty(MVN_REPOSITORY_LOCAL))));
+        }
         var cmdLineBuildArgs = getCmdLineBuildArgs();
         if (!cmdLineBuildArgs.isEmpty()) {
             cmdStream = Stream.concat(cmdStream, cmdLineBuildArgs.stream());


### PR DESCRIPTION
### Summary

In case of linux we propagating all build arguments which also contains `maven.repo.local`.
This is not case on windows where we getting only specific set of them (starts with quarkus).
When #1359 was introducedThe build start separatly using maven. But when provided path to local maven repo was set as cmd argument and the artifact is not public, causing the windows failing the build of app with that forced artifact.

Tested it localy on win and it's working.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)