### PR TITLE
Add checkout to release workflows

### DIFF
--- a/.github/workflows/daily-deploy.yml
+++ b/.github/workflows/daily-deploy.yml
@@ -10,6 +10,7 @@ jobs:
     name: release
 
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/release
         with:
           repository-id: 'ossrh'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
     if: ${{github.event.pull_request.merged == true}}
 
     steps:
+      - uses: actions/checkout@v4
       - uses: radcortez/project-metadata-action@master
         name: Retrieve project metadata
         id: metadata


### PR DESCRIPTION
### Summary

I leftout checkout here https://github.com/quarkus-qe/quarkus-test-framework/pull/1441 because release workflows doesn't need any specific branch, current main is just fine. Seems to be necessary anyway though https://github.com/quarkus-qe/quarkus-test-framework/actions/runs/12302119733/job/34334240205. I can't find proper docs that would say why actions run in `/home/runner/work/quarkus-test-framework/quarkus-test-framework/.github/actions/release` and FW is not there. Maybe it's in a parent dir, anyway, using checkout as that's what we do everywhere.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)