### PR TITLE
Remove the | from path when copying resources to container

### DIFF
--- a/quarkus-test-containers/src/main/java/io/quarkus/test/services/containers/DockerContainerManagedResource.java
+++ b/quarkus-test-containers/src/main/java/io/quarkus/test/services/containers/DockerContainerManagedResource.java
@@ -1,6 +1,7 @@
 package io.quarkus.test.services.containers;
 
 import static io.quarkus.test.bootstrap.BaseService.SERVICE_STARTUP_TIMEOUT_DEFAULT;
+import static io.quarkus.test.utils.PropertiesUtils.DESTINATION_TO_FILENAME_SEPARATOR;
 import static io.quarkus.test.utils.PropertiesUtils.RESOURCE_PREFIX;
 import static io.quarkus.test.utils.PropertiesUtils.RESOURCE_WITH_DESTINATION_PREFIX;
 import static io.quarkus.test.utils.PropertiesUtils.RESOURCE_WITH_DESTINATION_PREFIX_MATCHER;
@@ -140,6 +141,7 @@ public abstract class DockerContainerManagedResource implements ManagedResource 
                 String destinationPath = value.split(RESOURCE_WITH_DESTINATION_SPLIT_CHAR)[0];
                 String fileName = value.split(RESOURCE_WITH_DESTINATION_SPLIT_CHAR)[1];
                 addFileToContainer(destinationPath, fileName);
+                value = value.replace(DESTINATION_TO_FILENAME_SEPARATOR, "");
             } else if (isResourceWithDestinationPath(entry.getValue())) {
                 value = entry.getValue().replace(RESOURCE_WITH_DESTINATION_PREFIX, StringUtils.EMPTY);
                 if (!value.matches(RESOURCE_WITH_DESTINATION_PREFIX_MATCHER)) {
@@ -151,6 +153,7 @@ public abstract class DockerContainerManagedResource implements ManagedResource 
                 String destinationPath = value.split(RESOURCE_WITH_DESTINATION_SPLIT_CHAR)[0];
                 String fileName = value.split(RESOURCE_WITH_DESTINATION_SPLIT_CHAR)[1];
                 addFileToContainer(destinationPath, fileName);
+                value = value.replace(DESTINATION_TO_FILENAME_SEPARATOR, "");
             } else if (isSecret(entry.getValue())) {
                 value = entry.getValue().replace(SECRET_PREFIX, StringUtils.EMPTY);
                 addFileToContainer(value);


### PR DESCRIPTION
### Summary

Fixing the bug, when you copy resource with destination that the `|` is not removed.

This mainly affecting the resources when the property is used for setting the path.

For example I have `KC_HTTPS_KEY_STORE_FILE` which setting the path for Keycloak. If I assign it `withProperty("KC_HTTPS_KEY_STORE_FILE", "secret_with_destination::/opt/keycloak/conf/|keystore.jks");` the Keycloak try to look for `/opt/keycloak/conf/|keystore.jks` in container and fail.

With this fix the the path will be `/opt/keycloak/conf/keystore.jks`

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)