### PR TITLE
[1.5.z] Backport 23/10/2024

### DIFF
--- a/quarkus-test-cli/src/main/java/io/quarkus/test/util/QuarkusCLIUtils.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/util/QuarkusCLIUtils.java
@@ -196,8 +196,10 @@ public abstract class QuarkusCLIUtils {
 
     public static Properties loadPropertiesFromFile(File file) throws IOException {
         Properties properties = new Properties();
-        properties.load(new FileInputStream(file));
-        return properties;
+        try (FileInputStream is = new FileInputStream(file)) {
+            properties.load(is);
+            return properties;
+        }
     }
 
     public static File getPropertiesFile(QuarkusCliRestService app) {
@@ -312,13 +314,15 @@ public abstract class QuarkusCLIUtils {
     public static Model getPom(QuarkusCliRestService app, String subdir) throws IOException, XmlPullParserException {
         File pomfile = app.getFileFromApplication(subdir, POM_FILE);
         MavenXpp3Reader mavenReader = new MavenXpp3Reader();
-        XmlStreamReader streamReader = new XmlStreamReader(pomfile);
-        return mavenReader.read(streamReader);
+        try (XmlStreamReader streamReader = new XmlStreamReader(pomfile)) {
+            return mavenReader.read(streamReader);
+        }
     }
 
     public static void savePom(QuarkusCliRestService app, Model model) throws IOException {
-        OutputStream output = new FileOutputStream(app.getFileFromApplication(POM_FILE));
-        new MavenXpp3Writer().write(output, model);
+        try (OutputStream output = new FileOutputStream(app.getFileFromApplication(POM_FILE))) {
+            new MavenXpp3Writer().write(output, model);
+        }
     }
 
     /**

--- a/quarkus-test-cli/src/main/java/io/quarkus/test/util/YamlPropertiesHandler.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/util/YamlPropertiesHandler.java
@@ -5,7 +5,6 @@ import static org.apache.maven.surefire.shared.lang3.StringUtils.isBlank;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.Collection;
@@ -22,14 +21,16 @@ public abstract class YamlPropertiesHandler {
         yaml.dump(properties, new FileWriter(yamlFile));
     }
 
-    public static Properties readYamlFileIntoProperties(File yamlFile) throws FileNotFoundException {
+    public static Properties readYamlFileIntoProperties(File yamlFile) throws IOException {
         Yaml yaml = new Yaml();
-        Map<String, Object> obj = yaml.load(new FileInputStream(yamlFile));
+        try (FileInputStream is = new FileInputStream(yamlFile)) {
+            Map<String, Object> obj = yaml.load(is);
 
-        Properties properties = new Properties();
-        properties.putAll(getFlattenedMap(obj));
+            Properties properties = new Properties();
+            properties.putAll(getFlattenedMap(obj));
 
-        return properties;
+            return properties;
+        }
     }
 
     private static Map<String, Object> getFlattenedMap(Map<String, Object> source) {

--- a/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/annotations/DisabledOnFipsAndNative.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/annotations/DisabledOnFipsAndNative.java
@@ -11,8 +11,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @Inherited
 @Target({ ElementType.TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
-@ExtendWith(DisabledOnFipsAndJava17Condition.class)
-public @interface DisabledOnFipsAndJava17 {
+@ExtendWith(DisabledOnFipsAndNativeCondition.class)
+public @interface DisabledOnFipsAndNative {
     /**
      * Why is the annotated test class or test method disabled.
      */

--- a/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/annotations/DisabledOnFipsAndNativeCondition.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/annotations/DisabledOnFipsAndNativeCondition.java
@@ -1,31 +1,29 @@
 package io.quarkus.test.scenarios.annotations;
 
+import static io.quarkus.test.services.quarkus.model.QuarkusProperties.isNativeEnabled;
+
 import org.junit.jupiter.api.extension.ConditionEvaluationResult;
 import org.junit.jupiter.api.extension.ExecutionCondition;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
-public class DisabledOnFipsAndJava17Condition implements ExecutionCondition {
+public class DisabledOnFipsAndNativeCondition implements ExecutionCondition {
 
     /**
      * We set environment variable "FIPS" to "fips" in our Jenkins jobs when FIPS are enabled.
      */
     private static final String FIPS_ENABLED = "fips";
-    private static final int JAVA_17 = 17;
 
     @Override
     public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
-        if (isFipsEnabledEnvironment() && isJava17()) {
-            return ConditionEvaluationResult.disabled("The test is running in FIPS enabled environment with Java 17");
+        if (isFipsEnabledEnvironment() && isNativeEnabled()) {
+            return ConditionEvaluationResult.disabled("The test is running in FIPS enabled environment in native mode");
         }
 
-        return ConditionEvaluationResult.enabled("The test is not running in FIPS enabled environment with Java 17");
+        return ConditionEvaluationResult.enabled("The test is not running in FIPS enabled environment in native mode");
     }
 
     private static boolean isFipsEnabledEnvironment() {
-        return FIPS_ENABLED.equals(System.getenv().get("FIPS"));
+        return FIPS_ENABLED.equalsIgnoreCase(System.getenv().get("FIPS"));
     }
 
-    private static boolean isJava17() {
-        return JAVA_17 == Runtime.version().feature();
-    }
 }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/annotations/DisabledOnRHBQWindowsConditions.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/annotations/DisabledOnRHBQWindowsConditions.java
@@ -1,0 +1,21 @@
+package io.quarkus.test.scenarios.annotations;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import io.quarkus.test.services.quarkus.model.QuarkusProperties;
+import io.smallrye.common.os.OS;
+
+public class DisabledOnRHBQWindowsConditions implements ExecutionCondition {
+
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext extensionContext) {
+        boolean isWindows = OS.current().equals(OS.WINDOWS);
+        if (QuarkusProperties.isRHBQ() && isWindows) {
+            return ConditionEvaluationResult.disabled("It is RHBQ on Windows");
+        } else {
+            return ConditionEvaluationResult.enabled("It is not RHBQ on Windows");
+        }
+    }
+}

--- a/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/annotations/DisabledOnRHBQandWindows.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/annotations/DisabledOnRHBQandWindows.java
@@ -1,0 +1,21 @@
+package io.quarkus.test.scenarios.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Inherited
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(DisabledOnRHBQWindowsConditions.class)
+public @interface DisabledOnRHBQandWindows {
+
+    /**
+     * Why is the annotated test class or test method disabled.
+     */
+    String reason();
+}

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusMavenPluginBuildHelper.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusMavenPluginBuildHelper.java
@@ -9,6 +9,7 @@ import static io.quarkus.test.services.quarkus.model.QuarkusProperties.PLUGIN_VE
 import static io.quarkus.test.services.quarkus.model.QuarkusProperties.getPluginVersion;
 import static io.quarkus.test.services.quarkus.model.QuarkusProperties.getVersion;
 import static io.quarkus.test.utils.FileUtils.findTargetFile;
+import static io.quarkus.test.utils.MavenUtils.MVN_REPOSITORY_LOCAL;
 import static io.quarkus.test.utils.PropertiesUtils.SLASH;
 import static io.quarkus.test.utils.PropertiesUtils.toMvnSystemProperty;
 import static java.util.stream.Collectors.toSet;
@@ -237,6 +238,12 @@ class QuarkusMavenPluginBuildHelper {
                 toMvnSystemProperty(PLATFORM_VERSION.getPropertyKey(), getVersion()),
                 toMvnSystemProperty(PLATFORM_GROUP_ID.getPropertyKey(), PLATFORM_GROUP_ID.get()),
                 toMvnSystemProperty(PLUGIN_VERSION.getPropertyKey(), getPluginVersion())));
+
+        // Need to add local maven repo due to differences in `getCmdLineBuildArgs` as by default it's not picked on Windows
+        if (OS.WINDOWS.isCurrent() && System.getProperty(MVN_REPOSITORY_LOCAL) != null) {
+            cmdStream = Stream.concat(cmdStream,
+                    Stream.of(toMvnSystemProperty(MVN_REPOSITORY_LOCAL, System.getProperty(MVN_REPOSITORY_LOCAL))));
+        }
         var cmdLineBuildArgs = getCmdLineBuildArgs();
         if (!cmdLineBuildArgs.isEmpty()) {
             cmdStream = Stream.concat(cmdStream, cmdLineBuildArgs.stream());


### PR DESCRIPTION
### Summary

Backport contains:
- https://github.com/quarkus-qe/quarkus-test-framework/pull/1373
- https://github.com/quarkus-qe/quarkus-test-framework/pull/1377
- https://github.com/quarkus-qe/quarkus-test-framework/pull/1378
- https://github.com/quarkus-qe/quarkus-test-framework/pull/1380

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [x] Backport
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)