### PR TITLE
Switch from UBI8 to UBI9 as Quarkus does in 3.19

### DIFF
--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/model/QuarkusProperties.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/model/QuarkusProperties.java
@@ -28,9 +28,9 @@ public final class QuarkusProperties {
     public static final List<String> PACKAGE_TYPE_LEGACY_JAR_VALUES = Arrays.asList("legacy-jar", "uber-jar", "mutable-jar");
     public static final List<String> PACKAGE_TYPE_JVM_VALUES = Arrays.asList("fast-jar", "jar");
     public static final PropertyLookup QUARKUS_JVM_S2I = new PropertyLookup("quarkus.s2i.base-jvm-image",
-            "registry.access.redhat.com/ubi8/openjdk-17:latest");
+            "registry.access.redhat.com/ubi9/openjdk-21:latest");
     public static final PropertyLookup QUARKUS_NATIVE_S2I = new PropertyLookup("quarkus.s2i.base-native-image",
-            "quay.io/quarkus/ubi-quarkus-native-binary-s2i:2.0");
+            "quay.io/quarkus/ubi9-quarkus-native-binary-s2i:2.0");
 
     private QuarkusProperties() {
 

--- a/quarkus-test-images/src/main/resources/Dockerfile.jvm
+++ b/quarkus-test-images/src/main/resources/Dockerfile.jvm
@@ -75,7 +75,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-17:latest
+FROM registry.access.redhat.com/ubi9/openjdk-21:latest
 
 ENV LANGUAGE='en_US:en'
 

--- a/quarkus-test-images/src/main/resources/Dockerfile.legacy-jar
+++ b/quarkus-test-images/src/main/resources/Dockerfile.legacy-jar
@@ -76,7 +76,7 @@
 #
 ###
 
-FROM registry.access.redhat.com/ubi8/openjdk-17:latest
+FROM registry.access.redhat.com/ubi9/openjdk-21:latest
 
 ENV LANGUAGE='en_US:en'
 

--- a/quarkus-test-images/src/main/resources/Dockerfile.native
+++ b/quarkus-test-images/src/main/resources/Dockerfile.native
@@ -14,7 +14,7 @@
 # docker run -i --rm -p 8080:8080 quarkus/code-with-quarkus
 #
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9
+FROM registry.access.redhat.com/ubi9-minimal:9.5
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \


### PR DESCRIPTION
### Summary

Move to UBI9 as described in the migration guide here https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.19. I hope this fixes native K8 daily build failures as well.

FYI:
- I will write a test plan and probably incorporate using UBI8 at least for a smoke test, but I need to think about it and want to switch to UBI9 ASAP so that I can see all the runs and continue with changes downstream.
- Regarding 17 vs 21, I think 21 is preferred and it is a time, I'll add a smoke test for UBI8 and for UBI9 with 17 in TS daily I think, let's see what TP says

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)