### PR TITLE
Add websocket into protocol list

### DIFF
--- a/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/Protocol.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/Protocol.java
@@ -5,6 +5,8 @@ public enum Protocol {
     HTTPS("https", 8443),
     GRPC("grpc", 9000),
     MANAGEMENT("management", 9000), //can be either http or https
+    WS("ws", 8080),
+    WSS("wss", 8443),
     NONE(null, -1);
 
     private final String value;


### PR DESCRIPTION
### Summary

Websocket has it's own protocol scheme, so when we test it's endpoints, we should also have it in protocol list.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)