### PR TITLE
Rely on Java to get the lines, avoid usage of System.lineSeparator()

### DIFF
--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusApplicationManagedResourceBuilder.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusApplicationManagedResourceBuilder.java
@@ -8,10 +8,10 @@ import static java.util.stream.Collectors.toSet;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -23,6 +23,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import io.quarkus.deployment.configuration.BuildTimeConfigurationReader;
@@ -325,12 +326,15 @@ public abstract class QuarkusApplicationManagedResourceBuilder implements Manage
 
             // gather build-time config keys from extensions deployment modules
             // this won't work for named config keys (without regex), but we can tweak that in the future if we need to
-            var deploymentBuildProps = Arrays
-                    .stream(FileUtils
-                            .loadFile("/deployment-build-props.txt")
-                            .split(System.lineSeparator()))
+            var deploymentBuildProps = IOUtils
+                    .readLines(QuarkusApplicationManagedResourceBuilder.class
+                            .getResourceAsStream("/deployment-build-props.txt"), StandardCharsets.UTF_8)
+                    .stream()
                     .map(String::trim)
                     .collect(toSet());
+            if (deploymentBuildProps.size() <= 1) {
+                throw new RuntimeException("deployment-build-props.txt couldn't be properly loaded");
+            }
             buildTimeConfigKeys.addAll(deploymentBuildProps);
 
             // handle relocations - if relocation processor is applied, we won't find original config property


### PR DESCRIPTION
### Summary

Do not use System.lineSeparator(), deployment-build-props.txt file was generated on Unix-like system and causes troubles on Windows systems (in some cases, especially when build time fixed property is redefined). Rely on Java to get the lines instead.

On Windows the whole deployment-build-props.txt was treated as one entry in `buildTimeConfigKeys` before this change. I've added safety check to avoid this situation in the future.

This is the root cause of io.quarkus.ts.http.advanced.ContainerRequestFilterIT and io.quarkus.ts.http.advanced.reactive.ContainerRequestFilterReactiveIT failures on Windows in TS PRs - e.g. https://github.com/quarkus-qe/quarkus-test-suite/actions/runs/12600192714/job/35127050598?pr=2255

Generated applications.properties file was much smaller on Windows than on Linux. The investigation was quite time consuming, but the fix is pretty trivial :)

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)