### PR TITLE
Use DIGEST-SHA-512 mechanism in infinispan configs

### DIFF
--- a/examples/infinispan/src/test/resources/infinispan.xml
+++ b/examples/infinispan/src/test/resources/infinispan.xml
@@ -45,7 +45,7 @@
             <endpoint socket-binding="default" security-realm="default">
                 <hotrod-connector name="hotrod">
                     <authentication>
-                        <sasl mechanisms="PLAIN DIGEST-MD5 BASIC" server-name="infinispan"/>
+                        <sasl mechanisms="PLAIN DIGEST-SHA-512 BASIC" server-name="infinispan"/>
                     </authentication>
                 </hotrod-connector>
                 <rest-connector name="rest">


### PR DESCRIPTION
### Summary

In 3.19 Quarkus changed[1] default digest mechanism for Infinispan from MD5 to more secure SHA-512 to be FIPS-compatible. We should use this digest in Infinispan config as well.

[1] https://github.com/quarkusio/quarkus/pull/45982

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)