### PR TITLE
Handle 4 digit version as 3 digit one due to DefaultArtifactVersion limitations

### DIFF
--- a/quarkus-test-cli/src/main/java/io/quarkus/test/util/QuarkusCLIUtils.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/util/QuarkusCLIUtils.java
@@ -25,6 +25,7 @@ import org.apache.maven.model.Model;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.apache.maven.model.io.xpp3.MavenXpp3Writer;
+import org.codehaus.plexus.util.StringUtils;
 import org.codehaus.plexus.util.xml.XmlStreamReader;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 
@@ -233,7 +234,14 @@ public abstract class QuarkusCLIUtils {
      */
     public static DefaultArtifactVersion getQuarkusAppVersion(QuarkusCliRestService app)
             throws IOException, XmlPullParserException {
-        return new DefaultArtifactVersion(getPom(app).getProperties().getProperty("quarkus.platform.version"));
+        String version = getPom(app).getProperties().getProperty("quarkus.platform.version");
+        int countOfDotsInVersion = StringUtils.countMatches(version, ".");
+        if (countOfDotsInVersion > 2) {
+            // cases like 3.15.3.1 need to be transformed to 3.15.3, 4 digit version is not supported
+            // Look at DefaultArtifactVersionTest.java#L74 in https://github.com/apache/maven repo
+            version = version.substring(0, version.lastIndexOf("."));
+        }
+        return new DefaultArtifactVersion(version);
     }
 
     public static void addDependenciesToPom(QuarkusCliRestService app, List<Dependency> dependencies)


### PR DESCRIPTION
### Summary

Handle 4 digit version as 3 digit one due to DefaultArtifactVersion limitations

4 digit version is reported as 0.0.0 when calling getMajorVersion() etc.

https://github.com/apache/maven/blob/master/compat/maven-artifact/src/test/java/org/apache/maven/artifact/versioning/DefaultArtifactVersionTest.java#L74

Fixes `QuarkusCli35to315UpdateIT#versionUpdateTest` test in TS

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)