### PR TITLE
Fix typo in a deployment action

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -39,7 +39,7 @@ runs:
         mvn -B -DskipTests -DskipITs \
           -DretryFailedDeploymentCount=3 \
           -Pdeploy,framework \
-          -Prelease=$RELEASE \
+          -Drelease=$RELEASE \
           clean deploy
       env:
         MAVEN_USERNAME: ${{ inputs.ossrh-username }}


### PR DESCRIPTION
### Summary

It should be setting a system property that activates a profile, not activating the profile directly (which it doesn't because no such a profile exists).

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)