### PR TITLE
Revert "Bump org.apache.maven.plugins:maven-javadoc-plugin from 3.11.1 to 3.11.2"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <properties>
         <compiler-plugin.version>3.13.0</compiler-plugin.version>
         <source-plugin.version>3.3.1</source-plugin.version>
-        <javadoc-plugin.version>3.11.2</javadoc-plugin.version>
+        <javadoc-plugin.version>3.11.1</javadoc-plugin.version>
         <maven.compiler.parameters>true</maven.compiler.parameters>
         <maven.compiler.release>17</maven.compiler.release>
         <maven.javadoc.failOnError>false</maven.javadoc.failOnError>
@@ -44,7 +44,7 @@
         <formatter-maven-plugin.version>2.24.1</formatter-maven-plugin.version>
         <impsort-maven-plugin.version>1.12.0</impsort-maven-plugin.version>
         <maven-gpg-plugin.version>3.2.7</maven-gpg-plugin.version>
-        <maven-javadoc-plugin.version>3.11.2</maven-javadoc-plugin.version>
+        <maven-javadoc-plugin.version>3.11.1</maven-javadoc-plugin.version>
         <maven-release-plugin.version>3.1.1</maven-release-plugin.version>
         <nexus-staging-maven-plugin.version>1.7.0</nexus-staging-maven-plugin.version>
         <maven-deploy-plugin.version>3.1.3</maven-deploy-plugin.version>


### PR DESCRIPTION
Reverts quarkus-qe/quarkus-test-framework#1429. It is very unlikely, but it is only remaining change from the last successful release that I can see as related to the failing release https://github.com/quarkus-qe/quarkus-test-framework/pull/1437.