### PR TITLE
Raise OpenShiftTodoDemoIT service startup timeouts to make this test more stable

### DIFF
--- a/examples/external-applications/src/test/java/io/quarkus/qe/TodoDemoIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/TodoDemoIT.java
@@ -31,21 +31,21 @@ public class TodoDemoIT {
             .withProperty("PGDATA", "/tmp/psql");
 
     @GitRepositoryQuarkusApplication(repo = REPO, mavenArgs = DEFAULT_ARGS + UBER)
-    static final RestService app = new RestService()
+    static final RestService todoApp = new RestService()
             .withProperty("quarkus.datasource.username", database.getUser())
             .withProperty("quarkus.datasource.password", database.getPassword())
             .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl);
 
     @GitRepositoryQuarkusApplication(repo = REPO, artifact = "todo-backend-1.0-SNAPSHOT-runner.jar", mavenArgs = DEFAULT_ARGS
             + UBER)
-    static final RestService explicit = new RestService()
+    static final RestService todoExplicitApp = new RestService()
             .withProperty("quarkus.datasource.username", database.getUser())
             .withProperty("quarkus.datasource.password", database.getPassword())
             .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl);
 
     @GitRepositoryQuarkusApplication(repo = REPO, artifact = "todo-backend-1.0-SNAPSHOT.jar", mavenArgs = DEFAULT_ARGS + UBER
             + NO_SUFFIX)
-    static final RestService unsuffixed = new RestService()
+    static final RestService todoUnsuffixedApp = new RestService()
             .withProperty("quarkus.datasource.username", database.getUser())
             .withProperty("quarkus.datasource.password", database.getPassword())
             .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl);
@@ -53,7 +53,7 @@ public class TodoDemoIT {
     @Test
     @Order(1)
     public void verify() {
-        app.given()
+        todoApp.given()
                 .contentType(ContentType.JSON)
                 .body("{\"title\": \"Use Quarkus\", \"order\": 1, \"url\": \"https://quarkus.io\"}")
                 .post("/api")
@@ -64,7 +64,7 @@ public class TodoDemoIT {
     @Test
     @Order(2)
     public void verifyExplicitArtifact() {
-        explicit.given()
+        todoExplicitApp.given()
                 .accept(ContentType.JSON)
                 .get("/api/1")
                 .then()
@@ -75,7 +75,7 @@ public class TodoDemoIT {
     @Test
     @Order(3)
     public void verifyNoSuffix() {
-        unsuffixed.given()
+        todoUnsuffixedApp.given()
                 .pathParam("id", 1)
                 .delete("/api/{id}")
                 .then()

--- a/examples/external-applications/src/test/resources/test.properties
+++ b/examples/external-applications/src/test/resources/test.properties
@@ -1,2 +1,7 @@
 ts.appuberjar.openshift.template=/uber-jar-quarkus-s2i-source-build-template.yml
 ts.database.openshift.use-internal-service-as-url=true
+
+# extend TodoDemoIT startup timeouts because the test was flaky with 5 minutes timeout
+ts.todoApp.startup.timeout=9m
+ts.todoExplicitApp.startup.timeout=9m
+ts.todoUnsuffixedApp.startup.timeout=9m


### PR DESCRIPTION
### Summary

This test keeps failing, just look at FW GH OCP runs and I just run it 5 times, it failed always on random of these 3 services (explicit, suffix, app; which one has changed)), I can't see anything wrong there. Also it takes ages to run it. I renamed services to make sure that timeout is only raised (from original 5 minutes) for services inside the troublesome test class.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)