### PR TITLE
Revert "Release 1.6.0.Beta18 - attempt #2"

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 name: Quarkus QE Test Framework
 release:
-  current-version: 1.6.0.Beta18
-  next-version: 1.6.0.Beta19
+  current-version: 1.6.0.Beta17
+  next-version: 1.6.0.Beta18


### PR DESCRIPTION
Reverts quarkus-qe/quarkus-test-framework#1436 as release failure https://github.com/quarkus-qe/quarkus-test-framework/actions/runs/12295673777/job/34313030204 didn't change with https://github.com/quarkus-qe/quarkus-test-framework/pull/1435.