### PR TITLE
[1.5.z] Backport Fix the Keycloak memory issue on Podman setting JAVA_OPTS_APPEND

### DIFF
--- a/quarkus-test-service-keycloak/src/main/java/io/quarkus/test/services/containers/KeycloakGenericDockerContainerManagedResource.java
+++ b/quarkus-test-service-keycloak/src/main/java/io/quarkus/test/services/containers/KeycloakGenericDockerContainerManagedResource.java
@@ -1,7 +1,5 @@
 package io.quarkus.test.services.containers;
 
-import java.util.Optional;
-
 import org.apache.commons.lang3.StringUtils;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
@@ -40,8 +38,10 @@ public class KeycloakGenericDockerContainerManagedResource extends GenericDocker
         }
 
         container.withCreateContainerCmdModifier(cmd -> cmd.withName(DockerUtils.generateDockerContainerName()));
-        container.withCreateContainerCmdModifier(cmd -> Optional.ofNullable(cmd.getHostConfig())
-                .ifPresent(config -> config.withMemory(convertMiBtoBytes(model.getMemoryLimitMiB()))));
+
+        // Currently, we can't properly set the container's memory limit when running with Podman.
+        // More details on this issue can be found here: https://github.com/quarkus-qe/quarkus-test-suite/issues/2106
+        container.withEnv("JAVA_OPTS_APPEND", String.format("-XX:MaxRAM=%sm", model.getMemoryLimitMiB()));
 
         if (isReusable()) {
             Log.info(model.getContext().getOwner(), "Running container on Reusable mode");


### PR DESCRIPTION
### Summary

This is a backport contains:
 https://github.com/quarkus-qe/quarkus-test-framework/pull/1389

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [x] Backport
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)