### PR TITLE
Add `custom-build.required` to list of known framework properties

### DIFF
--- a/quarkus-test-core/src/main/java/io/quarkus/test/configuration/Configuration.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/configuration/Configuration.java
@@ -204,7 +204,8 @@ public final class Configuration {
         CONTAINER_PREFIX("docker-container-prefix"),
         S2I_MAVEN_REMOTE_REPOSITORY("s2i.maven.remote.repository"),
         S2I_REPLACE_CA_CERTS("s2i.java.replace-ca-certs"),
-        S2I_BASE_NATIVE_IMAGE("s2i.openshift.base-native-image");
+        S2I_BASE_NATIVE_IMAGE("s2i.openshift.base-native-image"),
+        CUSTOM_BUILD_REQUIRED("custom-build.required");
 
         private final String name;
 

--- a/quarkus-test-core/src/main/java/io/quarkus/test/utils/TestExecutionProperties.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/utils/TestExecutionProperties.java
@@ -1,5 +1,7 @@
 package io.quarkus.test.utils;
 
+import static io.quarkus.test.configuration.Configuration.Property.CUSTOM_BUILD_REQUIRED;
+
 import io.quarkus.test.bootstrap.Service;
 import io.quarkus.test.bootstrap.ServiceContext;
 import io.quarkus.test.configuration.PropertyLookup;
@@ -19,9 +21,10 @@ public final class TestExecutionProperties {
     private static final String APP_STARTED_KEY = "ts-internal.app-started";
     /**
      * You can enforce custom artifact build by setting this property for 'app' service with
-     * this 'ts.app.custom-build.required=true' or for all the services within a test class with 'ts.global.required=true'.
+     * this 'ts.app.custom-build.required=true' or for all the services within a test class
+     * with 'ts.global.custom-build.required=true'.
      */
-    private static final PropertyLookup REQUIRE_CUSTOM_BUILD = new PropertyLookup("custom-build.required", "false");
+    private static final PropertyLookup REQUIRE_CUSTOM_BUILD = new PropertyLookup(CUSTOM_BUILD_REQUIRED.toString(), "false");
 
     private final String serviceName;
     private final String buildNumber;


### PR DESCRIPTION
### Summary

This was missed in https://github.com/quarkus-qe/quarkus-test-framework/pull/791, but this property is used and documented in https://github.com/quarkus-qe/quarkus-test-framework/wiki/1.-Getting-Started#standalone-reproducer. It must be constant because JVM part of TS daily build fails over this https://github.com/quarkus-qe/quarkus-test-suite/actions/runs/13148597675/job/36691792761.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)