### PR TITLE
Finish deployment with a release for non-snapshot versions

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -1,5 +1,5 @@
-name: 'Release Quarkus QE Test Framework'
-description: 'Releases Quarkus QE Test Framework'
+name: 'Deploy Quarkus QE Test Framework'
+description: 'Deploys Quarkus QE Test Framework'
 inputs:
   repository-id:
     description: 'Must match a repository id present in of the POM file distributionManagement repositories'
@@ -33,17 +33,19 @@ runs:
       run: mvn -B versions:set -DnewVersion=$NEW_FRAMEWORK_VERSION
       env:
         NEW_FRAMEWORK_VERSION: ${{ inputs.release-version }}
-    - name: Maven release ${{ inputs.release-version }}
+    - name: Maven deploy ${{ inputs.release-version }}
       shell: bash
       run: |
         mvn -B -DskipTests -DskipITs \
           -DretryFailedDeploymentCount=3 \
-          -Prelease,framework \
+          -Pdeploy,framework \
+          -Prelease=$RELEASE \
           clean deploy
       env:
         MAVEN_USERNAME: ${{ inputs.ossrh-username }}
         MAVEN_PASSWORD: ${{ inputs.ossrh-token }}
         MAVEN_GPG_PASSPHRASE: ${{ inputs.gpg-passphrase }}
+        RELEASE: ${{ ! endsWith(inputs.release-version, 'SNAPSHOT') }}
     - name: Delete Local Artifacts From Cache
       shell: bash
       run: rm -r ~/.m2/repository/io/quarkus/qe

--- a/.github/workflows/daily-deploy.yml
+++ b/.github/workflows/daily-deploy.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/release
+      - uses: ./.github/actions/deploy
         with:
           repository-id: 'ossrh'
           release-version: '999-SNAPSHOT'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           metadata-file-path: '.github/project.yml'
-      - uses: ./.github/actions/release
+      - uses: ./.github/actions/deploy
         with:
           repository-id: 'oss.sonatype'
           release-version: ${{steps.metadata.outputs.current-version}}

--- a/pom.xml
+++ b/pom.xml
@@ -577,7 +577,7 @@
             </build>
         </profile>
         <profile>
-            <id>release</id>
+            <id>deploy</id>
             <build>
                 <plugins>
                     <plugin>
@@ -626,6 +626,30 @@
                                 </goals>
                             </execution>
                         </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>release</id>
+            <activation>
+                <property>
+                    <name>release</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <version>${nexus-staging-maven-plugin.version}</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
+                            <serverId>oss.sonatype</serverId>
+                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                            <stagingProgressTimeoutMinutes>60</stagingProgressTimeoutMinutes>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
### Summary

https://github.com/quarkus-qe/quarkus-test-framework/actions/runs/12302838673/job/34336585607 has finished more than 2 hours ago, but I still can't see it in the Maven central. I think it is because for non-snapshot version you need Nexus Staging Maven plugin https://central.sonatype.org/publish/publish-maven/#nexus-staging-maven-plugin-for-deployment-and-release. I removed it here https://github.com/quarkus-qe/quarkus-test-framework/pull/1441 because I experienced repeated issues with it. So it is fairly possible that issues will be back when I add it, but this probably needs to be done and fix in another way...

Here https://github.com/sonatype/nexus-maven-plugins/blob/main/staging/maven-plugin/README.md#maven3-only it is said that deployment plugin is automatically disabled, so I'm leaving it there for now. I suspect this won't be only attempt anyway.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)