### PR TITLE
Improve fileUtils error logging.

### DIFF
--- a/quarkus-test-core/src/main/java/io/quarkus/test/utils/FileUtils.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/utils/FileUtils.java
@@ -29,7 +29,7 @@ public final class FileUtils {
         try {
             Files.writeString(target, content);
         } catch (IOException e) {
-            fail("Failed when writing file " + target + ". Caused by " + e.getMessage());
+            fail("Failed when writing file " + target, e);
         }
 
         return target;
@@ -39,7 +39,7 @@ public final class FileUtils {
         try {
             return org.apache.commons.io.FileUtils.readFileToString(file, StandardCharsets.UTF_8);
         } catch (IOException e) {
-            fail("Could not load file " + file + " . Caused by " + e.getMessage());
+            fail("Could not load file " + file, e);
         }
 
         return null;
@@ -51,7 +51,7 @@ public final class FileUtils {
                     FileUtils.class.getResourceAsStream(file),
                     StandardCharsets.UTF_8);
         } catch (IOException e) {
-            fail("Could not load file " + file + " . Caused by " + e.getMessage());
+            fail("Could not load file " + file, e);
         }
 
         return EMPTY;
@@ -80,7 +80,7 @@ public final class FileUtils {
         try {
             org.apache.commons.io.FileUtils.copyFileToDirectory(file, target.toFile());
         } catch (IOException e) {
-            fail("Could not copy project. Caused by " + e.getMessage());
+            fail("Could not copy project.", e);
         }
     }
 
@@ -96,7 +96,7 @@ public final class FileUtils {
         try {
             org.apache.commons.io.FileUtils.copyDirectory(source.toFile(), target.toFile());
         } catch (IOException e) {
-            fail("Could not copy project. Caused by " + e.getMessage());
+            fail("Could not copy project.", e);
         }
     }
 


### PR DESCRIPTION
### Summary

Current error messages from fileUtils provide little useful information, since root cause is often not in error message but in exception object itself, that is originally thrown and now ignored. Change this to propagate original exception into fail stacktrace.

For instance, when I tried to access file `/tmp/root` Accessible only by root (should throws permission denied) I originally got only:
```
org.opentest4j.AssertionFailedError: Could not load file /tmp/root . Caused by /tmp/root
	at org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:42)
	at org.junit.jupiter.api.Assertions.fail(Assertions.java:150)
	at io.quarkus.test.utils.FileUtils.loadFile(FileUtils.java:42)
	at io.quarkus.test.services.WtfTest.foo(WtfTest.java:12)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
```
Which does not show real problem.

Newly fail will print
```
org.opentest4j.AssertionFailedError: Could not load file /tmp/root
	at org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:42)
	at org.junit.jupiter.api.Assertions.fail(Assertions.java:150)
	at io.quarkus.test.utils.FileUtils.loadFile(FileUtils.java:42)
	at io.quarkus.test.services.WtfTest.foo(WtfTest.java:12)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
Caused by: java.nio.file.AccessDeniedException: /tmp/root
	at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:90)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:106)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
	at java.base/sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:218)
	at java.base/java.nio.file.Files.newByteChannel(Files.java:380)
	at java.base/java.nio.file.Files.newByteChannel(Files.java:432)
	at java.base/java.nio.file.spi.FileSystemProvider.newInputStream(FileSystemProvider.java:422)
	at java.base/java.nio.file.Files.newInputStream(Files.java:160)
	at org.apache.commons.io.FileUtils.lambda$readFileToString$14(FileUtils.java:2757)
	at org.apache.commons.io.IOUtils.toString(IOUtils.java:3238)
	at org.apache.commons.io.IOUtils.toString(IOUtils.java:3213)
	at org.apache.commons.io.FileUtils.readFileToString(FileUtils.java:2757)
	at io.quarkus.test.utils.FileUtils.loadFile(FileUtils.java:40)
	... 4 more
```

Please check the relevant options

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)