### PR TITLE
Define quarkus-test-preparer plugin version

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ And also build plugin that prepares Quarkus application:
         <plugin>
             <groupId>io.quarkus.qe</groupId>
             <artifactId>quarkus-test-preparer</artifactId>
+            <version>${quarkus.qe.framework.version}</version>
             <executions>
                 <execution>
                     <goals>


### PR DESCRIPTION
Define quarkus-test-preparer plugin version

Eliminates warnings about missing version

https://github.com/quarkus-qe/quarkus-test-framework/wiki/1.-Getting-Started is also updated

Trigger: https://github.com/quarkus-qe/quarkus-jdkspecifics/pull/182

### Summary

(Summarize the problem solved by this PR, and how to verify it manually)

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)