### PR TITLE
Build warnings cleanup

### DIFF
--- a/examples/https/pom.xml
+++ b/examples/https/pom.xml
@@ -68,9 +68,9 @@
                         <executions>
                             <execution>
                                 <configuration>
-                                    <systemProperties>
+                                    <systemPropertyVariables>
                                         <quarkus.ssl.native>${quarkus.ssl.native}</quarkus.ssl.native>
-                                    </systemProperties>
+                                    </systemPropertyVariables>
                                 </configuration>
                             </execution>
                         </executions>

--- a/examples/kafka/pom.xml
+++ b/examples/kafka/pom.xml
@@ -50,10 +50,10 @@
                 <executions>
                     <execution>
                         <configuration>
-                            <systemProperties>
+                            <systemPropertyVariables>
                                 <custom.kafka.image>quay.io/strimzi/kafka</custom.kafka.image>
                                 <custom.kafka.version>0.41.0-kafka-3.7.0</custom.kafka.version>
-                            </systemProperties>
+                            </systemPropertyVariables>
                         </configuration>
                     </execution>
                 </executions>

--- a/examples/quarkus-cli/pom.xml
+++ b/examples/quarkus-cli/pom.xml
@@ -29,6 +29,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire-plugin.version}</version>
                 <!-- Skip unit tests as we only want to run ITs -->
                 <!-- This will allow us to have unit tests for apps created via CLI in src/test/java -->
                 <!-- Which makes them better maintainable from IDE than Java classes in resources -->


### PR DESCRIPTION
### Summary

 * Use systemPropertyVariables instead of deprecated systemProperties
 * Specify surefire version to avoid build warnings

Removes following warnings
```
[INFO] Scanning for projects...
[WARNING]
[WARNING] Some problems were encountered while building the effective model for io.quarkus.qe:examples-quarkus-cli:jar:1.6.0.Beta15-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ line 29, column 21
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Build Order:
--
[INFO]
[INFO] --- failsafe:3.5.1:integration-test (default) @ examples-kafka ---
[WARNING]  Parameter 'systemProperties' is deprecated: Use systemPropertyVariables instead.
[INFO] Tests are skipped.
[INFO]
--
```

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)