### PR TITLE
Document Quarkus Test Preparer in the project README and fix error message that is raised when the test preparer plugin didn't run

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,26 @@ Now, we can add the core dependency in the `pom.xml` file:
 </dependency>
 ```
 
+And also build plugin that prepares Quarkus application:
+
+```xml
+<build>
+    <plugins>
+        <plugin>
+            <groupId>io.quarkus.qe</groupId>
+            <artifactId>quarkus-test-preparer</artifactId>
+            <executions>
+                <execution>
+                    <goals>
+                        <goal>prepare-pom-mojo</goal>
+                    </goals>
+                </execution>
+            </executions>
+        </plugin>
+    </plugins>
+</build>
+```
+
 And finally, let's write our first scenario:
 
 ```java

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusMavenPluginBuildHelper.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusMavenPluginBuildHelper.java
@@ -250,7 +250,8 @@ public final class QuarkusMavenPluginBuildHelper {
     private File getPomFileCreatedByOurPlugin() {
         var pomFileCreatedByOurPlugin = Path.of(TARGET).resolve(isS2iScenario() ? POM_XML : TARGET_POM).toFile();
         if (!pomFileCreatedByOurPlugin.exists()) {
-            throw new RuntimeException("Could not find '%s' POM file, please add 'io.quarkus.qe:quarkus-test-preparer' plugin");
+            throw new RuntimeException(("Could not find '%s' POM file, please add 'io.quarkus.qe:quarkus-test-preparer'"
+                    + " plugin").formatted(pomFileCreatedByOurPlugin));
         }
         return pomFileCreatedByOurPlugin;
     }


### PR DESCRIPTION
### Summary

- When users upgrade from 1.5.x to 1.6.x version of this framework, they also need to add Quarkus Test Preparer plugin as mentioned in the https://github.com/quarkus-qe/quarkus-test-framework/wiki/1.-Getting-Started#first-application. It is necessary because we need to prepare Quarkus application when Maven metadata like properties, dependency versions etc. are resolved. It is also an action that is performed just once per a test module, therefore it doesn't make sense to perform it later.
- Fixes error message raised when no plugin was detected in a scenario that requires plugin (which is not necessary every scenario, for example if Quarkus Maven plugin in project that all the work and no customization is needed, the plugin output is not used).

The project README already refers to the wiki https://github.com/quarkus-qe/quarkus-test-framework?tab=readme-ov-file#documentation.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)