### PR TITLE
Propagate OSSRH and GPG secrets into a release workflow

### DIFF
--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -6,6 +6,14 @@ inputs:
     required: true
   release-version:
     description: 'Version under which should this framework be released'
+  ossrh-username:
+    required: true
+  ossrh-token:
+    required: true
+  gpg-passphrase:
+    required: true
+  gpg-private-key:
+    required: true
 runs:
   using: "composite"
   steps:
@@ -18,7 +26,7 @@ runs:
         server-id: ${{ inputs.repository-id }}
         server-username: MAVEN_USERNAME
         server-password: MAVEN_PASSWORD
-        gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+        gpg-private-key: ${{ inputs.gpg-private-key }}
         gpg-passphrase: MAVEN_GPG_PASSPHRASE
     - name: Set Quarkus QE Test Framework version to ${{ inputs.release-version }}
       shell: bash
@@ -33,9 +41,9 @@ runs:
           -Prelease,framework \
           clean deploy
       env:
-        MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-        MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
-        MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        MAVEN_USERNAME: ${{ inputs.ossrh-username }}
+        MAVEN_PASSWORD: ${{ inputs.ossrh-token }}
+        MAVEN_GPG_PASSPHRASE: ${{ inputs.gpg-passphrase }}
     - name: Delete Local Artifacts From Cache
       shell: bash
       run: rm -r ~/.m2/repository/io/quarkus/qe

--- a/.github/workflows/daily-deploy.yml
+++ b/.github/workflows/daily-deploy.yml
@@ -15,3 +15,7 @@ jobs:
         with:
           repository-id: 'ossrh'
           release-version: '999-SNAPSHOT'
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          ossrh-token: ${{ secrets.OSSRH_TOKEN }}
+          gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          ossrh-username: ${{ secrets.OSSRH_USERNAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,10 @@ jobs:
         with:
           repository-id: 'oss.sonatype'
           release-version: ${{steps.metadata.outputs.current-version}}
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          ossrh-token: ${{ secrets.OSSRH_TOKEN }}
+          gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          ossrh-username: ${{ secrets.OSSRH_USERNAME }}
       - name: Configure Git
         shell: bash
         run: |


### PR DESCRIPTION
### Summary

I extracted shared release steps into one action https://github.com/quarkus-qe/quarkus-test-framework/pull/1441 and actions can't access secrets https://github.com/quarkus-qe/quarkus-test-framework/actions/runs/12302233616/job/34334621718 which makes total sense. Need to use action inputs.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)