### PR TITLE
Add @DisabledOnFipsAndNative annotation and drop @DisabledOnFipsAndJava17

### DIFF
--- a/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/annotations/DisabledOnFipsAndNative.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/annotations/DisabledOnFipsAndNative.java
@@ -11,8 +11,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @Inherited
 @Target({ ElementType.TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
-@ExtendWith(DisabledOnFipsAndJava17Condition.class)
-public @interface DisabledOnFipsAndJava17 {
+@ExtendWith(DisabledOnFipsAndNativeCondition.class)
+public @interface DisabledOnFipsAndNative {
     /**
      * Why is the annotated test class or test method disabled.
      */

--- a/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/annotations/DisabledOnFipsAndNativeCondition.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/annotations/DisabledOnFipsAndNativeCondition.java
@@ -1,31 +1,29 @@
 package io.quarkus.test.scenarios.annotations;
 
+import static io.quarkus.test.services.quarkus.model.QuarkusProperties.isNativeEnabled;
+
 import org.junit.jupiter.api.extension.ConditionEvaluationResult;
 import org.junit.jupiter.api.extension.ExecutionCondition;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
-public class DisabledOnFipsAndJava17Condition implements ExecutionCondition {
+public class DisabledOnFipsAndNativeCondition implements ExecutionCondition {
 
     /**
      * We set environment variable "FIPS" to "fips" in our Jenkins jobs when FIPS are enabled.
      */
     private static final String FIPS_ENABLED = "fips";
-    private static final int JAVA_17 = 17;
 
     @Override
     public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
-        if (isFipsEnabledEnvironment() && isJava17()) {
-            return ConditionEvaluationResult.disabled("The test is running in FIPS enabled environment with Java 17");
+        if (isFipsEnabledEnvironment() && isNativeEnabled()) {
+            return ConditionEvaluationResult.disabled("The test is running in FIPS enabled environment in native mode");
         }
 
-        return ConditionEvaluationResult.enabled("The test is not running in FIPS enabled environment with Java 17");
+        return ConditionEvaluationResult.enabled("The test is not running in FIPS enabled environment in native mode");
     }
 
     private static boolean isFipsEnabledEnvironment() {
-        return FIPS_ENABLED.equals(System.getenv().get("FIPS"));
+        return FIPS_ENABLED.equalsIgnoreCase(System.getenv().get("FIPS"));
     }
 
-    private static boolean isJava17() {
-        return JAVA_17 == Runtime.version().feature();
-    }
 }


### PR DESCRIPTION
### Summary

- closes https://github.com/quarkus-qe/quarkus-test-framework/issues/1372
- I need to use this annotation a lot in 3.15 as FIPS in native are failing and currently not supported, so this is pressing issue

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)