### PR TITLE
Fix loading of UBI8 compatible Docker file

### DIFF
--- a/quarkus-test-images/src/main/java/io/quarkus/test/utils/DockerUtils.java
+++ b/quarkus-test-images/src/main/java/io/quarkus/test/utils/DockerUtils.java
@@ -44,11 +44,24 @@ public final class DockerUtils {
 
     }
 
+    /**
+     * @return Docker file name as expected by Quarkus
+     */
     public static String getDockerfile(LaunchMode mode) {
-        if (testUbi8Compatibility()) {
-            return String.format(DOCKERFILE_COMPATIBILITY_TEMPLATE, mode.getName());
-        }
         return String.format(DOCKERFILE_TEMPLATE, mode.getName());
+    }
+
+    /**
+     * @return loaded Docker file content from 'quarkus-test-images'
+     */
+    public static String loadDockerFileContent(LaunchMode mode) {
+        final String dockerFileNameInResources;
+        if (testUbi8Compatibility()) {
+            dockerFileNameInResources = String.format(DOCKERFILE_COMPATIBILITY_TEMPLATE, mode.getName());
+        } else {
+            dockerFileNameInResources = String.format(DOCKERFILE_TEMPLATE, mode.getName());
+        }
+        return FileUtils.loadFile(dockerFileNameInResources);
     }
 
     public static String createImageAndPush(ServiceContext service, LaunchMode mode, Path artifact) {
@@ -56,7 +69,7 @@ public final class DockerUtils {
 
         Path target = getTargetFolder(mode, artifact);
 
-        String dockerfileContent = FileUtils.loadFile(getDockerfile(mode))
+        String dockerfileContent = loadDockerFileContent(mode)
                 .replaceAll(quote("${ARTIFACT_PARENT}"), target.toString());
 
         Path dockerfilePath = FileUtils.copyContentTo(dockerfileContent, service.getServiceFolder().resolve(DOCKERFILE));

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/ExtensionOpenShiftUsingDockerBuildStrategyQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/ExtensionOpenShiftUsingDockerBuildStrategyQuarkusApplicationManagedResource.java
@@ -39,7 +39,7 @@ public class ExtensionOpenShiftUsingDockerBuildStrategyQuarkusApplicationManaged
         }
 
         if (!Files.exists(dockerfileTargetFile)) {
-            String dockerFileContent = FileUtils.loadFile(dockerfileName)
+            String dockerFileContent = DockerUtils.loadDockerFileContent(getLaunchMode())
                     .replaceAll(quote("${ARTIFACT_PARENT}"), "target");
             FileUtils.copyContentTo(dockerFileContent, dockerfileTargetFile);
         }


### PR DESCRIPTION
### Summary

When running `OpenShiftUsingExtensionDockerBuildStrategyManyExtensionsIT` in Quarkus QE Test Suite in UBI8 compatible mode it fails because Quarkus looks for `Dockerfile.jvm` so that `-compatibility` must be dropped. This is follow-up of the https://github.com/quarkus-qe/quarkus-test-framework/pull/1495. Sorry, I understand how this works better than before.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)