### PR TITLE
Insignificant refactoring: move custom build detection to one place and set Maven compiler version just once

### DIFF
--- a/plugins/test-preparer/src/main/java/io/quarkus/test/plugin/preparer/PreparePomMojo.java
+++ b/plugins/test-preparer/src/main/java/io/quarkus/test/plugin/preparer/PreparePomMojo.java
@@ -104,13 +104,13 @@ public class PreparePomMojo extends AbstractMojo {
                         "POM file property '" + propertyKey + "' is required but could not found");
             }
             newPomModel.getProperties().setProperty(propertyKey, propertyValue);
-            if (project.getProperties().getProperty(MAVEN_COMPILER_RELEASE) != null) {
-                newPomModel.getProperties().setProperty(MAVEN_COMPILER_RELEASE,
-                        project.getProperties().getProperty(MAVEN_COMPILER_RELEASE));
-            } else {
-                newPomModel.getProperties().setProperty(MAVEN_COMPILER_RELEASE, Integer.toString(Runtime.version().feature()));
-            }
         });
+        if (project.getProperties().getProperty(MAVEN_COMPILER_RELEASE) != null) {
+            newPomModel.getProperties().setProperty(MAVEN_COMPILER_RELEASE,
+                    project.getProperties().getProperty(MAVEN_COMPILER_RELEASE));
+        } else {
+            newPomModel.getProperties().setProperty(MAVEN_COMPILER_RELEASE, Integer.toString(Runtime.version().feature()));
+        }
     }
 
     private static void addCurrentProjectPlugins(Model newPomModel, Model rawCurrentProjectModel, MavenProject project) {

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusMavenPluginBuildHelper.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusMavenPluginBuildHelper.java
@@ -285,10 +285,6 @@ public final class QuarkusMavenPluginBuildHelper {
             mavenBuildProjectRoot = prepareMavenProject(appFolder.resolve("mvn-build"));
         }
 
-        final boolean isCustomBuildRequired = TestExecutionProperties.isCustomBuildRequired(resourceBuilder.getContext());
-        if (isCustomBuildRequired) {
-            return buildArtifactWithQuarkusMvnPlugin(mavenBuildProjectRoot, additionalArgs);
-        }
         return getArtifact().or(() -> buildArtifactWithQuarkusMvnPlugin(mavenBuildProjectRoot, additionalArgs));
     }
 
@@ -394,8 +390,10 @@ public final class QuarkusMavenPluginBuildHelper {
     }
 
     private boolean isCustomBuildRequired() {
-        return resourceBuilder.requiresCustomBuild() || !forcedDependencies.isEmpty() || !requiredDependencies.isEmpty()
-                || resourceBuilder.areApplicationPropertiesEnhanced();
+        boolean customBuildRequiredImplicitly = resourceBuilder.requiresCustomBuild() || !forcedDependencies.isEmpty()
+                || !requiredDependencies.isEmpty() || resourceBuilder.areApplicationPropertiesEnhanced();
+        boolean customBuildRequiredExplicitly = TestExecutionProperties.isCustomBuildRequired(resourceBuilder.getContext());
+        return customBuildRequiredExplicitly || customBuildRequiredImplicitly;
     }
 
     private String[] getBuildCmd(Collection<String> additionalArgs) {


### PR DESCRIPTION
### Summary

TSIA, I mentioned this when debugging why some changes were required in QE TS SQL compatibility app. 

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)