### PR TITLE
Move DisabledOnRHBQWindowsConditions from testsuite to framework

### DIFF
--- a/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/annotations/DisabledOnRHBQWindowsConditions.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/annotations/DisabledOnRHBQWindowsConditions.java
@@ -1,0 +1,21 @@
+package io.quarkus.test.scenarios.annotations;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import io.quarkus.test.services.quarkus.model.QuarkusProperties;
+import io.smallrye.common.os.OS;
+
+public class DisabledOnRHBQWindowsConditions implements ExecutionCondition {
+
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext extensionContext) {
+        boolean isWindows = OS.current().equals(OS.WINDOWS);
+        if (QuarkusProperties.isRHBQ() && isWindows) {
+            return ConditionEvaluationResult.disabled("It is RHBQ on Windows");
+        } else {
+            return ConditionEvaluationResult.enabled("It is not RHBQ on Windows");
+        }
+    }
+}

--- a/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/annotations/DisabledOnRHBQandWindows.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/annotations/DisabledOnRHBQandWindows.java
@@ -1,0 +1,21 @@
+package io.quarkus.test.scenarios.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Inherited
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(DisabledOnRHBQWindowsConditions.class)
+public @interface DisabledOnRHBQandWindows {
+
+    /**
+     * Why is the annotated test class or test method disabled.
+     */
+    String reason();
+}


### PR DESCRIPTION
### Summary

Moving the `DisabledOnRHBQandWindows` from testsuite to framework. This anotation to disable test is available only [here](https://github.com/quarkus-qe/quarkus-test-suite/blob/main/messaging/kafka-streams-reactive-messaging/src/test/java/io/quarkus/ts/messaging/kafka/reactive/streams/DisabledOnRHBQandWindows.java) in my POV it's better to have it defined in framework as it can be used on multiple places. 

My motivation: I need to disable snappy test on windows which failing only with RHBQ.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)