### PR TITLE
Test creating of Quarkus applications and extensions with snapshot CLI targeting both Quarkus snapshot and the latest released version

### DIFF
--- a/examples/quarkus-cli/src/test/java/io/quarkus/qe/QuarkusCliClientIT.java
+++ b/examples/quarkus-cli/src/test/java/io/quarkus/qe/QuarkusCliClientIT.java
@@ -26,8 +26,10 @@ import org.junit.jupiter.api.Test;
 import io.quarkus.test.bootstrap.QuarkusCliClient;
 import io.quarkus.test.bootstrap.QuarkusCliDefaultService;
 import io.quarkus.test.bootstrap.QuarkusCliRestService;
+import io.quarkus.test.bootstrap.QuarkusVersionAwareCliClient;
 import io.quarkus.test.bootstrap.config.QuarkusConfigCommand;
 import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.scenarios.TestQuarkusCli;
 import io.quarkus.test.scenarios.annotations.EnabledOnNative;
 import io.quarkus.test.services.quarkus.CliDevModeVersionLessQuarkusApplicationManagedResource;
 import io.quarkus.test.services.quarkus.model.QuarkusProperties;
@@ -56,8 +58,8 @@ public class QuarkusCliClientIT {
         assertEquals(QuarkusProperties.getVersion(), cliClient.run("-v").getOutput());
     }
 
-    @Test
-    public void shouldCreateApplicationOnJvm() {
+    @TestQuarkusCli
+    public void shouldCreateApplicationOnJvm(QuarkusVersionAwareCliClient cliClient) {
         // Create application
         QuarkusCliRestService app = cliClient.createApplication("app");
 
@@ -82,10 +84,10 @@ public class QuarkusCliClientIT {
                 "The application didn't build on Native. Output: " + result.getOutput());
     }
 
-    @Test
-    public void shouldCreateApplicationWithCodeStarter() {
+    @TestQuarkusCli
+    public void shouldCreateApplicationWithCodeStarter(QuarkusVersionAwareCliClient cliClient) {
         // Create application with Resteasy Jackson
-        QuarkusCliRestService app = cliClient.createApplication("app", defaults()
+        QuarkusCliRestService app = cliClient.createApplication("app", cliClient.getDefaultCreateApplicationRequest()
                 .withExtensions(REST_SPRING_WEB_EXTENSION, REST_JACKSON_EXTENSION));
 
         // Verify By default, it installs only "quarkus-resteasy"
@@ -96,8 +98,8 @@ public class QuarkusCliClientIT {
         untilAsserted(() -> app.given().get("/greeting").then().statusCode(HttpStatus.SC_OK).and().body(is("Hello Spring")));
     }
 
-    @Test
-    public void shouldCreateExtension() {
+    @TestQuarkusCli
+    public void shouldCreateExtension(QuarkusVersionAwareCliClient cliClient) {
         // Create extension
         QuarkusCliDefaultService app = cliClient.createExtension("extension-abc");
 
@@ -106,8 +108,8 @@ public class QuarkusCliClientIT {
         assertTrue(result.isSuccessful(), "The extension build failed. Output: " + result.getOutput());
     }
 
-    @Test
-    public void shouldCreateApplicationUsingArtifactId() {
+    @TestQuarkusCli
+    public void shouldCreateApplicationUsingArtifactId(QuarkusVersionAwareCliClient cliClient) {
         QuarkusCliRestService app = cliClient.createApplication("com.mycompany:my-app");
         assertEquals("my-app", app.getServiceFolder().getFileName().toString(), "The application directory differs.");
 
@@ -131,8 +133,8 @@ public class QuarkusCliClientIT {
         assertTrue(response.contains("3.8"), "Quarkus is not running on 3.8");
     }
 
-    @Test
-    public void shouldAddAndRemoveExtensions() {
+    @TestQuarkusCli
+    public void shouldAddAndRemoveExtensions(QuarkusVersionAwareCliClient cliClient) {
         // Create application
         QuarkusCliRestService app = cliClient.createApplication("app");
 

--- a/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/QuarkusCliClient.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/QuarkusCliClient.java
@@ -37,6 +37,7 @@ public class QuarkusCliClient {
 
     public QuarkusCliClient(ScenarioContext context) {
         this.context = context;
+        this.context.getTestStore().put(QuarkusCliClient.class.getName(), this);
     }
 
     public Result run(Path servicePath, String... args) {
@@ -73,11 +74,11 @@ public class QuarkusCliClient {
 
     public QuarkusCliRestService createApplicationAt(String name, String targetFolderName) {
         Objects.requireNonNull(targetFolderName);
-        return createApplication(name, CreateApplicationRequest.defaults(), targetFolderName);
+        return createApplication(name, getDefaultCreateApplicationRequest(), targetFolderName);
     }
 
     public QuarkusCliRestService createApplication(String name) {
-        return createApplication(name, CreateApplicationRequest.defaults());
+        return createApplication(name, getDefaultCreateApplicationRequest());
     }
 
     public QuarkusCliRestService createApplication(String name, CreateApplicationRequest request) {
@@ -165,7 +166,7 @@ public class QuarkusCliClient {
     }
 
     public QuarkusCliDefaultService createExtension(String name) {
-        return createExtension(name, CreateExtensionRequest.defaults());
+        return createExtension(name, getDefaultCreateExtensionRequest());
     }
 
     public QuarkusCliDefaultService createExtension(String name, CreateExtensionRequest request) {
@@ -253,7 +254,7 @@ public class QuarkusCliClient {
         return version.contains(QUARKUS_UPSTREAM_VERSION);
     }
 
-    private static String getFixedStreamVersion() {
+    protected static String getFixedStreamVersion() {
         var rawVersion = QuarkusProperties.getVersion();
         if (isUpstream(rawVersion)) {
             throw new IllegalStateException("Cannot set fixed stream version for '%s' as it doesn't exist" + rawVersion);
@@ -282,6 +283,10 @@ public class QuarkusCliClient {
         var result = run(args.toArray(String[]::new));
         assertTrue(result.isSuccessful(), "Extensions list command didn't work. Output: " + result.getOutput());
         return result;
+    }
+
+    public String getQuarkusVersion() {
+        return QuarkusProperties.getVersion();
     }
 
     public static class CreateApplicationRequest {
@@ -416,5 +421,17 @@ public class QuarkusCliClient {
         public static ListExtensionRequest withSetStream() {
             return new ListExtensionRequest(isUpstream() ? QUARKUS_UPSTREAM_VERSION : getFixedStreamVersion());
         }
+    }
+
+    ScenarioContext getScenarioContext() {
+        return context;
+    }
+
+    public CreateApplicationRequest getDefaultCreateApplicationRequest() {
+        return CreateApplicationRequest.defaults();
+    }
+
+    public CreateExtensionRequest getDefaultCreateExtensionRequest() {
+        return CreateExtensionRequest.defaults();
     }
 }

--- a/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/QuarkusVersionAwareCliClient.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/QuarkusVersionAwareCliClient.java
@@ -1,0 +1,57 @@
+package io.quarkus.test.bootstrap;
+
+public final class QuarkusVersionAwareCliClient extends QuarkusCliClient {
+
+    public enum SetCliPlatformVersionMode {
+        SNAPSHOT(""),
+        FIXED_VERSION(" set explicitly"),
+        NO_VERSION("latest released Quarkus");
+
+        private final String quarkusVersionPostfix;
+
+        SetCliPlatformVersionMode(String quarkusVersionPostfix) {
+            this.quarkusVersionPostfix = quarkusVersionPostfix;
+        }
+
+        public String getQuarkusVersionPostfix() {
+            return quarkusVersionPostfix;
+        }
+    }
+
+    private final SetCliPlatformVersionMode mode;
+    private final String quarkusVersion;
+
+    public QuarkusVersionAwareCliClient(QuarkusCliClient cliClient, SetCliPlatformVersionMode mode, String quarkusVersion) {
+        super(cliClient.getScenarioContext());
+        this.mode = mode;
+        this.quarkusVersion = quarkusVersion;
+    }
+
+    @Override
+    public CreateApplicationRequest getDefaultCreateApplicationRequest() {
+        return switch (mode) {
+            case SNAPSHOT -> new CreateApplicationRequest().withCurrentPlatformBom();
+            case FIXED_VERSION -> new CreateApplicationRequest().withStream(getFixedStreamVersion());
+            // it is completely safe to not set platform
+            // because 'NO_VERSION' is only tested with the snapshots
+            // and RHBQ can never be snapshot, so we are testing the latest community version
+            // expected behavior for this option: you create app with CLI v 3.14 and the latest released is 3.17.6
+            // result: Quarkus app with 3.17.6 is created
+            case NO_VERSION -> new CreateApplicationRequest();
+        };
+    }
+
+    @Override
+    public CreateExtensionRequest getDefaultCreateExtensionRequest() {
+        return switch (mode) {
+            case SNAPSHOT -> new CreateExtensionRequest().withCurrentPlatformBom();
+            case FIXED_VERSION -> new CreateExtensionRequest().withStream(getFixedStreamVersion());
+            case NO_VERSION -> new CreateExtensionRequest();
+        };
+    }
+
+    @Override
+    public String getQuarkusVersion() {
+        return quarkusVersion;
+    }
+}

--- a/quarkus-test-cli/src/main/java/io/quarkus/test/extensions/TestQuarkusCliExtension.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/extensions/TestQuarkusCliExtension.java
@@ -1,0 +1,68 @@
+package io.quarkus.test.extensions;
+
+import static io.quarkus.test.extensions.TestQuarkusCliTemplateContext.QuarkusVersion.fixedVersion;
+import static io.quarkus.test.extensions.TestQuarkusCliTemplateContext.QuarkusVersion.latestReleased;
+import static io.quarkus.test.extensions.TestQuarkusCliTemplateContext.QuarkusVersion.snapshot;
+import static org.junit.platform.commons.support.AnnotationSupport.findAnnotation;
+
+import java.lang.reflect.Method;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
+
+import io.quarkus.test.configuration.PropertyLookup;
+import io.quarkus.test.extensions.TestQuarkusCliTemplateContext.QuarkusVersion;
+import io.quarkus.test.scenarios.TestQuarkusCli;
+import io.quarkus.test.services.quarkus.model.QuarkusProperties;
+
+/**
+ * Supports testing snapshot (999-SNAPSHOT, ...) Quarkus CLI with both released and snapshot Quarkus version.
+ * Allows you to test creating of applications with 999-SNAPSHOT and xyz Quarkus versions using one test method.
+ * Exactly like parametrized tests, but without need to declare argument source explicitly.
+ */
+public class TestQuarkusCliExtension implements TestTemplateInvocationContextProvider {
+
+    private static final String QUARKUS_UPSTREAM_VERSION = "999-SNAPSHOT";
+    private static final PropertyLookup RUN_WITH_LATEST_RELEASED = new PropertyLookup("cli.snapshot.test-released-quarkus",
+            "true");
+
+    @Override
+    public boolean supportsTestTemplate(ExtensionContext context) {
+        if (context.getTestMethod().isEmpty()) {
+            return false;
+        }
+
+        Method templateMethod = context.getTestMethod().get();
+        Optional<TestQuarkusCli> annotation = findAnnotation(templateMethod, TestQuarkusCli.class);
+        return annotation.isPresent();
+    }
+
+    @Override
+    public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(ExtensionContext extensionContext) {
+        return getTestedQuarkusVersions().map(TestQuarkusCliTemplateContext::new);
+    }
+
+    private static Stream<QuarkusVersion> getTestedQuarkusVersions() {
+        String quarkusVersion = QuarkusProperties.getVersion();
+
+        final Stream<QuarkusVersion> testedQuarkusVersions;
+        if (isUpstream(quarkusVersion)) {
+            if (RUN_WITH_LATEST_RELEASED.getAsBoolean()) {
+                testedQuarkusVersions = Stream.of(snapshot(quarkusVersion), latestReleased());
+            } else {
+                testedQuarkusVersions = Stream.of(snapshot(quarkusVersion));
+            }
+        } else {
+            testedQuarkusVersions = Stream.of(fixedVersion(quarkusVersion));
+        }
+
+        return testedQuarkusVersions;
+    }
+
+    private static boolean isUpstream(String version) {
+        return version.contains(QUARKUS_UPSTREAM_VERSION);
+    }
+}

--- a/quarkus-test-cli/src/main/java/io/quarkus/test/extensions/TestQuarkusCliTemplateContext.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/extensions/TestQuarkusCliTemplateContext.java
@@ -1,0 +1,86 @@
+package io.quarkus.test.extensions;
+
+import java.util.List;
+
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+
+import io.quarkus.test.bootstrap.QuarkusCliClient;
+import io.quarkus.test.bootstrap.QuarkusVersionAwareCliClient;
+import io.quarkus.test.bootstrap.QuarkusVersionAwareCliClient.SetCliPlatformVersionMode;
+import io.quarkus.test.bootstrap.ScenarioContext;
+
+/**
+ * Basically represents a Quarkus CLI test instance (method invocation).
+ * Also allows optionally inject tested Quarkus version as a method parameter.
+ */
+final class TestQuarkusCliTemplateContext implements TestTemplateInvocationContext, ParameterResolver {
+
+    record QuarkusVersion(String versionName, SetCliPlatformVersionMode mode) {
+
+        static QuarkusVersion snapshot(String quarkusVersion) {
+            return new QuarkusVersion(quarkusVersion, SetCliPlatformVersionMode.SNAPSHOT);
+        }
+
+        static QuarkusVersion latestReleased() {
+            return new QuarkusVersion(null, SetCliPlatformVersionMode.NO_VERSION);
+        }
+
+        static QuarkusVersion fixedVersion(String quarkusVersion) {
+            return new QuarkusVersion(quarkusVersion, SetCliPlatformVersionMode.FIXED_VERSION);
+        }
+    }
+
+    private final String quarkusVersion;
+    private final SetCliPlatformVersionMode mode;
+
+    TestQuarkusCliTemplateContext(QuarkusVersion quarkusVersion) {
+        this.quarkusVersion = quarkusVersion.versionName;
+        this.mode = quarkusVersion.mode;
+    }
+
+    @Override
+    public String getDisplayName(int invocationIndex) {
+        return (quarkusVersion == null ? "" : quarkusVersion) + mode.getQuarkusVersionPostfix();
+    }
+
+    @Override
+    public List<Extension> getAdditionalExtensions() {
+        return List.of(this);
+    }
+
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+            throws ParameterResolutionException {
+        var paramType = parameterContext.getParameter().getType();
+        return paramType == String.class || paramType == QuarkusCliClient.class
+                || paramType == QuarkusVersionAwareCliClient.class;
+    }
+
+    @Override
+    public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+            throws ParameterResolutionException {
+        var paramType = parameterContext.getParameter().getType();
+        if (paramType == QuarkusCliClient.class) {
+            return getQuarkusCliClient(extensionContext);
+        } else if (paramType == QuarkusVersionAwareCliClient.class) {
+            QuarkusCliClient cliClient = getQuarkusCliClient(extensionContext);
+            return new QuarkusVersionAwareCliClient(cliClient, mode, quarkusVersion);
+        } else if (paramType == String.class) {
+            return quarkusVersion;
+        } else {
+            throw new ParameterResolutionException("Unsupported parameter type: " + paramType);
+        }
+    }
+
+    private static QuarkusCliClient getQuarkusCliClient(ExtensionContext extensionContext) {
+        var testNamespace = ExtensionContext.Namespace.create(ScenarioContext.class);
+        var scenarioContextStore = extensionContext.getStore(testNamespace);
+        return (QuarkusCliClient) scenarioContextStore.get(QuarkusCliClient.class.getName());
+    }
+
+}

--- a/quarkus-test-cli/src/main/java/io/quarkus/test/scenarios/TestQuarkusCli.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/scenarios/TestQuarkusCli.java
@@ -1,0 +1,31 @@
+package io.quarkus.test.scenarios;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.quarkus.test.extensions.TestQuarkusCliExtension;
+
+/**
+ * Facilitates Quarkus CLI testing. When Quarkus snapshot is tested,
+ * the annotated test method is called twice, once for the snapshot version,
+ * once for the latest released version.
+ * This behavior can be disabled by setting the 'ts.global.cli.snapshot.test-released-quarkus'
+ * configuration property to 'false'.
+ * With such option, the test method is only called once, so that we test the snapshot version.
+ * There are multiple options how to set up Quarkus CLI test with this annotation, the easiest one
+ * is to inject the QuarkusVersionAwareCliClient and let our framework deal with versions.
+ * Other option is to inject Quarkus version as a {@link String} method argument and set up your tests manually.
+ */
+@Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@TestTemplate
+@ExtendWith(TestQuarkusCliExtension.class)
+public @interface TestQuarkusCli {
+}

--- a/quarkus-test-cli/src/main/java/io/quarkus/test/services/quarkus/CliDevModeLocalhostQuarkusApplicationManagedResource.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/services/quarkus/CliDevModeLocalhostQuarkusApplicationManagedResource.java
@@ -15,7 +15,6 @@ import io.quarkus.test.logging.LoggingHandler;
 import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusSnapshotCondition;
 import io.quarkus.test.services.URILike;
 import io.quarkus.test.services.quarkus.model.LaunchMode;
-import io.quarkus.test.services.quarkus.model.QuarkusProperties;
 import io.quarkus.test.utils.FileUtils;
 import io.quarkus.test.utils.ProcessUtils;
 import io.quarkus.test.utils.SocketUtils;
@@ -104,7 +103,9 @@ public class CliDevModeLocalhostQuarkusApplicationManagedResource extends Quarku
     protected Map<String, String> getPropertiesForCommand() {
         Map<String, String> runtimeProperties = new HashMap<>(serviceContext.getOwner().getProperties());
         runtimeProperties.putIfAbsent(QUARKUS_HTTP_PORT_PROPERTY, "" + assignedHttpPort);
-        runtimeProperties.putIfAbsent(QUARKUS_PLATFORM_VERSION, QuarkusProperties.getVersion());
+        if (client.getQuarkusVersion() != null) {
+            runtimeProperties.putIfAbsent(QUARKUS_PLATFORM_VERSION, client.getQuarkusVersion());
+        }
 
         if (DisabledOnQuarkusSnapshotCondition.isQuarkusSnapshotVersion()) {
             // In Quarkus Snapshot (999-SNAPSHOT), we can't use the quarkus platform bom as it's not resolved,


### PR DESCRIPTION
### Summary

Currently by default when we test snapshots (like 999-SNAPSHOT, 3.15.999-SNAPSHOT etc) with explicitly set platform like `--platform-bom=io.quarkus::999-SNAPSHOT` and non-snapshots also with explicitly set platform like `--platform-bom=io.quarkus::999-SNAPSHOT`.

That means that we:

1. don't test CLI without setting Quarkus platform (or stream)
2. don't test whether newer Quarkus CLI (like 999-SNAPSHOT one) can create application with older (e.g. currently latest released version) Quarkus application. this means we could miss issues like this one https://github.com/quarkusio/quarkus/issues/42649

This PR aims to make it easier to test creating both snapshot application/extension and the latest released application/extension. That it, it only comes into effect if the snapshot is tested.

How it works? You know parametrized tests, this is same principle, except we just use our test template provider. This way, we can also disable testing of the "latest released version" when we hit some incompatibility issues between released version and snapshot CLI. We can disable testing of the latest released Quarkus with the snapshot CLI using the `ts.global.cli.snapshot.test-released-quarkus=false` configuration property.

I have no illusion this is perfect, it doesn't cover every scenario we are testing and it can't. We need to explicitly declare what we want to test with both snapshot and the latest released Quarkus version (without setting `-P`) because wiring it implicitly would be too much magic noone would remember.

After this is merged, in the Quarkus QE Test Suite we must manually choose and alter tests that should run with both versions.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)