### PR TITLE
Bump manusa/actions-setup-minikube to 2.13.1 and update k8s version

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -91,10 +91,10 @@ jobs:
           check-latest: true
           cache: 'maven'
       - name: Set up Minikube-Kubernetes
-        uses: manusa/actions-setup-minikube@v2.13.0
+        uses: manusa/actions-setup-minikube@v2.13.1
         with:
-          minikube version: 'v1.33.1'
-          kubernetes version: 'v1.30.0'
+          minikube version: 'v1.35.0'
+          kubernetes version: 'v1.32.0'
           github token: ${{ secrets.GITHUB_TOKEN }}
       - name: Login to Docker Registry
         uses: docker/login-action@v3
@@ -134,10 +134,10 @@ jobs:
           check-latest: true
           cache: 'maven'
       - name: Set up Minikube-Kubernetes
-        uses: manusa/actions-setup-minikube@v2.13.0
+        uses: manusa/actions-setup-minikube@v2.13.1
         with:
-          minikube version: 'v1.33.1'
-          kubernetes version: 'v1.30.0'
+          minikube version: 'v1.35.0'
+          kubernetes version: 'v1.32.0'
           github token: ${{ secrets.GITHUB_TOKEN }}
       - name: Login to Docker Registry
         uses: docker/login-action@v3


### PR DESCRIPTION
### Summary

- Bumps [manusa/actions-setup-minikube](https://github.com/manusa/actions-setup-minikube) from 2.13.0 to 2.13.1.
- Use latest supported versions of minikube and kubernetes

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)