### PR TITLE
Revert "Release 1.6.0"

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 name: Quarkus QE Test Framework
 release:
-  current-version: 1.6.0
-  next-version: 1.6.1
+  current-version: 1.6.0.Beta20
+  next-version: 1.6.0.Beta21


### PR DESCRIPTION
Release workflow failed over `Error: Unable to resolve action `radcortez/project-metadata-action@master`, unable to find version `master`. We shall fix that in the main branch and then repeat release.