### PR TITLE
Retry container launch if failed

### DIFF
--- a/quarkus-test-containers/src/main/java/io/quarkus/test/services/containers/DockerContainerManagedResource.java
+++ b/quarkus-test-containers/src/main/java/io/quarkus/test/services/containers/DockerContainerManagedResource.java
@@ -25,6 +25,7 @@ import org.testcontainers.utility.MountableFile;
 import io.quarkus.test.bootstrap.ManagedResource;
 import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.ServiceContext;
+import io.quarkus.test.configuration.PropertyLookup;
 import io.quarkus.test.logging.Log;
 import io.quarkus.test.logging.LoggingHandler;
 import io.quarkus.test.logging.TestContainersLoggingHandler;
@@ -37,6 +38,7 @@ public abstract class DockerContainerManagedResource implements ManagedResource 
     public static final String DOCKER_INNER_CONTAINER = DockerContainerManagedResource.class.getName() + "_inner";
     private static final String DELETE_IMAGE_ON_STOP_PROPERTY = "container.delete.image.on.stop";
     private static final String TARGET = "target";
+    private static final PropertyLookup CONTAINER_STARTUP_ATTEMPTS = new PropertyLookup("container-startup-attempts", "1");
 
     private final ServiceContext context;
 
@@ -65,6 +67,7 @@ public abstract class DockerContainerManagedResource implements ManagedResource 
         innerContainer.withStartupTimeout(context.getOwner().getConfiguration()
                 .getAsDuration(SERVICE_STARTUP_TIMEOUT, SERVICE_STARTUP_TIMEOUT_DEFAULT));
         innerContainer.withEnv(resolveProperties());
+        innerContainer.withStartupAttempts(CONTAINER_STARTUP_ATTEMPTS.getAsInteger());
 
         loggingHandler = new TestContainersLoggingHandler(context.getOwner(), innerContainer);
         loggingHandler.startWatching();


### PR DESCRIPTION
### Summary

Test containers sometimes fails to launch (especially on podman), we can try to relaunch them in case of a failure.

Edit:
I changed the startup limit count to be configurable. By default it is 1 (will not retry at all), but can be configured using maven CLI `-Dts.global.container-startup-attempts=2`. So we can use it only it jobs where we want to retry.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)