### PR TITLE
Extend service start timeout to 7 minutes

### DIFF
--- a/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftS2iQuickstartUsingDefaultsIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftS2iQuickstartUsingDefaultsIT.java
@@ -2,8 +2,10 @@ package io.quarkus.qe;
 
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
+import io.quarkus.test.scenarios.annotations.DisabledOnNative;
 import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 
+@DisabledOnNative(reason = "https://github.com/quarkusio/quarkus/issues/44142")
 @OpenShiftScenario
 public class OpenShiftS2iQuickstartUsingDefaultsIT extends QuickstartUsingDefaultsIT {
 

--- a/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/BaseService.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/BaseService.java
@@ -34,7 +34,7 @@ import io.quarkus.test.utils.TestExecutionProperties;
 public class BaseService<T extends Service> implements Service {
 
     public static final String SERVICE_STARTUP_TIMEOUT = "startup.timeout";
-    public static final Duration SERVICE_STARTUP_TIMEOUT_DEFAULT = Duration.ofMinutes(5);
+    public static final Duration SERVICE_STARTUP_TIMEOUT_DEFAULT = Duration.ofMinutes(7);
     public static final String DELETE_FOLDER_ON_EXIT = "delete.folder.on.exit";
 
     private static final String SERVICE_STARTUP_CHECK_POLL_INTERVAL = "startup.check-poll-interval";

--- a/quarkus-test-core/src/main/resources/global.properties
+++ b/quarkus-test-core/src/main/resources/global.properties
@@ -11,13 +11,13 @@ ts.global.log.file.output=target/logs
 ## Timeouts ##
 ##############
 # Default startup timeout for services is 5 minutes
-ts.global.startup.timeout=5m
+ts.global.startup.timeout=7m
 # Default startup check poll interval is every 2 seconds
 ts.global.startup.check-poll-interval=2s
 # Default install operator timeout is 10 minutes
 ts.global.operator.install.timeout=10m
 # Default install image stream timeout is 5 minutes
-ts.global.imagestream.install.timeout=5m
+ts.global.imagestream.install.timeout=7m
 # Default timeout factor for all checks
 ts.global.factor.timeout=1
 

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
@@ -102,7 +102,7 @@ public final class OpenShiftClient {
     private static final Logger LOG = Logger.getLogger(OpenShiftClient.class);
     private static final String IMAGE_STREAM_TIMEOUT = "imagestream.install.timeout";
     private static final String OPERATOR_INSTALL_TIMEOUT = "operator.install.timeout";
-    private static final Duration TIMEOUT_DEFAULT = Duration.ofMinutes(5);
+    private static final Duration TIMEOUT_DEFAULT = Duration.ofMinutes(7);
     private static final int PROJECT_NAME_SIZE = 10;
     private static final int PROJECT_CREATION_RETRIES = 5;
     private static final int SPECS_SECRET_NAME_LIMIT = 63;


### PR DESCRIPTION
### Summary

OpenShift build images sometimes are slow to pull that cause test fail

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)