### PR TITLE
Revert "Release 1.6.0.Beta18"

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 name: Quarkus QE Test Framework
 release:
-  current-version: 1.6.0.Beta18
-  next-version: 1.6.0.Beta19
+  current-version: 1.6.0.Beta17
+  next-version: 1.6.0.Beta18


### PR DESCRIPTION
Reverts quarkus-qe/quarkus-test-framework#1432 for https://github.com/quarkus-qe/quarkus-test-framework/actions/runs/12291828284/job/34309866608 failed.