### PR TITLE
Add daily release & change deploy plugin

### DIFF
--- a/.github/workflows/daily-deploy.yml
+++ b/.github/workflows/daily-deploy.yml
@@ -1,0 +1,40 @@
+name: "Daily deploy snapshot"
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 23 * * *'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    name: release
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          check-latest: true
+          server-id: ossrh
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+
+      - name: Maven release 999-SNAPSHOT
+        run: |
+          mvn -B versions:set -DnewVersion=999-SNAPSHOT
+          mvn -B -DskipTests -DskipITs \
+            -DretryFailedDeploymentCount=3 \
+            -Prelease,framework \
+            clean deploy
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+
+      - name: Delete Local Artifacts From Cache
+        shell: bash
+        run: rm -r ~/.m2/repository/io/quarkus/qe

--- a/pom.xml
+++ b/pom.xml
@@ -622,16 +622,18 @@
                         </executions>
                     </plugin>
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.7.0</version>
-                        <extensions>true</extensions>
-                        <configuration>
-                            <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-                            <serverId>ossrh</serverId>
-                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                            <stagingProgressTimeoutMinutes>60</stagingProgressTimeoutMinutes>
-                        </configuration>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-deploy-plugin</artifactId>
+                        <version>3.1.3</version>
+                        <executions>
+                            <execution>
+                                <id>deploy-snapshot</id>
+                                <phase>deploy</phase>
+                                <goals>
+                                    <goal>deploy</goal>
+                                </goals>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
### Summary

This is not a final PR. It is a proposal for GH action to daily release snapshots.

The GH action itself is pretty simple and should be OK - here is a [success run](https://github.com/mocenas/quarkus-test-framework/actions/runs/12030325967)

Problem is the nexus-staging-maven-plugin.

Thing is, we are releasing a maven plugin - `quarkus-test-preparer`. And plugins should be listed in [org's maven-metadata.xml](https://s01.oss.sonatype.org/content/repositories/snapshots/io/quarkus/qe/maven-metadata.xml) in the maven repo. For us, it should look like this:
```
<metadata>
  <plugins>
    <plugin>
      <name>Quarkus - Test Framework - Test preparer</name>
      <prefix>quarkus-qe</prefix>
      <artifactId>quarkus-test-preparer</artifactId>
    </plugin>
  </plugins>
</metadata>
```
Problem is, that nexus-staging-maven-plugin is ommiting the "prefix" attribute in deployment, which the same plugin treats as mandatory when reading the file. As a result, if we use nexus-staging-maven-plugin the first upload is going to be OK, but any consecutive upload is going to fail with:
`
Failed to execute goal org.sonatype.plugins:nexus-staging-maven-plugin:1.7.0:deploy (injected-nexus-deploy) on project <whatever>: Failed to update metadata io.quarkus.qe/maven-metadata.xml: Cannot invoke "String.equals(Object)" because the return value of "org.apache.maven.artifact.repository.metadata.Plugin.getPrefix()" is null -> [Help 1]
`
and the only way to fix this broken cycle is to manually log into the nexus and remove uploaded stuff.

This is known problem I found few issues about and it doesn't seem to be fixed in near future:
- https://issues.apache.org/jira/browse/MPLUGIN-384
- https://issues.apache.org/jira/browse/MPLUGIN-524

Only hint I found about how to solve this, is to use `maven-deploy-plugin` instead. Which I did and it works. But I'm not sure if we're using the nexus-staging-maven-plugin for some specific reason/features or not. Also I'm not yet sure how is this change going to affect normal releases. Of course there is the possibility to use nexus-staging-maven-plugin for releases and maven-deploy-plguin for snapshots, but I would like to keep it simple and use only one.
WDYT @mjurc ? (cc @michalvavrik if you want to participate)




Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)