### PR TITLE
Use Kafka 3.9.0 to align with Strimzi Operator 0.45.0 support

### DIFF
--- a/examples/kafka/pom.xml
+++ b/examples/kafka/pom.xml
@@ -52,7 +52,7 @@
                         <configuration>
                             <systemPropertyVariables>
                                 <custom.kafka.image>quay.io/strimzi/kafka</custom.kafka.image>
-                                <custom.kafka.version>0.41.0-kafka-3.7.0</custom.kafka.version>
+                                <custom.kafka.version>0.45.0-kafka-3.9.0</custom.kafka.version>
                             </systemPropertyVariables>
                         </configuration>
                     </execution>

--- a/examples/kafka/src/test/resources/strimzi-custom-server-ssl.properties
+++ b/examples/kafka/src/test/resources/strimzi-custom-server-ssl.properties
@@ -35,7 +35,8 @@ controller.quorum.voters=1@localhost:9094
 #   EXAMPLE:
 #     listeners = PLAINTEXT://your.host.name:9092
 #listeners=PLAINTEXT://:9092
-listeners=BROKER://0.0.0.0:9093,SSL://0.0.0.0:9092,CONTROLLER://0.0.0.0:9094
+# TODO switch to listeners=BROKER://0.0.0.0:9093,SSL://0.0.0.0:9092,CONTROLLER://0.0.0.0:9094 when this issue is fixed - https://github.com/apache/kafka/pull/18387
+listeners=BROKER://:9093,SSL://:9092,CONTROLLER://:9094
 
 # Name of listener used for communication between brokers.
 inter.broker.listener.name=BROKER

--- a/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/model/KafkaVendor.java
+++ b/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/model/KafkaVendor.java
@@ -3,7 +3,7 @@ package io.quarkus.test.services.containers.model;
 public enum KafkaVendor {
     CONFLUENT("confluentinc/cp-kafka", "7.6.1", 9092, KafkaRegistry.CONFLUENT),
     // When updating strimzi kafka also update version in examples-kafka pom
-    STRIMZI("quay.io/strimzi/kafka", "0.41.0-kafka-3.7.0", 9092, KafkaRegistry.APICURIO);
+    STRIMZI("quay.io/strimzi/kafka", "0.45.0-kafka-3.9.0", 9092, KafkaRegistry.APICURIO);
 
     private final String image;
     private final String defaultVersion;

--- a/quarkus-test-service-kafka/src/main/resources/strimzi-default-server-sasl-ssl.properties
+++ b/quarkus-test-service-kafka/src/main/resources/strimzi-default-server-sasl-ssl.properties
@@ -35,7 +35,8 @@ controller.quorum.voters=1@localhost:9094
 #   EXAMPLE:
 #     listeners = PLAINTEXT://your.host.name:9092
 #listeners=PLAINTEXT://:9092
-listeners=BROKER://0.0.0.0:9093,SASL_SSL://0.0.0.0:9092,CONTROLLER://0.0.0.0:9094
+# TODO switch to listeners=BROKER://0.0.0.0:9093,SSL://0.0.0.0:9092,CONTROLLER://0.0.0.0:9094 when this issue is fixed - https://github.com/apache/kafka/pull/18387
+listeners=BROKER://:9093,SASL_SSL://:9092,CONTROLLER://:9094
 
 # Name of listener used for communication between brokers.
 inter.broker.listener.name=BROKER

--- a/quarkus-test-service-kafka/src/main/resources/strimzi-default-server-sasl.properties
+++ b/quarkus-test-service-kafka/src/main/resources/strimzi-default-server-sasl.properties
@@ -39,7 +39,8 @@ controller.quorum.voters=1@localhost:9094
 #     listeners = listener_name://host_name:port
 #   EXAMPLE:
 #     listeners = PLAINTEXT://your.host.name:9092
-listeners=BROKER://0.0.0.0:9093,SASL_PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9094
+# TODO switch to listeners=BROKER://0.0.0.0:9093,SSL://0.0.0.0:9092,CONTROLLER://0.0.0.0:9094 when this issue is fixed - https://github.com/apache/kafka/pull/18387
+listeners=BROKER://:9093,SASL_PLAINTEXT://:9092,CONTROLLER://:9094
 
 # Name of listener used for communication between brokers.
 inter.broker.listener.name=BROKER

--- a/quarkus-test-service-kafka/src/main/resources/strimzi-default-server-ssl.properties
+++ b/quarkus-test-service-kafka/src/main/resources/strimzi-default-server-ssl.properties
@@ -35,7 +35,8 @@ controller.quorum.voters=1@localhost:9094
 #   EXAMPLE:
 #     listeners = PLAINTEXT://your.host.name:9092
 #listeners=PLAINTEXT://:9092
-listeners=BROKER://0.0.0.0:9093,SSL://0.0.0.0:9092,CONTROLLER://0.0.0.0:9094
+# TODO switch to listeners=BROKER://0.0.0.0:9093,SSL://0.0.0.0:9092,CONTROLLER://0.0.0.0:9094 when this issue is fixed - https://github.com/apache/kafka/pull/18387
+listeners=BROKER://:9093,SSL://:9092,CONTROLLER://:9094
 
 # Name of listener used for communication between brokers.
 inter.broker.listener.name=BROKER

--- a/quarkus-test-service-kafka/src/main/resources/strimzi-operator-kafka-instance.yaml
+++ b/quarkus-test-service-kafka/src/main/resources/strimzi-operator-kafka-instance.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kafka-instance
 spec:
   kafka:
-    version: 3.7.0
+    version: 3.9.0
     replicas: 1
     listeners:
       - name: plain


### PR DESCRIPTION
This PR addresses an issue discovered in our Jenkins jobs (quarkus-main-rhel8-jdk17-openshift-tf jvm/native), the test OpenShiftStrimziOperatorKafkaWithoutRegistryMessagingIT failed due to UnsupportedKafkaVerisionException.
In this PR :
- It's updated strimzi-operator-kafka-instance.yaml to specify 3.9.0 Kafka version instead of 3.7.0
- It's adjusted KafkaVendor to 0.45.0-kafka-3.9.0
- Removing 0.0.0.0 from .properties files because in Kraft mode(Kafka 3.9.0) is disallowed and caused non-routable errors. [see my comment here](https://github.com/quarkus-qe/quarkus-test-framework/pull/1465#issuecomment-2586975017)

With these changes is resolved the incompatibility.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)