### PR TITLE
Fix native S2I scenarios in OpenShift

### DIFF
--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftS2iGitRepositoryQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftS2iGitRepositoryQuarkusApplicationManagedResource.java
@@ -16,6 +16,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Assertions;
 
 import io.quarkus.test.configuration.PropertyLookup;
+import io.quarkus.test.logging.Log;
 import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusSnapshotCondition;
 import io.quarkus.test.services.quarkus.model.QuarkusProperties;
 import io.quarkus.test.utils.FileUtils;
@@ -131,10 +132,12 @@ public class OpenShiftS2iGitRepositoryQuarkusApplicationManagedResource
             if (replaceJavaCaCerts && Files.exists(javaCaCertsPath)) {
                 // propagate java ca certs from executor machines so that secured communication
                 // with remote repositories can use private certificate authority
+                Log.info("Creating '%s' config map with 'cacerts' file".formatted(ETC_PKI_JAVA_CONFIG_MAP_NAME));
                 client.createConfigMap(ETC_PKI_JAVA_CONFIG_MAP_NAME, javaCaCertsPath);
             } else {
                 // build config doesn't support optional config mappings
                 // this does not overwrite default ca certs
+                Log.info("Creating empty '%s' config map".formatted(ETC_PKI_JAVA_CONFIG_MAP_NAME));
                 client.createEmptyConfigMap(ETC_PKI_JAVA_CONFIG_MAP_NAME);
             }
         }

--- a/quarkus-test-openshift/src/main/resources/quarkus-s2i-source-build-template.yml
+++ b/quarkus-test-openshift/src/main/resources/quarkus-s2i-source-build-template.yml
@@ -36,7 +36,7 @@ items:
         sourceStrategy:
           env:
             - name: MAVEN_ARGS
-              value: -s /configuration/settings.xml ${GIT_MAVEN_ARGS} -Dquarkus.platform.version=${QUARKUS_PLATFORM_VERSION} -Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus-plugin.version=${QUARKUS_PLATFORM_VERSION}
+              value: -s /configuration/settings.xml ${GIT_MAVEN_ARGS} -Dquarkus.platform.version=${QUARKUS_PLATFORM_VERSION} -Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus-plugin.version=${QUARKUS_PLATFORM_VERSION} -Djavax.net.ssl.trustStore=/etc/pki/java/cacerts
           from:
             kind: DockerImage
             name: ${QUARKUS_S2I_BUILDER_IMAGE}


### PR DESCRIPTION
### Summary

The `` image is used for native S2I runs in OpenShift, for example here in the framework it is `OpenShiftS2iQuickstartUsingDefaultsIT`. We can see this test keeps failing, Jenkins runs fails and I could reproduce it from my workstation. However JVM tests are not failing. The reason for the difference is that GraalVM CE does not use CA certs from `/etc/pki/java/cacerts` and we need to configure them explicitly according to the https://maven.apache.org/guides/mini/guide-repository-ssl.html.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)