### PR TITLE
Add space case for long quarkus version

### DIFF
--- a/quarkus-test-cli/src/main/java/io/quarkus/test/util/QuarkusCLIUtils.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/util/QuarkusCLIUtils.java
@@ -233,7 +233,16 @@ public abstract class QuarkusCLIUtils {
      */
     public static DefaultArtifactVersion getQuarkusAppVersion(QuarkusCliRestService app)
             throws IOException, XmlPullParserException {
-        return new DefaultArtifactVersion(getPom(app).getProperties().getProperty("quarkus.platform.version"));
+        String quarkusVersion = getPom(app).getProperties().getProperty("quarkus.platform.version");
+        /*
+         * DefaultArtifactVersion cannot properly parse versions X.Y.Z.z
+         * There is such a quarkus version 3.15.3.1, which requires tripping to be properly parsed
+         * In these cases, drop the last number from the version
+         */
+        if (quarkusVersion.matches("\\d+\\.\\d+\\.\\d+\\.\\d+")) {
+            return new DefaultArtifactVersion(quarkusVersion.substring(0, quarkusVersion.lastIndexOf(".")));
+        }
+        return new DefaultArtifactVersion(quarkusVersion);
     }
 
     public static void addDependenciesToPom(QuarkusCliRestService app, List<Dependency> dependencies)


### PR DESCRIPTION
### Summary

Maven library with `DefaultArtifactVersion` which we use, cannot parse versions with four numbers like X.Y.Z.z. Quarkus released version 3.15.3.1 which breaks our tests. This should fixed the issue by ignoring the last number in such cases.

Please check the relevant options

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [X] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)