### PR TITLE
Use quarkus-bom snapshot in main

### DIFF
--- a/.github/actions/prepare-quarkus-cli/action.yml
+++ b/.github/actions/prepare-quarkus-cli/action.yml
@@ -1,0 +1,20 @@
+name: 'Create Quarkus CLI 999-SNAPSHOT'
+description: 'Creates Quarkus CLI based on the current Quarkus main (999-SNAPSHOT version)'
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Maven settings.xml # we need to do this because of CLI and external app tests does not propagate '-s' option
+      shell: bash
+      run: cp .github/quarkus-snapshots-mvn-settings.xml ~/.m2/settings.xml
+    - name: Download Quarkus CLI
+      shell: bash
+      run: mvn org.apache.maven.plugins:maven-dependency-plugin:get -Dartifact=io.quarkus:quarkus-cli:999-SNAPSHOT:jar:runner
+    - name: Install Quarkus CLI
+      shell: bash
+      run: |
+        cat <<EOF > ./quarkus-dev-cli
+        #!/bin/bash
+        java -jar ~/.m2/repository/io/quarkus/quarkus-cli/999-SNAPSHOT/quarkus-cli-999-SNAPSHOT-runner.jar "\$@"
+        EOF
+        chmod +x ./quarkus-dev-cli
+        ./quarkus-dev-cli version

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -23,17 +23,7 @@ jobs:
           check-latest: true
           cache: 'maven'
         id: install-jdk
-      - name: Build Quarkus CLI
-        run: |
-          git clone https://github.com/quarkusio/quarkus.git && cd quarkus/devtools/cli && mvn -B --no-transfer-progress -s ../../../.github/mvn-settings.xml clean install -Dquickly -Dno-test-modules -Prelocations
-      - name: Install Quarkus CLI
-        run: |
-          cat <<EOF > ./quarkus-dev-cli
-          #!/bin/bash
-          java -jar $PWD/quarkus/devtools/cli/target/quarkus-cli-999-SNAPSHOT-runner.jar "\$@"
-          EOF
-          chmod +x ./quarkus-dev-cli
-          ./quarkus-dev-cli version
+      - uses: ./.github/actions/prepare-quarkus-cli
       - name: Build
         run: |
           mvn -B --no-transfer-progress -fae -s .github/mvn-settings.xml clean install -Pframework,examples,coverage -Dvalidate-format -Drun-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli" -Dquarkus.platform.version="${{ matrix.quarkus-version }}"

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -4,76 +4,9 @@ on:
   schedule:
     - cron: '0 23 * * *'
 jobs:
-  quarkus-main-build:
-    name: Quarkus main build
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        java: [ 17 ]
-    steps:
-      - uses: actions/checkout@v4
-      - name: Reclaim Disk Space
-        run: .github/ci-prerequisites.sh
-      - name: Install required tools
-        run: sudo apt update && sudo apt install pigz
-      - name: Install JDK {{ matrix.java }}
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: ${{ matrix.java }}
-          check-latest: true
-          cache: 'maven'
-      - name: Build Quarkus main
-        run: |
-          git clone https://github.com/quarkusio/quarkus.git && cd quarkus && ./mvnw -B --no-transfer-progress -s .github/mvn-settings.xml clean install -Dquickly -Dno-test-modules -Prelocations
-      - name: Tar Maven Repo
-        shell: bash
-        run: tar -I 'pigz -9' -cf maven-repo.tgz -C ~ .m2/repository
-      - name: Persist Maven Repo
-        uses: actions/upload-artifact@v4
-        with:
-          name: maven-repo
-          path: maven-repo.tgz
-          retention-days: 1
-  linux-build-jvm-released:
-    name: Daily - Linux - JVM build - Released Versions
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        quarkus-version: ["current"]
-        java: [ 17, 21 ]
-    steps:
-      - uses: actions/checkout@v4
-      - name: Reclaim Disk Space
-        run: .github/ci-prerequisites.sh
-      - name: Install JDK {{ matrix.java }}
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: ${{ matrix.java }}
-          check-latest: true
-          cache: 'maven'
-      - name: Build
-        run: |
-          if [[ "${{ matrix.quarkus-version }}" != current ]]; then
-             QUARKUS_VERSION="-Dquarkus.platform.version=${{ matrix.quarkus-version }}"
-          fi
-
-          mvn -B --no-transfer-progress -fae -s .github/mvn-settings.xml clean install -Dvalidate-format $QUARKUS_VERSION -Pframework,examples
-      - name: Zip Artifacts
-        if: failure()
-        run: |
-          zip -R artifacts-quarkus${{ matrix.quarkus-version }}-linux-jvm${{ matrix.java }}.zip '*-reports/*'
-      - name: Archive artifacts
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: artifacts-quarkus${{ matrix.quarkus-version }}-linux-jvm${{ matrix.java }}
-          path: artifacts-quarkus${{ matrix.quarkus-version }}-linux-jvm${{ matrix.java }}.zip
   linux-build-jvm-latest:
     name: Daily - Linux - JVM build - Latest Version
     runs-on: ubuntu-latest
-    needs: quarkus-main-build
     strategy:
       matrix:
         quarkus-version: ["999-SNAPSHOT"]
@@ -90,14 +23,6 @@ jobs:
           check-latest: true
           cache: 'maven'
         id: install-jdk
-      - name: Download Maven Repo
-        uses: actions/download-artifact@v4
-        with:
-          name: maven-repo
-          path: .
-      - name: Extract Maven Repo
-        shell: bash
-        run: tar -xzf maven-repo.tgz -C ~
       - name: Build Quarkus CLI
         run: |
           git clone https://github.com/quarkusio/quarkus.git && cd quarkus/devtools/cli && mvn -B --no-transfer-progress -s ../../../.github/mvn-settings.xml clean install -Dquickly -Dno-test-modules -Prelocations
@@ -163,7 +88,6 @@ jobs:
   linux-build-native:
     name: Daily - Linux - Native build
     runs-on: ubuntu-latest
-    needs: quarkus-main-build
     strategy:
       matrix:
         quarkus-version: ["current", "999-SNAPSHOT"]
@@ -179,14 +103,6 @@ jobs:
           java-version: ${{ matrix.java }}
           check-latest: true
           cache: 'maven'
-      - name: Download Maven Repo
-        uses: actions/download-artifact@v4
-        with:
-          name: maven-repo
-          path: .
-      - name: Extract Maven Repo
-        shell: bash
-        run: tar -xzf maven-repo.tgz -C ~
       - name: Build
         run: |
           if [[ "${{ matrix.quarkus-version }}" != current ]]; then
@@ -207,7 +123,6 @@ jobs:
   kubernetes-build-jvm-latest:
     name: Daily - Kubernetes - JVM - Latest version
     runs-on: ubuntu-latest
-    needs: quarkus-main-build
     strategy:
       matrix:
         quarkus-version: ["999-SNAPSHOT"]
@@ -223,14 +138,6 @@ jobs:
           java-version: ${{ matrix.java }}
           check-latest: true
           cache: 'maven'
-      - name: Download Maven Repo
-        uses: actions/download-artifact@v4
-        with:
-          name: maven-repo
-          path: .
-      - name: Extract Maven Repo
-        shell: bash
-        run: tar -xzf maven-repo.tgz -C ~
       - name: Set up Minikube-Kubernetes
         uses: manusa/actions-setup-minikube@v2.13.0
         with:
@@ -259,7 +166,6 @@ jobs:
   kubernetes-build-native-latest:
     name: Daily - Kubernetes - Native build - Latest version
     runs-on: ubuntu-latest
-    needs: quarkus-main-build
     strategy:
       matrix:
         quarkus-version: ["999-SNAPSHOT"]
@@ -275,14 +181,6 @@ jobs:
           java-version: ${{ matrix.java }}
           check-latest: true
           cache: 'maven'
-      - name: Download Maven Repo
-        uses: actions/download-artifact@v4
-        with:
-          name: maven-repo
-          path: .
-      - name: Extract Maven Repo
-        shell: bash
-        run: tar -xzf maven-repo.tgz -C ~
       - name: Set up Minikube-Kubernetes
         uses: manusa/actions-setup-minikube@v2.13.0
         with:
@@ -311,7 +209,6 @@ jobs:
   windows-build-jvm-latest:
     name: Daily - Windows - JVM build - Latest Version
     runs-on: windows-latest
-    needs: quarkus-main-build
     strategy:
       matrix:
         java: [ 17, 21 ]
@@ -325,14 +222,6 @@ jobs:
           java-version: ${{ matrix.java }}
           check-latest: true
           cache: 'maven'
-      - name: Download Maven Repo
-        uses: actions/download-artifact@v4
-        with:
-          name: maven-repo
-          path: .
-      - name: Extract Maven Repo
-        shell: bash
-        run: tar -xzf maven-repo.tgz -C ~
       - name: Build in JVM mode
         shell: bash
         run: |
@@ -352,7 +241,6 @@ jobs:
   windows-build-native-latest:
     name: Daily - Windows - Native build - Latest Version
     runs-on: windows-latest
-    needs: quarkus-main-build
     strategy:
       matrix:
         java: [ 17 ]
@@ -374,14 +262,6 @@ jobs:
       - name: Unzip Sysinternals Handle
         shell: pwsh
         run: Expand-Archive .\handle.zip -DestinationPath .
-      - name: Download Maven Repo
-        uses: actions/download-artifact@v4
-        with:
-          name: maven-repo
-          path: .
-      - name: Extract Maven Repo
-        shell: bash
-        run: tar -xzf maven-repo.tgz -C ~
       - name: Install cl.exe
         uses: ilammy/msvc-dev-cmd@v1
       - uses: microsoft/setup-msbuild@v2

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -33,63 +33,6 @@ jobs:
           name: maven-repo-current-fw${{matrix.java}}
           path: maven-repo-current-fw.tgz
           retention-days: 1
-  linux-build-jvm-released:
-    name: Linux - JVM build - Released Versions
-    runs-on: ubuntu-latest
-    needs: validate-format
-    strategy:
-      matrix:
-        quarkus-version: ["current"]
-        java: [ 17 ]
-    outputs:
-      has-flaky-tests: ${{steps.flaky-test-detector.outputs.has-flaky-tests}}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Reclaim Disk Space
-        run: .github/ci-prerequisites.sh
-      - name: Install JDK {{ matrix.java }}
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: ${{ matrix.java }}
-          check-latest: true
-          cache: 'maven'
-      - name: Download Maven Repo
-        uses: actions/download-artifact@v4
-        with:
-          name: maven-repo-current-fw${{matrix.java}}
-          path: .
-      - name: Extract Maven Repo
-        shell: bash
-        run: tar -xzf maven-repo-current-fw.tgz -C ~
-      - name: Build in JVM mode
-        run: |
-          mvn -B --no-transfer-progress -fae -s .github/mvn-settings.xml clean install -Pexamples
-      - name: Detect flaky tests
-        id: flaky-test-detector
-        shell: bash
-        if: ${{ hashFiles('**/flaky-run-report.json') != '' }}
-        run: echo "has-flaky-tests=true" >> "$GITHUB_OUTPUT"
-      - name: Rename flaky test run report to avoid file name conflicts
-        id: rename-flaky-test-run-report
-        if: ${{ hashFiles('**/flaky-run-report.json') != '' }}
-        shell: bash
-        run: mv target/flaky-run-report.json target/flaky-run-report-linux-jvm-released.json
-      - name: Archive flaky run report
-        id: archive-flaky-run-report
-        if: ${{ hashFiles('**/flaky-run-report-linux-jvm-released.json') != '' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: flaky-run-report-linux-jvm-released
-          path: target/flaky-run-report-linux-jvm-released.json
-      - name: Zip Artifacts
-        run: |
-          zip -R artifacts-quarkus${{ matrix.quarkus-version }}-linux-jvm${{ matrix.java }}.zip '*-reports/*'
-      - name: Archive artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: artifacts-quarkus${{ matrix.quarkus-version }}-linux-jvm${{ matrix.java }}
-          path: artifacts-quarkus${{ matrix.quarkus-version }}-linux-jvm${{ matrix.java }}.zip
   linux-build-jvm-latest:
     name: Linux - JVM build - Latest Version
     runs-on: ubuntu-latest
@@ -151,69 +94,6 @@ jobs:
         with:
           name: artifacts-latest-linux-jvm${{ matrix.java }}
           path: artifacts-latest-linux-jvm${{ matrix.java }}.zip
-  linux-build-native-released:
-    name: Linux - Native build - Released Version
-    runs-on: ubuntu-latest
-    needs: validate-format
-    strategy:
-      matrix:
-        quarkus-version: [ "current" ]
-        java: [ 17 ]
-        examples: [
-          'examples/pingpong,examples/restclient,examples/greetings,examples/blocking-reactive-model,examples/https,examples/grpc,examples/consul,examples/infinispan,examples/microprofile,examples/keycloak,examples/kafka,examples/kafka-registry,examples/kafka-streams',
-          '!examples/pingpong,!examples/restclient,!examples/greetings,!examples/blocking-reactive-model,!examples/https,!examples/grpc,!examples/consul,!examples/infinispan,!examples/microprofile,!examples/keycloak,!examples/kafka,!examples/kafka-registry,!examples/kafka-streams'
-        ]
-    outputs:
-      has-flaky-tests: ${{steps.flaky-test-detector.outputs.has-flaky-tests}}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Reclaim Disk Space
-        run: .github/ci-prerequisites.sh
-      - name: Install JDK {{ matrix.java }}
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: ${{ matrix.java }}
-          check-latest: true
-          cache: 'maven'
-      - name: Download Maven Repo
-        uses: actions/download-artifact@v4
-        with:
-          name: maven-repo-current-fw${{matrix.java}}
-          path: .
-      - name: Extract Maven Repo
-        shell: bash
-        run: tar -xzf maven-repo-current-fw.tgz -C ~
-      - name: Build
-        run: |
-          mvn -B --no-transfer-progress -fae -s .github/mvn-settings.xml clean install -Pexamples,native -pl '${{ matrix.examples }}'
-      - name: Detect flaky tests
-        id: flaky-test-detector
-        shell: bash
-        if: ${{ hashFiles('**/flaky-run-report.json') != '' }}
-        run: echo "has-flaky-tests=true" >> "$GITHUB_OUTPUT"
-      - name: Rename flaky test run report to avoid file name conflicts
-        id: rename-flaky-test-run-report
-        if: ${{ hashFiles('**/flaky-run-report.json') != '' }}
-        shell: bash
-        run: mv target/flaky-run-report.json target/flaky-run-report-linux-native-released.json
-      - name: Archive flaky run report
-        id: archive-flaky-run-report
-        if: ${{ hashFiles('**/flaky-run-report-linux-native-released.json') != '' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: flaky-run-report-linux-native-released
-          path: target/flaky-run-report-linux-native-released.json
-      - name: Zip Artifacts
-        if: failure()
-        run: |
-          zip -R artifacts-native-${{ matrix.quarkus-version }}-${{ matrix.java }}.zip '*-reports/*'
-      - name: Archive artifacts
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: artifacts-native-${{ matrix.quarkus-version }}-${{ matrix.java }}
-          path: artifacts-native-${{ matrix.quarkus-version }}-${{ matrix.java }}.zip
   windows-build-jvm-latest:
     name: Windows - JVM build - Latest Version
     runs-on: windows-latest
@@ -269,23 +149,15 @@ jobs:
   detect-flaky-tests:
     name: Detect flaky tests
     runs-on: ubuntu-latest
-    needs: [linux-build-jvm-released, linux-build-jvm-latest, linux-build-native-released, windows-build-jvm-latest]
+    needs: [linux-build-jvm-latest, windows-build-jvm-latest]
     steps:
       - name: Create file with information about job with flaky test
-        if: needs.linux-build-jvm-released.outputs.has-flaky-tests == 'true' || needs.linux-build-jvm-latest.outputs.has-flaky-tests == 'true' || needs.linux-build-native-released.outputs.has-flaky-tests == 'true' || needs.windows-build-jvm-latest.outputs.has-flaky-tests == 'true'
+        if: needs.linux-build-jvm-latest.outputs.has-flaky-tests == 'true' || needs.windows-build-jvm-latest.outputs.has-flaky-tests == 'true'
         run: |
           job_name=""
           if $IS_LINUX_JVM_LATEST
           then
           job_name+=", 'Linux - JVM build - Latest Version'"
-          fi
-          if $IS_LINUX_JVM_RELEASED
-          then
-          job_name+=", 'Linux - JVM build - Released Versions'"
-          fi
-          if $IS_LINUX_NATIVE_RELEASED
-          then
-          job_name+=", 'Linux - Native build - Released Version'"
           fi
           if $IS_WINDOWS_JVM_LATEST
           then
@@ -294,8 +166,6 @@ jobs:
           echo "${job_name:2}" > jobs-with-flaky-tests
         env:
           IS_LINUX_JVM_LATEST: ${{ needs.linux-build-jvm-latest.outputs.has-flaky-tests == 'true' }}
-          IS_LINUX_JVM_RELEASED: ${{ needs.linux-build-jvm-released.outputs.has-flaky-tests == 'true' }}
-          IS_LINUX_NATIVE_RELEASED: ${{ needs.linux-build-native-released.outputs.has-flaky-tests == 'true' }}
           IS_WINDOWS_JVM_LATEST: ${{ needs.windows-build-jvm-latest.outputs.has-flaky-tests == 'true' }}
       - name: Archive 'jobs-with-flaky-tests' artifact
         if: ${{ hashFiles('**/jobs-with-flaky-tests') != '' }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -54,18 +54,7 @@ jobs:
           java-version: ${{ matrix.java }}
           check-latest: true
           cache: 'maven'
-      - name: Set up Maven settings.xml # we need to do this because of CLI and external app tests does not propagate '-s' option
-        run: cp .github/quarkus-snapshots-mvn-settings.xml ~/.m2/settings.xml
-      - name: Download Quarkus CLI
-        run: mvn org.apache.maven.plugins:maven-dependency-plugin:get -Dartifact=io.quarkus:quarkus-cli:999-SNAPSHOT:jar:runner
-      - name: Install Quarkus CLI
-        run: |
-          cat <<EOF > ./quarkus-dev-cli
-          #!/bin/bash
-          java -jar ~/.m2/repository/io/quarkus/quarkus-cli/999-SNAPSHOT/quarkus-cli-999-SNAPSHOT-runner.jar "\$@"
-          EOF
-          chmod +x ./quarkus-dev-cli
-          ./quarkus-dev-cli version
+      - uses: ./.github/actions/prepare-quarkus-cli
       - name: Build in JVM mode
         run: |
           mvn -B --no-transfer-progress -fae clean install -Pframework,examples -Drun-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli" -Dquarkus.platform.version="${{ matrix.quarkus-version }}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,7 +137,9 @@ When creating new branch please ensure following items:
  - There are no pending PRs for relevant RHBQ or Quarkus stream
  - Pin external application branches, see for example https://github.com/quarkus-qe/quarkus-test-framework/pull/905
  - Pin CLI to concrete stream, see for example https://github.com/quarkus-qe/quarkus-test-framework/pull/918
+ - Use GH Action pr, based on previous stream branch, for example https://github.com/quarkus-qe/quarkus-test-framework/blob/37f099ad8851f05ebdf1a9284dc006c4849b7bf4/.github/workflows/pr.yaml
  - Update GH Actions to use the right Quarkus branch, see for example https://github.com/quarkus-qe/quarkus-test-framework/pull/920
+ - Change `quarkus.platform.version` property in parent pom.xml to use specific quarkus version, not snapshot
 
 ## The small print
 

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <maven-deploy-plugin.version>3.1.3</maven-deploy-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>3.17.5</quarkus.platform.version>
+        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
         <exclude.tests.with.tags>quarkus-cli</exclude.tests.with.tags>
         <include.tests>**/*IT.java</include.tests>
         <exclude.openshift.tests>**/OpenShift*IT.java</exclude.openshift.tests>
@@ -77,6 +77,31 @@
         <reruns>2</reruns>
         <flaky-run-reporter.version>0.1.4</flaky-run-reporter.version>
     </properties>
+    <repositories>
+        <repository>
+            <!-- repository where quarkus 999-snapshot is built -->
+            <id>ossrh</id>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>quarkus-snapshots-plugin-repository</id>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
     <distributionManagement>
         <snapshotRepository>
             <id>ossrh</id>


### PR DESCRIPTION
### Summary

This PR continues on https://github.com/quarkus-qe/quarkus-test-framework/pull/1422.

Original goal was to have a daily compatible build of FW and TS. Currently our TS is quarkus 999-SNAPSHOT while framework use 3.17.5. This causes binary incompatibilities between FW and TS. Changing FW to also quarkus 999-SNAPSHOT in main branch.

This might cause instability with daily FW builds but I see no other way to have FW and TS in same line.

Please check the relevant options

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)