### PR TITLE
Feature/direct mount

### DIFF
--- a/examples/external-applications/src/test/resources/nginx.conf
+++ b/examples/external-applications/src/test/resources/nginx.conf
@@ -1,0 +1,16 @@
+# This file is based on info from these resources:
+# http://nginx.org/en/docs/beginners_guide.html#proxy
+# http://nginx.org/en/docs/http/ngx_http_proxy_module.html
+# https://www.baeldung.com/nginx-forward-proxy
+
+pid /tmp/nginx.pid;
+events {}
+http {
+    client_body_temp_path /tmp/nginx_client_temp;
+	server {
+		listen 8090;
+		location / {
+			return 200 "Example domain $host";
+		}
+	}
+}

--- a/quarkus-test-containers/src/main/java/io/quarkus/test/services/Container.java
+++ b/quarkus-test-containers/src/main/java/io/quarkus/test/services/Container.java
@@ -26,4 +26,6 @@ public @interface Container {
     boolean portDockerHostToLocalhost() default false;
 
     Class<? extends ManagedResourceBuilder> builder() default ContainerManagedResourceBuilder.class;
+
+    Mount[] mounts() default {};
 }

--- a/quarkus-test-containers/src/main/java/io/quarkus/test/services/Mount.java
+++ b/quarkus-test-containers/src/main/java/io/quarkus/test/services/Mount.java
@@ -1,0 +1,7 @@
+package io.quarkus.test.services;
+
+public @interface Mount {
+    String from() default "";
+
+    String to() default "";
+}

--- a/quarkus-test-containers/src/main/java/io/quarkus/test/services/containers/ContainerManagedResourceBuilder.java
+++ b/quarkus-test-containers/src/main/java/io/quarkus/test/services/containers/ContainerManagedResourceBuilder.java
@@ -1,6 +1,9 @@
 package io.quarkus.test.services.containers;
 
 import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import java.util.ServiceLoader;
 
@@ -20,6 +23,7 @@ public class ContainerManagedResourceBuilder implements ManagedResourceBuilder {
     private String image;
     private String expectedLog;
     private String[] command;
+    private List<MountConfig> mounts = new ArrayList<>();
     private Integer port;
     private boolean portDockerHostToLocalhost;
 
@@ -48,6 +52,9 @@ public class ContainerManagedResourceBuilder implements ManagedResourceBuilder {
         Container metadata = (Container) annotation;
         init(metadata.image(), metadata.command(), metadata.expectedLog(), metadata.port(),
                 metadata.portDockerHostToLocalhost());
+        this.mounts = Arrays.stream(metadata.mounts()).sequential()
+                .map(mount -> new MountConfig(mount.from(), mount.to()))
+                .toList();
     }
 
     protected void init(String image, String[] command, String expectedLog, int port, boolean portDockerHostToLocalhost) {
@@ -74,5 +81,19 @@ public class ContainerManagedResourceBuilder implements ManagedResourceBuilder {
             return new LocalhostManagedResource(new GenericDockerContainerManagedResource(this));
         }
         return new GenericDockerContainerManagedResource(this);
+    }
+
+    public List<MountConfig> getMounts() {
+        return mounts;
+    }
+
+    class MountConfig {
+        final String from;
+        final String to;
+
+        MountConfig(String from, String to) {
+            this.from = from;
+            this.to = to;
+        }
     }
 }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/configuration/Configuration.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/configuration/Configuration.java
@@ -161,7 +161,7 @@ public final class Configuration {
         OPENSHIFT_DEPLOYMENT_SERVICE_PROPERTY("openshift.service"),
         OPENSHIFT_DEPLOYMENT_TEMPLATE_PROPERTY("openshift.template"),
         OPENSHIFT_USE_INTERNAL_SERVICE_AS_URL_PROPERTY("openshift.use-internal-service-as-url"),
-        OPENSHIFT_DELETE_AFTERWARDS("openshift.delete.namespace.after.all"),
+        OPENSHIFT_DELETE_AFTERWARDS("openshift.delete.project.after.all"),
         OPENSHIFT_PRINT_ON_ERROR("openshift.print.info.on.error"),
         OPENSHIFT_EPHEMERAL_NAMESPACES("openshift.ephemeral.namespaces.enabled"),
 

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftUtils.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftUtils.java
@@ -1,0 +1,39 @@
+package io.quarkus.test.bootstrap.inject;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+import org.opentest4j.AssertionFailedError;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesList;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.client.utils.Serialization;
+
+public final class OpenShiftUtils {
+    private OpenShiftUtils() {
+    }
+
+    public static Optional<Deployment> getDeployment(List<HasMetadata> metadata) {
+        for (HasMetadata metadatum : metadata) {
+            if (metadatum instanceof Deployment) {
+                return Optional.of((Deployment) metadatum);
+            }
+        }
+        return Optional.empty();
+    }
+
+    public static String toYaml(List<HasMetadata> objects) {
+        KubernetesList list = new KubernetesList();
+        list.setItems(objects);
+        try {
+            ByteArrayOutputStream os = new ByteArrayOutputStream();
+            os.write(Serialization.asYaml(list).getBytes());
+            return os.toString();
+        } catch (IOException e) {
+            throw new AssertionFailedError("Failed adding properties into OpenShift template", e);
+        }
+    }
+}


### PR DESCRIPTION
### Summary
- Add ability to mount files to local and Openshift containers. Fixes https://github.com/quarkus-qe/quarkus-test-framework/issues/1333
- Restore the old name of `delete.folder.on.exit` property, which was accidentally renamed in https://github.com/quarkus-qe/quarkus-test-framework/pull/791

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)