### PR TITLE
Fix container registry tests by adding proper configuration property scope as our FW doesn't recognize scopeless format anymore

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -104,7 +104,7 @@ jobs:
           password: ${{ secrets.CI_REGISTRY_PASSWORD }}
       - name: Build
         run: |
-          mvn -B --no-transfer-progress -fae -s .github/quarkus-snapshots-mvn-settings.xml clean install -Pframework,examples,kubernetes -Dquarkus.platform.version="${{ matrix.quarkus-version }}" -Dts.container.registry-url=${{ secrets.CI_REGISTRY }}
+          mvn -B --no-transfer-progress -fae -s .github/quarkus-snapshots-mvn-settings.xml clean install -Pframework,examples,kubernetes -Dquarkus.platform.version="${{ matrix.quarkus-version }}" -Dts.global.container.registry-url=${{ secrets.CI_REGISTRY }}
       - name: Zip Artifacts
         if: failure()
         run: |
@@ -147,7 +147,7 @@ jobs:
           password: ${{ secrets.CI_REGISTRY_PASSWORD }}
       - name: Build
         run: |
-          mvn -B --no-transfer-progress -fae -s .github/quarkus-snapshots-mvn-settings.xml clean install -Pframework,examples,native,kubernetes -Dquarkus.platform.version="${{ matrix.quarkus-version }}" -Dts.container.registry-url=${{ secrets.CI_REGISTRY }}
+          mvn -B --no-transfer-progress -fae -s .github/quarkus-snapshots-mvn-settings.xml clean install -Pframework,examples,native,kubernetes -Dquarkus.platform.version="${{ matrix.quarkus-version }}" -Dts.global.container.registry-url=${{ secrets.CI_REGISTRY }}
       - name: Zip Artifacts
         if: failure()
         run: |

--- a/quarkus-test-core/src/main/java/io/quarkus/test/configuration/Configuration.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/configuration/Configuration.java
@@ -225,6 +225,10 @@ public final class Configuration {
             return name;
         }
 
+        public String getGlobalScopeName() {
+            return getName(GLOBAL_SCOPE);
+        }
+
         public static Optional<Property> getByName(String requested) {
             return Arrays.stream(Property.values())
                     .filter(property -> property.name.equals(requested))

--- a/quarkus-test-images/src/main/java/io/quarkus/test/annotations/DisabledIfNotContainerRegistryCondition.java
+++ b/quarkus-test-images/src/main/java/io/quarkus/test/annotations/DisabledIfNotContainerRegistryCondition.java
@@ -11,7 +11,7 @@ public class DisabledIfNotContainerRegistryCondition extends CheckIfSystemProper
 
     @Override
     protected String getSystemPropertyName(ExtensionContext context) {
-        return CONTAINER_REGISTRY_URL.getName();
+        return CONTAINER_REGISTRY_URL.getGlobalScopeName();
     }
 
     @Override

--- a/quarkus-test-images/src/main/java/io/quarkus/test/utils/DockerUtils.java
+++ b/quarkus-test-images/src/main/java/io/quarkus/test/utils/DockerUtils.java
@@ -176,7 +176,7 @@ public final class DockerUtils {
 
     private static void validateContainerRegistry() {
         if (StringUtils.isEmpty(getRegistryURL())) {
-            fail("Container Registry URL is not provided, use -Dts.container.registry-url=XXX");
+            fail("Container Registry URL is not provided, use -Dts.global.container.registry-url=XXX");
         }
     }
 


### PR DESCRIPTION
### Summary

I have mentioned that container registry tests fail. One example are K8 tests in daily build of this project. You can see that `-Dquarkus.container-image.registry=quay.io -Dquarkus.container-image.group=quarkusqeteam` are not set anymore, therefore instead of `quay.io` Jib processor is using `docker.io` and tests fail with following error:

```
2025-02-04T23:21:46.1450205Z 23:21:46,009 INFO  mvn: Caused by: com.google.api.client.http.HttpResponseException: 401 Unauthorized
2025-02-04T23:21:46.1451493Z 23:21:46,009 INFO  mvn: GET https://auth.docker.io/token?service=registry.docker.io&scope=repository:runner/pingpong:pull,push
2025-02-04T23:21:46.1452621Z 23:21:46,009 INFO  mvn: {"details":"access token has insufficient scopes"}
```

The issue is that https://github.com/quarkus-qe/quarkus-test-framework/pull/791 has changed `ts.container.registry-url` configuration property to scoped property at some places and at some places, it still recognize the old format. This way, at places where `PropertyLookup` is used, the old format is not recognized anymore.

This PR unify behavior and use `global` scope as it is one -to-one to the old behavior.

**IMPORTANT**: 

- I also provided MR in Gitlab for Jenkins jobs and this must go in as well (and if you insist on OpenShift tests, I suppose it needs to go first).
- We should also change FW `1.5.z` and `1.4.z` branches so that they in addition to the old format also supports the new format, this way, we don't need to support 2 formats in our Jenkins jobs.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)