### PR TITLE
Fix test that use Strimzi Kafka containers because enabling of Kraft mode fails over discrepancy between node and broker id

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <oracle.image>docker.io/gvenzl/oracle-free:23-slim-faststart</oracle.image>
         <postgresql.image>docker.io/postgres:16</postgresql.image>
         <mysql.image>docker.io/mysql:8.4</mysql.image>
-        <strimzi.testcontainers.version>0.107.0</strimzi.testcontainers.version>
+        <strimzi.testcontainers.version>0.109.1</strimzi.testcontainers.version>
         <infinispan.image>docker.io/infinispan/server:15.0</infinispan.image>
         <infinispan-legacy.image>docker.io/infinispan/server:13.0</infinispan-legacy.image>
         <!-- TODO use official image if this fixed https://github.com/hashicorp/docker-consul/issues/184 -->

--- a/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/strimzi/ExtendedStrimziKafkaContainer.java
+++ b/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/strimzi/ExtendedStrimziKafkaContainer.java
@@ -74,8 +74,7 @@ public class ExtendedStrimziKafkaContainer extends StrimziKafkaContainer {
      * since config/kraft/server.properties contains node.id=1, we have to use this value
      */
     public ExtendedStrimziKafkaContainer enableKraftMode() {
-        return (ExtendedStrimziKafkaContainer) super.withKraft()
-                .withBrokerId(1);
+        return (ExtendedStrimziKafkaContainer) super.withNodeId(1).withBrokerId(1).withKraft();
     }
 
     public void configureScram(String name, String password) {


### PR DESCRIPTION
### Summary

Literally every Kafka test and Infinispan test that use Strimzi fails to start a Strimzi container https://github.com/quarkus-qe/quarkus-test-suite/actions/runs/12810036907/job/35716160691. I checked dependency tree in `quarkus-test-suite/messaging/kafka-streams-reactive-messaging`:

```
[INFO] +- io.quarkus.qe:quarkus-test-service-kafka:jar:999-SNAPSHOT:test
[INFO] |  +- org.testcontainers:kafka:jar:1.20.4:test
[INFO] |  +- io.strimzi:strimzi-test-container:jar:0.109.1:test
```

Our POM manages Strimzi version we declare explicitly https://github.com/quarkus-qe/quarkus-test-framework/blob/main/pom.xml#L72 and we know that there is something that can override this version, because it is documented: https://github.com/quarkus-qe/quarkus-test-framework/blob/d99146304f52c9a5ccfeede1d423a85374e0bd19/pom.xml#L125. I have tried to enforce Strimzi version we set in our POM, but that must probably be done in TS, not sure if it is important, it works now.

The issue itself is that effective `io.strimzi:strimzi-test-container` version to the `0.109.1` while our explicitly set version `0.107.0`. And in `0.109.1` is validation that says node id must be same as the broker id https://github.com/strimzi/test-container/blob/974411ff0989675b14693493579fcf9516c4a5b4/src/main/java/io/strimzi/test/container/StrimziKafkaContainer.java#L657. That is also not a new thing, if you check this javadoc in our FW, it explicitly mentions it: https://github.com/quarkus-qe/quarkus-test-framework/blob/d99146304f52c9a5ccfeede1d423a85374e0bd19/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/strimzi/ExtendedStrimziKafkaContainer.java#L71. However, we cannot just set `nodeId` and then `brokerId` because if you mention Strimzi code, it doesn't use method argument for the validation, but existing instance broker id `this.useKraft && this.brokerId != this.nodeId`. So if you set correct `withBrokerId`, it still fails because it doesn't use the method argument, it uses `this.brokerId` for validation :-).

Long story short, this PR updates `strimzi-test-container` to match the effective one in Quarkus QE Test Suite and makes sure that we set first broker id and node id before we enabler Kraft mode.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)