### PR TITLE
Do not depend on fabric8 extensions directly

### DIFF
--- a/quarkus-test-openshift/pom.xml
+++ b/quarkus-test-openshift/pom.xml
@@ -18,16 +18,12 @@
             <artifactId>quarkus-test-images</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.fabric8</groupId>
-            <artifactId>openshift-client</artifactId>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-openshift-client</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.fabric8</groupId>
-            <artifactId>kubernetes-httpclient-vertx</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.fabric8</groupId>
-            <artifactId>knative-client</artifactId>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-kubernetes-deployment</artifactId>
         </dependency>
         <dependency>
             <groupId>io.rest-assured</groupId>


### PR DESCRIPTION
### Summary
When we import fabric8 extensions directly (not via Quarkus boms), native compilation consumes too much memory.
The recommended solution is to use io.quarkus:openshift-client, but unfortunately, it doesn't contain KnativeClient which we use in io.quarkus.test.bootstrap.inject.OpenShiftClient, so we have to import quarkus-kubernetes-deployment, which provides knative classes.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Dependency update
- [x] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)