### PR TITLE
Make sure applications created with Quarkus CLI are build using configured native builder image

### DIFF
--- a/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/QuarkusCliClient.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/QuarkusCliClient.java
@@ -65,6 +65,11 @@ public class QuarkusCliClient {
         List<String> args = new ArrayList<>();
         args.add(BUILD);
         args.add("--native");
+        PropertyLookup nativeBuilderImageProperty = new PropertyLookup("quarkus.native.builder-image");
+        String nativeBuilderImage = nativeBuilderImageProperty.get();
+        if (nativeBuilderImage != null && !nativeBuilderImage.isEmpty()) {
+            args.add("-D" + nativeBuilderImageProperty.getPropertyKey() + "=" + nativeBuilderImage);
+        }
         args.addAll(Arrays.asList(extraArgs));
         return runCliAndWait(serviceFolder, args.toArray(new String[0]));
     }


### PR DESCRIPTION
### Summary

I inspected TS daily build here https://github.com/quarkus-qe/quarkus-test-suite/actions/runs/13404688482/job/37442397040 and found that Quarkus CLI and build-time analytics tests are build with UBI9-based images even though `quarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-21` is configured. This fixes the issue, verified locally.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)