### PR TITLE
Fix GH action (check release version) for older releases

### DIFF
--- a/.github/workflows/check-release-version.yml
+++ b/.github/workflows/check-release-version.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Check release version
         run: |
-          releases=$(curl -sSL "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases")
+          releases=$(curl -sSL "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases?per_page=100")
 
           if [[ "$GITHUB_BASE_REF" == "main" ]]; then
             latest_prerelease=$(echo "$releases" | jq -r '.[] | select(.prerelease) | .tag_name' | head -n 1)


### PR DESCRIPTION
### Summary

In case of stable releases the script check if the initial release was released, the GitHub give the response contains the default value of entries (30). The initial release was not found in the response list so it failed the release check. This PR raising the number or returned releases from 30 to 100 items.

You can see the possible parameters at https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#list-releases


Checked this localy on my machine and it worked.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)