### PR TITLE
Add buildtime properties for init-task

### DIFF
--- a/quarkus-test-core/src/main/resources/deployment-build-props.txt
+++ b/quarkus-test-core/src/main/resources/deployment-build-props.txt
@@ -565,6 +565,9 @@ quarkus.knative.readiness-probe.tcp-socket-action
 quarkus.kubernetes.liveness-probe.tcp-socket-action
 quarkus.pulsar.devservices.shared
 quarkus.openshift.init-tasks."init-tasks".wait-for-container.image
+quarkus.openshift.init-tasks."init-tasks".wait-for-container.image-pull-policy
+quarkus.openshift.init-tasks.flyway.wait-for-container.image
+quarkus.openshift.init-tasks.flyway.wait-for-container.image-pull-policy
 quarkus.kubernetes.sidecars."sidecars".ports."ports".tls
 quarkus.smallrye-openapi.info-version
 quarkus.openshift.ports."ports".host-port


### PR DESCRIPTION
### Summary

Adding these specific build properies for flyway and the `quarkus.openshift.init-tasks."init-tasks".wait-for-container.image-pull-policy` as it was missing

I was try to enable and update the [OpenShiftFlywayInitContainerIT](https://github.com/quarkus-qe/quarkus-test-suite/blob/3.20/sql-db/panache-flyway/src/test/java/io/quarkus/ts/sqldb/panacheflyway/init/OpenShiftFlywayInitContainerIT.java) when I find out about that some build time properties are ignored as I described in https://github.com/quarkus-qe/quarkus-test-framework/issues/1531

Related TS PR https://github.com/quarkus-qe/quarkus-test-suite/pull/2340

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)