### PR TITLE
Fix release workflow

### DIFF
--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -1,0 +1,42 @@
+name: 'Release Quarkus QE Test Framework'
+description: 'Releases Quarkus QE Test Framework'
+inputs:
+  repository-id:
+    description: 'Must match a repository id present in of the POM file distributionManagement repositories'
+    required: true
+  release-version:
+    description: 'Version under which should this framework be released'
+runs:
+  using: "composite"
+  steps:
+    - name: Install JDK 17
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: 17
+        check-latest: true
+        server-id: ${{ inputs.repository-id }}
+        server-username: MAVEN_USERNAME
+        server-password: MAVEN_PASSWORD
+        gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+        gpg-passphrase: MAVEN_GPG_PASSPHRASE
+    - name: Set Quarkus QE Test Framework version to ${{ inputs.release-version }}
+      shell: bash
+      run: mvn -B versions:set -DnewVersion=$NEW_FRAMEWORK_VERSION
+      env:
+        NEW_FRAMEWORK_VERSION: ${{ inputs.release-version }}
+    - name: Maven release ${{ inputs.release-version }}
+      shell: bash
+      run: |
+        mvn -B -DskipTests -DskipITs \
+          -DretryFailedDeploymentCount=3 \
+          -Prelease,framework \
+          clean deploy
+      env:
+        MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+        MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+        MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+    - name: Delete Local Artifacts From Cache
+      shell: bash
+      run: rm -r ~/.m2/repository/io/quarkus/qe
+

--- a/.github/workflows/daily-deploy.yml
+++ b/.github/workflows/daily-deploy.yml
@@ -10,31 +10,7 @@ jobs:
     name: release
 
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Install JDK 17
-        uses: actions/setup-java@v4
+      - uses: ./.github/actions/release
         with:
-          distribution: 'temurin'
-          java-version: 17
-          check-latest: true
-          server-id: ossrh
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_PASSWORD
-          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
-          gpg-passphrase: MAVEN_GPG_PASSPHRASE
-
-      - name: Maven release 999-SNAPSHOT
-        run: |
-          mvn -B -DskipTests -DskipITs \
-            -DretryFailedDeploymentCount=3 \
-            -Psnapshot,framework \
-            clean deploy
-        env:
-          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
-          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-
-      - name: Delete Local Artifacts From Cache
-        shell: bash
-        run: rm -r ~/.m2/repository/io/quarkus/qe
+          repository-id: 'ossrh'
+          release-version: '999-SNAPSHOT'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,41 +19,24 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           metadata-file-path: '.github/project.yml'
-
-      - uses: actions/checkout@v4
-
-      - name: Install JDK 17
-        uses: actions/setup-java@v4
+      - uses: ./.github/actions/release
         with:
-          distribution: 'temurin'
-          java-version: 17
-          check-latest: true
-          server-id: oss.sonatype
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_PASSWORD
-          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
-          gpg-passphrase: MAVEN_GPG_PASSPHRASE
-
-      - name: Configure Git author
+          repository-id: 'oss.sonatype'
+          release-version: ${{steps.metadata.outputs.current-version}}
+      - name: Configure Git
+        shell: bash
         run: |
+          gh auth setup-git
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-
-      - name: Maven release ${{steps.metadata.outputs.current-version}}
-        run: |
-          git checkout -b release
-          mvn -B release:prepare -Prelease,framework,examples -DpushChanges=false -DautoVersionSubmodules -DreleaseVersion=${{steps.metadata.outputs.current-version}} -DdevelopmentVersion=999-SNAPSHOT
-          git checkout ${{github.base_ref}}
-          git rebase release
-          mvn -B release:perform -DskipITs -Prelease,framework
         env:
-          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
-          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-
-      - name: Push tags
-        uses: ad-m/github-push-action@v0.8.0
-        with:
-          branch: ${{github.base_ref}}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          tags: true
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GH_REPO: ${{github.repository}}
+      - name: Tag the HEAD branch and push the tag to GitHub
+        shell: bash
+        run: |
+          git reset --hard
+          git tag $CURRENT_FRAMEWORK_VERSION
+          git push origin --tags
+        env:
+          CURRENT_FRAMEWORK_VERSION: ${{steps.metadata.outputs.current-version}}

--- a/pom.xml
+++ b/pom.xml
@@ -582,51 +582,6 @@
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-release-plugin</artifactId>
-                        <version>${maven-release-plugin.version}</version>
-                        <configuration>
-                            <autoVersionSubmodules>true</autoVersionSubmodules>
-                            <tagNameFormat>@{project.version}</tagNameFormat>
-                            <pushChanges>false</pushChanges>
-                            <localCheckout>true</localCheckout>
-                            <remoteTagging>false</remoteTagging>
-                            <arguments>-DskipTests=true</arguments>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>${maven-javadoc-plugin.version}</version>
-                        <executions>
-                            <execution>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>${nexus-staging-maven-plugin.version}</version>
-                        <extensions>true</extensions>
-                        <configuration>
-                            <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-                            <serverId>oss.sonatype</serverId>
-                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                            <stagingProgressTimeoutMinutes>60</stagingProgressTimeoutMinutes>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>snapshot</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
                         <version>${maven-gpg-plugin.version}</version>
                         <configuration>
@@ -664,7 +619,7 @@
                         <version>${maven-deploy-plugin.version}</version>
                         <executions>
                             <execution>
-                                <id>deploy-snapshot</id>
+                                <id>deploy</id>
                                 <phase>deploy</phase>
                                 <goals>
                                     <goal>deploy</goal>


### PR DESCRIPTION
### Summary

After switch to 999-SNAPSHOT, I have repeated issues with the release workflow that doesn't work, see all the PRs linked to this https://github.com/quarkus-qe/quarkus-test-framework/pull/1440. I remember using Mavin deploy plugin was discussed but I think someone said it doesn't work. I'd like to try it based on this documentation https://central.sonatype.org/publish/publish-maven/, I don't see why it shouldn't work. If doesn't work, will revert this.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)