### PR TITLE
Remove java setting from mvn command in Jacoco CI

### DIFF
--- a/.github/workflows/weekly-jacoco.yml
+++ b/.github/workflows/weekly-jacoco.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: ./.github/actions/prepare-quarkus-cli
       - name: Generate Jacoco Report
         run: |
-          mvn -B --no-transfer-progress -fae -s .github/mvn-settings.xml clean install -Pframework,examples,coverage -Dvalidate-format -Drun-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli" -Dquarkus.platform.version="${{ matrix.quarkus-version }}"
+          mvn -B --no-transfer-progress -fae clean install -Pframework,examples,coverage -Dvalidate-format -Drun-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli" -Dquarkus.platform.version="${{ matrix.quarkus-version }}"
           cd coverage-report
           mvn -B package
       - name: Generate Jacoco Badge


### PR DESCRIPTION
### Summary

Removing the setting.xml from Jacoco CI. The same was done in here https://github.com/quarkus-qe/quarkus-test-framework/pull/1470 . In this case we don't need add settings as [`prepare-quarkus-cli`](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/.github/actions/prepare-quarkus-cli/action.yml#L8) already setting it system wide.

This should fix the CI failiure which happend over the weekend.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)