### PR TITLE
Add closing resources in quarkus cli as windows is more strict

### DIFF
--- a/quarkus-test-cli/src/main/java/io/quarkus/test/util/QuarkusCLIUtils.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/util/QuarkusCLIUtils.java
@@ -196,8 +196,10 @@ public abstract class QuarkusCLIUtils {
 
     public static Properties loadPropertiesFromFile(File file) throws IOException {
         Properties properties = new Properties();
-        properties.load(new FileInputStream(file));
-        return properties;
+        try (FileInputStream is = new FileInputStream(file)) {
+            properties.load(is);
+            return properties;
+        }
     }
 
     public static File getPropertiesFile(QuarkusCliRestService app) {
@@ -312,13 +314,15 @@ public abstract class QuarkusCLIUtils {
     public static Model getPom(QuarkusCliRestService app, String subdir) throws IOException, XmlPullParserException {
         File pomfile = app.getFileFromApplication(subdir, POM_FILE);
         MavenXpp3Reader mavenReader = new MavenXpp3Reader();
-        XmlStreamReader streamReader = new XmlStreamReader(pomfile);
-        return mavenReader.read(streamReader);
+        try (XmlStreamReader streamReader = new XmlStreamReader(pomfile)) {
+            return mavenReader.read(streamReader);
+        }
     }
 
     public static void savePom(QuarkusCliRestService app, Model model) throws IOException {
-        OutputStream output = new FileOutputStream(app.getFileFromApplication(POM_FILE));
-        new MavenXpp3Writer().write(output, model);
+        try (OutputStream output = new FileOutputStream(app.getFileFromApplication(POM_FILE))) {
+            new MavenXpp3Writer().write(output, model);
+        }
     }
 
     /**

--- a/quarkus-test-cli/src/main/java/io/quarkus/test/util/YamlPropertiesHandler.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/util/YamlPropertiesHandler.java
@@ -5,7 +5,6 @@ import static org.apache.maven.surefire.shared.lang3.StringUtils.isBlank;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.Collection;
@@ -22,14 +21,16 @@ public abstract class YamlPropertiesHandler {
         yaml.dump(properties, new FileWriter(yamlFile));
     }
 
-    public static Properties readYamlFileIntoProperties(File yamlFile) throws FileNotFoundException {
+    public static Properties readYamlFileIntoProperties(File yamlFile) throws IOException {
         Yaml yaml = new Yaml();
-        Map<String, Object> obj = yaml.load(new FileInputStream(yamlFile));
+        try (FileInputStream is = new FileInputStream(yamlFile)) {
+            Map<String, Object> obj = yaml.load(is);
 
-        Properties properties = new Properties();
-        properties.putAll(getFlattenedMap(obj));
+            Properties properties = new Properties();
+            properties.putAll(getFlattenedMap(obj));
 
-        return properties;
+            return properties;
+        }
     }
 
     private static Map<String, Object> getFlattenedMap(Map<String, Object> source) {


### PR DESCRIPTION
### Summary

When running update tes coverage on windows, the resources were not closed and blocking deletion of file and directories. Probably Windows is more strict on this that this was not caught on Linux.

Also even if I dind't see any usage of `readYamlFileIntoProperties` (actual method which use it is `checkYamlPropertiesUpdate` but didn't find it in framework or testsuite). I also add try-with-resources for it as it can be problematic in future.

Tested it localy on AWS windows

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)