### PR TITLE
Fix source-to-image OpenShift scenarios when remote repository requires private certificate authority

### DIFF
--- a/examples/external-applications/src/test/resources/uber-jar-quarkus-s2i-source-build-template.yml
+++ b/examples/external-applications/src/test/resources/uber-jar-quarkus-s2i-source-build-template.yml
@@ -28,6 +28,9 @@ items:
           - configMap:
               name: settings-mvn
             destinationDir: "/configuration"
+          - configMap:
+              name: etc-pki-java
+            destinationDir: "/etc/pki/java/"
       strategy:
         type: Source
         sourceStrategy:

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/TemplateOpenShiftQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/TemplateOpenShiftQuarkusApplicationManagedResource.java
@@ -61,9 +61,13 @@ public abstract class TemplateOpenShiftQuarkusApplicationManagedResource<T exten
         return Collections.emptyMap();
     }
 
-    private void applyTemplate() {
-        String deploymentFile = model.getContext().getOwner().getConfiguration().getOrDefault(DEPLOYMENT_TEMPLATE_PROPERTY,
+    protected final String getTemplate() {
+        return model.getContext().getOwner().getConfiguration().getOrDefault(DEPLOYMENT_TEMPLATE_PROPERTY,
                 getDefaultTemplate());
+    }
+
+    private void applyTemplate() {
+        String deploymentFile = getTemplate();
 
         client.applyServicePropertiesUsingTemplate(model.getContext().getOwner(), deploymentFile,
                 this::internalReplaceDeploymentContent,

--- a/quarkus-test-openshift/src/main/resources/quarkus-s2i-source-build-template.yml
+++ b/quarkus-test-openshift/src/main/resources/quarkus-s2i-source-build-template.yml
@@ -28,6 +28,9 @@ items:
           - configMap:
               name: settings-mvn
             destinationDir: "/configuration"
+          - configMap:
+              name: etc-pki-java
+            destinationDir: "/etc/pki/java/"
       strategy:
         type: Source
         sourceStrategy:


### PR DESCRIPTION
### Summary

This fixes S2I scenarios when remote repository requires "private" CA. I'll spare you details, but I have tried proper solutions like https://maven.apache.org/guides/mini/guide-repository-ssl.html as well as https://docs.openshift.com/container-platform/4.17/networking/configuring-a-custom-pki.html and https://docs.openshift.com/container-platform/4.17/cicd/builds/setting-up-trusted-ca.html (and many others). It seems to me that unless you are able to run `update-ca-trust` (which we can't with the `registry.access.redhat.com/ubi8/openjdk-17:latest`) or use your own docker file or docker image, you can't update CA certs. Why vanilla Maven solution doesn't work I am not sure, I think it might be related to the fact that we need a certificate chain, or I made mistake somewhere in the process.

This fix ensures that [OpenJDK trust anchor certificates](https://docs.redhat.com/es/documentation/red_hat_build_of_openjdk/17/html-single/configuring_red_hat_build_of_openjdk_17_on_rhel_with_fips/index#crypto_policies) are copied from our test executors to UBI images.

OCP runs in this PR are testing changes because periodic TF OpenShift runs fail.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)