### PR TITLE
Move to 1.7.Beta0 as preparation for Quarkus 3.20 release processing

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 name: Quarkus QE Test Framework
 release:
-  current-version: 1.6.0.Beta20
-  next-version: 1.6.0.Beta21
+  current-version: 1.7.0.Beta0
+  next-version: 1.7.0.Beta1


### PR DESCRIPTION
### Summary

For Quarkus 3.20, dedicated 1.6.z branch has been created, even though CI preparation and some refinement is still work in a progress. We need to move to 1.7.x as Quarkus main is already on 3.21. https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md doesn't say if beta should start from 0 or 1, so I chose zero to match suggested `1.6.0` patch version.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)