### PR TITLE
Move to next development iteration as there was problem with release job

### DIFF
--- a/examples/amq-amqp/pom.xml
+++ b/examples/amq-amqp/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-examples-parent</artifactId>
-        <version>1.6.0.Beta14</version>
+        <version>1.6.0.Beta15-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>examples-amq-amqp</artifactId>

--- a/examples/amq-amqp/pom.xml
+++ b/examples/amq-amqp/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-examples-parent</artifactId>
-        <version>1.6.0.Beta14-SNAPSHOT</version>
+        <version>1.6.0.Beta14</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>examples-amq-amqp</artifactId>

--- a/examples/amq-tcp/pom.xml
+++ b/examples/amq-tcp/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-examples-parent</artifactId>
-        <version>1.6.0.Beta14-SNAPSHOT</version>
+        <version>1.6.0.Beta14</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>examples-amq-tcp</artifactId>

--- a/examples/amq-tcp/pom.xml
+++ b/examples/amq-tcp/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-examples-parent</artifactId>
-        <version>1.6.0.Beta14</version>
+        <version>1.6.0.Beta15-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>examples-amq-tcp</artifactId>

--- a/examples/blocking-reactive-model/pom.xml
+++ b/examples/blocking-reactive-model/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-examples-parent</artifactId>
-        <version>1.6.0.Beta14</version>
+        <version>1.6.0.Beta15-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>examples-blocking-reactive</artifactId>

--- a/examples/blocking-reactive-model/pom.xml
+++ b/examples/blocking-reactive-model/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-examples-parent</artifactId>
-        <version>1.6.0.Beta14-SNAPSHOT</version>
+        <version>1.6.0.Beta14</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>examples-blocking-reactive</artifactId>

--- a/examples/consul/pom.xml
+++ b/examples/consul/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-examples-parent</artifactId>
-        <version>1.6.0.Beta14-SNAPSHOT</version>
+        <version>1.6.0.Beta14</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>examples-consul</artifactId>

--- a/examples/consul/pom.xml
+++ b/examples/consul/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-examples-parent</artifactId>
-        <version>1.6.0.Beta14</version>
+        <version>1.6.0.Beta15-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>examples-consul</artifactId>

--- a/examples/database-mysql/pom.xml
+++ b/examples/database-mysql/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-examples-parent</artifactId>
-        <version>1.6.0.Beta14</version>
+        <version>1.6.0.Beta15-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>examples-database-mysql</artifactId>

--- a/examples/database-mysql/pom.xml
+++ b/examples/database-mysql/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-examples-parent</artifactId>
-        <version>1.6.0.Beta14-SNAPSHOT</version>
+        <version>1.6.0.Beta14</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>examples-database-mysql</artifactId>

--- a/examples/database-oracle/pom.xml
+++ b/examples/database-oracle/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-examples-parent</artifactId>
-        <version>1.6.0.Beta14-SNAPSHOT</version>
+        <version>1.6.0.Beta14</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>examples-database-oracle</artifactId>

--- a/examples/database-oracle/pom.xml
+++ b/examples/database-oracle/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-examples-parent</artifactId>
-        <version>1.6.0.Beta14</version>
+        <version>1.6.0.Beta15-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>examples-database-oracle</artifactId>

--- a/examples/database-postgresql/pom.xml
+++ b/examples/database-postgresql/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-examples-parent</artifactId>
-        <version>1.6.0.Beta14</version>
+        <version>1.6.0.Beta15-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>examples-database-postgresql</artifactId>

--- a/examples/database-postgresql/pom.xml
+++ b/examples/database-postgresql/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-examples-parent</artifactId>
-        <version>1.6.0.Beta14-SNAPSHOT</version>
+        <version>1.6.0.Beta14</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>examples-database-postgresql</artifactId>

--- a/examples/debug/pom.xml
+++ b/examples/debug/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-examples-parent</artifactId>
-        <version>1.6.0.Beta14</version>
+        <version>1.6.0.Beta15-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>examples-debug</artifactId>

--- a/examples/debug/pom.xml
+++ b/examples/debug/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-examples-parent</artifactId>
-        <version>1.6.0.Beta14-SNAPSHOT</version>
+        <version>1.6.0.Beta14</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>examples-debug</artifactId>

--- a/examples/external-applications/pom.xml
+++ b/examples/external-applications/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-examples-parent</artifactId>
-        <version>1.6.0.Beta14</version>
+        <version>1.6.0.Beta15-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>examples-external-applications</artifactId>

--- a/examples/external-applications/pom.xml
+++ b/examples/external-applications/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-examples-parent</artifactId>
-        <version>1.6.0.Beta14-SNAPSHOT</version>
+        <version>1.6.0.Beta14</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>examples-external-applications</artifactId>

--- a/examples/funqy-knative-events/pom.xml
+++ b/examples/funqy-knative-events/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-examples-parent</artifactId>
-        <version>1.6.0.Beta14</version>
+        <version>1.6.0.Beta15-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>examples-funqy-knative-events</artifactId>

--- a/examples/funqy-knative-events/pom.xml
+++ b/examples/funqy-knative-events/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-examples-parent</artifactId>
-        <version>1.6.0.Beta14-SNAPSHOT</version>
+        <version>1.6.0.Beta14</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>examples-funqy-knative-events</artifactId>

--- a/examples/greetings/pom.xml
+++ b/examples/greetings/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-examples-parent</artifactId>
-        <version>1.6.0.Beta14</version>
+        <version>1.6.0.Beta15-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>examples-greetings</artifactId>

--- a/examples/greetings/pom.xml
+++ b/examples/greetings/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-examples-parent</artifactId>
-        <version>1.6.0.Beta14-SNAPSHOT</version>
+        <version>1.6.0.Beta14</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>examples-greetings</artifactId>

--- a/examples/grpc/pom.xml
+++ b/examples/grpc/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-examples-parent</artifactId>
-        <version>1.6.0.Beta14-SNAPSHOT</version>
+        <version>1.6.0.Beta14</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>examples-grpc</artifactId>

--- a/examples/grpc/pom.xml
+++ b/examples/grpc/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-examples-parent</artifactId>
-        <version>1.6.0.Beta14</version>
+        <version>1.6.0.Beta15-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>examples-grpc</artifactId>

--- a/examples/https/pom.xml
+++ b/examples/https/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-examples-parent</artifactId>
-        <version>1.6.0.Beta14-SNAPSHOT</version>
+        <version>1.6.0.Beta14</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>examples-https</artifactId>

--- a/examples/https/pom.xml
+++ b/examples/https/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-examples-parent</artifactId>
-        <version>1.6.0.Beta14</version>
+        <version>1.6.0.Beta15-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>examples-https</artifactId>

--- a/examples/infinispan/pom.xml
+++ b/examples/infinispan/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-examples-parent</artifactId>
-        <version>1.6.0.Beta14</version>
+        <version>1.6.0.Beta15-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>examples-infinispan</artifactId>

--- a/examples/infinispan/pom.xml
+++ b/examples/infinispan/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-examples-parent</artifactId>
-        <version>1.6.0.Beta14-SNAPSHOT</version>
+        <version>1.6.0.Beta14</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>examples-infinispan</artifactId>

--- a/examples/jaeger/pom.xml
+++ b/examples/jaeger/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-examples-parent</artifactId>
-        <version>1.6.0.Beta14-SNAPSHOT</version>
+        <version>1.6.0.Beta14</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>examples-jaeger</artifactId>

--- a/examples/jaeger/pom.xml
+++ b/examples/jaeger/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-examples-parent</artifactId>
-        <version>1.6.0.Beta14</version>
+        <version>1.6.0.Beta15-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>examples-jaeger</artifactId>

--- a/examples/kafka-registry/pom.xml
+++ b/examples/kafka-registry/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-examples-parent</artifactId>
-        <version>1.6.0.Beta14</version>
+        <version>1.6.0.Beta15-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>examples-kafka-registry</artifactId>

--- a/examples/kafka-registry/pom.xml
+++ b/examples/kafka-registry/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-examples-parent</artifactId>
-        <version>1.6.0.Beta14-SNAPSHOT</version>
+        <version>1.6.0.Beta14</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>examples-kafka-registry</artifactId>

--- a/examples/kafka-streams/pom.xml
+++ b/examples/kafka-streams/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-examples-parent</artifactId>
-        <version>1.6.0.Beta14</version>
+        <version>1.6.0.Beta15-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>examples-Kafka-streams</artifactId>

--- a/examples/kafka-streams/pom.xml
+++ b/examples/kafka-streams/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-examples-parent</artifactId>
-        <version>1.6.0.Beta14-SNAPSHOT</version>
+        <version>1.6.0.Beta14</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>examples-Kafka-streams</artifactId>

--- a/examples/kafka/pom.xml
+++ b/examples/kafka/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-examples-parent</artifactId>
-        <version>1.6.0.Beta14</version>
+        <version>1.6.0.Beta15-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>examples-kafka</artifactId>

--- a/examples/kafka/pom.xml
+++ b/examples/kafka/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-examples-parent</artifactId>
-        <version>1.6.0.Beta14-SNAPSHOT</version>
+        <version>1.6.0.Beta14</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>examples-kafka</artifactId>

--- a/examples/keycloak/pom.xml
+++ b/examples/keycloak/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-examples-parent</artifactId>
-        <version>1.6.0.Beta14</version>
+        <version>1.6.0.Beta15-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>examples-keycloak</artifactId>

--- a/examples/keycloak/pom.xml
+++ b/examples/keycloak/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-examples-parent</artifactId>
-        <version>1.6.0.Beta14-SNAPSHOT</version>
+        <version>1.6.0.Beta14</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>examples-keycloak</artifactId>

--- a/examples/management/pom.xml
+++ b/examples/management/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-examples-parent</artifactId>
-        <version>1.6.0.Beta14</version>
+        <version>1.6.0.Beta15-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>examples-management</artifactId>

--- a/examples/management/pom.xml
+++ b/examples/management/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-examples-parent</artifactId>
-        <version>1.6.0.Beta14-SNAPSHOT</version>
+        <version>1.6.0.Beta14</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>examples-management</artifactId>

--- a/examples/microprofile/pom.xml
+++ b/examples/microprofile/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-examples-parent</artifactId>
-        <version>1.6.0.Beta14</version>
+        <version>1.6.0.Beta15-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>examples-microprofile</artifactId>

--- a/examples/microprofile/pom.xml
+++ b/examples/microprofile/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-examples-parent</artifactId>
-        <version>1.6.0.Beta14-SNAPSHOT</version>
+        <version>1.6.0.Beta14</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>examples-microprofile</artifactId>

--- a/examples/picocli/pom.xml
+++ b/examples/picocli/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-examples-parent</artifactId>
-        <version>1.6.0.Beta14</version>
+        <version>1.6.0.Beta15-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>examples-picocli</artifactId>

--- a/examples/picocli/pom.xml
+++ b/examples/picocli/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-examples-parent</artifactId>
-        <version>1.6.0.Beta14-SNAPSHOT</version>
+        <version>1.6.0.Beta14</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>examples-picocli</artifactId>

--- a/examples/pingpong/pom.xml
+++ b/examples/pingpong/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-examples-parent</artifactId>
-        <version>1.6.0.Beta14-SNAPSHOT</version>
+        <version>1.6.0.Beta14</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>examples-pingpong</artifactId>

--- a/examples/pingpong/pom.xml
+++ b/examples/pingpong/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-examples-parent</artifactId>
-        <version>1.6.0.Beta14</version>
+        <version>1.6.0.Beta15-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>examples-pingpong</artifactId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-test-parent</artifactId>
-        <version>1.6.0.Beta14</version>
+        <version>1.6.0.Beta15-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>quarkus-examples-parent</artifactId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-test-parent</artifactId>
-        <version>1.6.0.Beta14-SNAPSHOT</version>
+        <version>1.6.0.Beta14</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>quarkus-examples-parent</artifactId>

--- a/examples/quarkus-cli/pom.xml
+++ b/examples/quarkus-cli/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-examples-parent</artifactId>
-        <version>1.6.0.Beta14</version>
+        <version>1.6.0.Beta15-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>examples-quarkus-cli</artifactId>

--- a/examples/quarkus-cli/pom.xml
+++ b/examples/quarkus-cli/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-examples-parent</artifactId>
-        <version>1.6.0.Beta14-SNAPSHOT</version>
+        <version>1.6.0.Beta14</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>examples-quarkus-cli</artifactId>

--- a/examples/restclient/pom.xml
+++ b/examples/restclient/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-examples-parent</artifactId>
-        <version>1.6.0.Beta14</version>
+        <version>1.6.0.Beta15-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>examples-restclient</artifactId>

--- a/examples/restclient/pom.xml
+++ b/examples/restclient/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-examples-parent</artifactId>
-        <version>1.6.0.Beta14-SNAPSHOT</version>
+        <version>1.6.0.Beta14</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>examples-restclient</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.quarkus.qe</groupId>
     <artifactId>quarkus-test-parent</artifactId>
-    <version>1.6.0.Beta14-SNAPSHOT</version>
+    <version>1.6.0.Beta14</version>
     <packaging>pom</packaging>
     <name>Quarkus - Test Framework - Parent</name>
     <description>Quarkus QE Test Framework is a library enabling the developers to easily deploy multiple Quarkus applications across different platforms in a single test.</description>
@@ -25,7 +25,7 @@
         <connection>scm:git:git@github.com:quarkus-qe/quarkus-test-framework.git</connection>
         <developerConnection>scm:git:git@github.com:quarkus-qe/quarkus-test-framework.git</developerConnection>
         <url>https://github.com/quarkus-qe/quarkus-test-framework</url>
-        <tag>HEAD</tag>
+        <tag>1.6.0.Beta14</tag>
     </scm>
     <url>https://github.com/quarkus-qe/quarkus-test-framework/</url>
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.quarkus.qe</groupId>
     <artifactId>quarkus-test-parent</artifactId>
-    <version>1.6.0.Beta14</version>
+    <version>1.6.0.Beta15-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Quarkus - Test Framework - Parent</name>
     <description>Quarkus QE Test Framework is a library enabling the developers to easily deploy multiple Quarkus applications across different platforms in a single test.</description>
@@ -25,7 +25,7 @@
         <connection>scm:git:git@github.com:quarkus-qe/quarkus-test-framework.git</connection>
         <developerConnection>scm:git:git@github.com:quarkus-qe/quarkus-test-framework.git</developerConnection>
         <url>https://github.com/quarkus-qe/quarkus-test-framework</url>
-        <tag>1.6.0.Beta14</tag>
+        <tag>HEAD</tag>
     </scm>
     <url>https://github.com/quarkus-qe/quarkus-test-framework/</url>
     <properties>

--- a/quarkus-test-cli/pom.xml
+++ b/quarkus-test-cli/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-test-parent</artifactId>
-        <version>1.6.0.Beta14-SNAPSHOT</version>
+        <version>1.6.0.Beta14</version>
     </parent>
     <artifactId>quarkus-test-cli</artifactId>
     <name>Quarkus - Test Framework - CLI</name>

--- a/quarkus-test-cli/pom.xml
+++ b/quarkus-test-cli/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-test-parent</artifactId>
-        <version>1.6.0.Beta14</version>
+        <version>1.6.0.Beta15-SNAPSHOT</version>
     </parent>
     <artifactId>quarkus-test-cli</artifactId>
     <name>Quarkus - Test Framework - CLI</name>

--- a/quarkus-test-containers/pom.xml
+++ b/quarkus-test-containers/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-test-parent</artifactId>
-        <version>1.6.0.Beta14-SNAPSHOT</version>
+        <version>1.6.0.Beta14</version>
     </parent>
     <artifactId>quarkus-test-containers</artifactId>
     <name>Quarkus - Test Framework - Containers</name>

--- a/quarkus-test-containers/pom.xml
+++ b/quarkus-test-containers/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-test-parent</artifactId>
-        <version>1.6.0.Beta14</version>
+        <version>1.6.0.Beta15-SNAPSHOT</version>
     </parent>
     <artifactId>quarkus-test-containers</artifactId>
     <name>Quarkus - Test Framework - Containers</name>

--- a/quarkus-test-core/pom.xml
+++ b/quarkus-test-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-test-parent</artifactId>
-        <version>1.6.0.Beta14</version>
+        <version>1.6.0.Beta15-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>quarkus-test-core</artifactId>

--- a/quarkus-test-core/pom.xml
+++ b/quarkus-test-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-test-parent</artifactId>
-        <version>1.6.0.Beta14-SNAPSHOT</version>
+        <version>1.6.0.Beta14</version>
         <relativePath>../</relativePath>
     </parent>
     <artifactId>quarkus-test-core</artifactId>

--- a/quarkus-test-images/pom.xml
+++ b/quarkus-test-images/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-test-parent</artifactId>
-        <version>1.6.0.Beta14-SNAPSHOT</version>
+        <version>1.6.0.Beta14</version>
     </parent>
     <artifactId>quarkus-test-images</artifactId>
     <name>Quarkus - Test Framework - Core - Images</name>

--- a/quarkus-test-images/pom.xml
+++ b/quarkus-test-images/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-test-parent</artifactId>
-        <version>1.6.0.Beta14</version>
+        <version>1.6.0.Beta15-SNAPSHOT</version>
     </parent>
     <artifactId>quarkus-test-images</artifactId>
     <name>Quarkus - Test Framework - Core - Images</name>

--- a/quarkus-test-knative-events/pom.xml
+++ b/quarkus-test-knative-events/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-test-parent</artifactId>
-        <version>1.6.0.Beta14-SNAPSHOT</version>
+        <version>1.6.0.Beta14</version>
     </parent>
     <artifactId>quarkus-test-knative-events-parent</artifactId>
     <name>Quarkus - Test Framework - Knative Events - Parent</name>

--- a/quarkus-test-knative-events/pom.xml
+++ b/quarkus-test-knative-events/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-test-parent</artifactId>
-        <version>1.6.0.Beta14</version>
+        <version>1.6.0.Beta15-SNAPSHOT</version>
     </parent>
     <artifactId>quarkus-test-knative-events-parent</artifactId>
     <name>Quarkus - Test Framework - Knative Events - Parent</name>

--- a/quarkus-test-knative-events/root/pom.xml
+++ b/quarkus-test-knative-events/root/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-test-knative-events-parent</artifactId>
-        <version>1.6.0.Beta14</version>
+        <version>1.6.0.Beta15-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>quarkus-test-knative-events</artifactId>

--- a/quarkus-test-knative-events/root/pom.xml
+++ b/quarkus-test-knative-events/root/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-test-knative-events-parent</artifactId>
-        <version>1.6.0.Beta14-SNAPSHOT</version>
+        <version>1.6.0.Beta14</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>quarkus-test-knative-events</artifactId>

--- a/quarkus-test-knative-events/spi/pom.xml
+++ b/quarkus-test-knative-events/spi/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-test-knative-events-parent</artifactId>
-        <version>1.6.0.Beta14-SNAPSHOT</version>
+        <version>1.6.0.Beta14</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>quarkus-test-knative-events-spi</artifactId>

--- a/quarkus-test-knative-events/spi/pom.xml
+++ b/quarkus-test-knative-events/spi/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-test-knative-events-parent</artifactId>
-        <version>1.6.0.Beta14</version>
+        <version>1.6.0.Beta15-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>quarkus-test-knative-events-spi</artifactId>

--- a/quarkus-test-kubernetes/pom.xml
+++ b/quarkus-test-kubernetes/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-test-parent</artifactId>
-        <version>1.6.0.Beta14</version>
+        <version>1.6.0.Beta15-SNAPSHOT</version>
     </parent>
     <artifactId>quarkus-test-kubernetes</artifactId>
     <name>Quarkus - Test Framework - Kubernetes</name>

--- a/quarkus-test-kubernetes/pom.xml
+++ b/quarkus-test-kubernetes/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-test-parent</artifactId>
-        <version>1.6.0.Beta14-SNAPSHOT</version>
+        <version>1.6.0.Beta14</version>
     </parent>
     <artifactId>quarkus-test-kubernetes</artifactId>
     <name>Quarkus - Test Framework - Kubernetes</name>

--- a/quarkus-test-openshift/pom.xml
+++ b/quarkus-test-openshift/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-test-parent</artifactId>
-        <version>1.6.0.Beta14-SNAPSHOT</version>
+        <version>1.6.0.Beta14</version>
     </parent>
     <artifactId>quarkus-test-openshift</artifactId>
     <name>Quarkus - Test Framework - OpenShift</name>

--- a/quarkus-test-openshift/pom.xml
+++ b/quarkus-test-openshift/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-test-parent</artifactId>
-        <version>1.6.0.Beta14</version>
+        <version>1.6.0.Beta15-SNAPSHOT</version>
     </parent>
     <artifactId>quarkus-test-openshift</artifactId>
     <name>Quarkus - Test Framework - OpenShift</name>

--- a/quarkus-test-service-amq/pom.xml
+++ b/quarkus-test-service-amq/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-test-parent</artifactId>
-        <version>1.6.0.Beta14</version>
+        <version>1.6.0.Beta15-SNAPSHOT</version>
     </parent>
     <artifactId>quarkus-test-service-amq</artifactId>
     <name>Quarkus - Test Framework - Service - AMQ</name>

--- a/quarkus-test-service-amq/pom.xml
+++ b/quarkus-test-service-amq/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-test-parent</artifactId>
-        <version>1.6.0.Beta14-SNAPSHOT</version>
+        <version>1.6.0.Beta14</version>
     </parent>
     <artifactId>quarkus-test-service-amq</artifactId>
     <name>Quarkus - Test Framework - Service - AMQ</name>

--- a/quarkus-test-service-consul/pom.xml
+++ b/quarkus-test-service-consul/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-test-parent</artifactId>
-        <version>1.6.0.Beta14-SNAPSHOT</version>
+        <version>1.6.0.Beta14</version>
     </parent>
     <artifactId>quarkus-test-service-consul</artifactId>
     <name>Quarkus - Test Framework - Service - Consul</name>

--- a/quarkus-test-service-consul/pom.xml
+++ b/quarkus-test-service-consul/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-test-parent</artifactId>
-        <version>1.6.0.Beta14</version>
+        <version>1.6.0.Beta15-SNAPSHOT</version>
     </parent>
     <artifactId>quarkus-test-service-consul</artifactId>
     <name>Quarkus - Test Framework - Service - Consul</name>

--- a/quarkus-test-service-database/pom.xml
+++ b/quarkus-test-service-database/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-test-parent</artifactId>
-        <version>1.6.0.Beta14-SNAPSHOT</version>
+        <version>1.6.0.Beta14</version>
     </parent>
     <artifactId>quarkus-test-service-database</artifactId>
     <name>Quarkus - Test Framework - Service - Database</name>

--- a/quarkus-test-service-database/pom.xml
+++ b/quarkus-test-service-database/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-test-parent</artifactId>
-        <version>1.6.0.Beta14</version>
+        <version>1.6.0.Beta15-SNAPSHOT</version>
     </parent>
     <artifactId>quarkus-test-service-database</artifactId>
     <name>Quarkus - Test Framework - Service - Database</name>

--- a/quarkus-test-service-grpc/pom.xml
+++ b/quarkus-test-service-grpc/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-test-parent</artifactId>
-        <version>1.6.0.Beta14-SNAPSHOT</version>
+        <version>1.6.0.Beta14</version>
     </parent>
     <artifactId>quarkus-test-service-grpc</artifactId>
     <name>Quarkus - Test Framework - Service - gRPC</name>

--- a/quarkus-test-service-grpc/pom.xml
+++ b/quarkus-test-service-grpc/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-test-parent</artifactId>
-        <version>1.6.0.Beta14</version>
+        <version>1.6.0.Beta15-SNAPSHOT</version>
     </parent>
     <artifactId>quarkus-test-service-grpc</artifactId>
     <name>Quarkus - Test Framework - Service - gRPC</name>

--- a/quarkus-test-service-infinispan/pom.xml
+++ b/quarkus-test-service-infinispan/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-test-parent</artifactId>
-        <version>1.6.0.Beta14-SNAPSHOT</version>
+        <version>1.6.0.Beta14</version>
     </parent>
     <artifactId>quarkus-test-service-infinispan</artifactId>
     <name>Quarkus - Test Framework - Service - Infinispan</name>

--- a/quarkus-test-service-infinispan/pom.xml
+++ b/quarkus-test-service-infinispan/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-test-parent</artifactId>
-        <version>1.6.0.Beta14</version>
+        <version>1.6.0.Beta15-SNAPSHOT</version>
     </parent>
     <artifactId>quarkus-test-service-infinispan</artifactId>
     <name>Quarkus - Test Framework - Service - Infinispan</name>

--- a/quarkus-test-service-jaeger/pom.xml
+++ b/quarkus-test-service-jaeger/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-test-parent</artifactId>
-        <version>1.6.0.Beta14-SNAPSHOT</version>
+        <version>1.6.0.Beta14</version>
     </parent>
     <artifactId>quarkus-test-service-jaeger</artifactId>
     <name>Quarkus - Test Framework - Service - Jaeger</name>

--- a/quarkus-test-service-jaeger/pom.xml
+++ b/quarkus-test-service-jaeger/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-test-parent</artifactId>
-        <version>1.6.0.Beta14</version>
+        <version>1.6.0.Beta15-SNAPSHOT</version>
     </parent>
     <artifactId>quarkus-test-service-jaeger</artifactId>
     <name>Quarkus - Test Framework - Service - Jaeger</name>

--- a/quarkus-test-service-kafka/pom.xml
+++ b/quarkus-test-service-kafka/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-test-parent</artifactId>
-        <version>1.6.0.Beta14</version>
+        <version>1.6.0.Beta15-SNAPSHOT</version>
     </parent>
     <artifactId>quarkus-test-service-kafka</artifactId>
     <name>Quarkus - Test Framework - Service - Kafka</name>

--- a/quarkus-test-service-kafka/pom.xml
+++ b/quarkus-test-service-kafka/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-test-parent</artifactId>
-        <version>1.6.0.Beta14-SNAPSHOT</version>
+        <version>1.6.0.Beta14</version>
     </parent>
     <artifactId>quarkus-test-service-kafka</artifactId>
     <name>Quarkus - Test Framework - Service - Kafka</name>

--- a/quarkus-test-service-keycloak/pom.xml
+++ b/quarkus-test-service-keycloak/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-test-parent</artifactId>
-        <version>1.6.0.Beta14</version>
+        <version>1.6.0.Beta15-SNAPSHOT</version>
     </parent>
     <artifactId>quarkus-test-service-keycloak</artifactId>
     <name>Quarkus - Test Framework - Service - Keycloak</name>

--- a/quarkus-test-service-keycloak/pom.xml
+++ b/quarkus-test-service-keycloak/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.qe</groupId>
         <artifactId>quarkus-test-parent</artifactId>
-        <version>1.6.0.Beta14-SNAPSHOT</version>
+        <version>1.6.0.Beta14</version>
     </parent>
     <artifactId>quarkus-test-service-keycloak</artifactId>
     <name>Quarkus - Test Framework - Service - Keycloak</name>


### PR DESCRIPTION
### Summary

Yesterday the release failed when releasing to sonatype. I today rerun it again and it failed on pushing to repository step. So now we end up with released framework but not prepared repository for next development. This should fix it. As FW is released I don't think that the job can pass as it can't overwrite artifact in sonatype.

I think it failed because of the jacoco badge generation commit by error message. For yesterday error I don't know what caused it.

Link to failed release https://github.com/quarkus-qe/quarkus-test-framework/actions/runs/11614988663/job/32380798087

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)