### PR TITLE
[1.5.z] Support container registry URL with property `ts.` configuration property scope like we do in the latest framework version

### DIFF
--- a/quarkus-test-kubernetes/src/main/java/io/quarkus/test/services/quarkus/ExtensionKubernetesQuarkusApplicationManagedResource.java
+++ b/quarkus-test-kubernetes/src/main/java/io/quarkus/test/services/quarkus/ExtensionKubernetesQuarkusApplicationManagedResource.java
@@ -1,6 +1,5 @@
 package io.quarkus.test.services.quarkus;
 
-import static io.quarkus.test.utils.DockerUtils.CONTAINER_REGISTRY_URL_PROPERTY;
 import static io.quarkus.test.utils.MavenUtils.BATCH_MODE;
 import static io.quarkus.test.utils.MavenUtils.DISPLAY_VERSION;
 import static io.quarkus.test.utils.MavenUtils.ENSURE_QUARKUS_BUILD;
@@ -26,6 +25,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import io.quarkus.test.bootstrap.inject.KubectlClient;
 import io.quarkus.test.utils.Command;
+import io.quarkus.test.utils.DockerUtils;
 import io.quarkus.test.utils.FileUtils;
 import io.quarkus.test.utils.PropertiesUtils;
 
@@ -119,7 +119,7 @@ public class ExtensionKubernetesQuarkusApplicationManagedResource
     }
 
     private void propagateContainerRegistryIfSet(List<String> args) {
-        String containerRegistry = System.getProperty(CONTAINER_REGISTRY_URL_PROPERTY);
+        String containerRegistry = DockerUtils.getContainerRegistryUrl();
         if (StringUtils.isNotEmpty(containerRegistry)) {
             int lastSlash = containerRegistry.lastIndexOf("/");
             String registryHost = containerRegistry.substring(0, lastSlash);


### PR DESCRIPTION
### Summary

I migrated all Jenkins jobs to a new (and IMHO only correct) container registry URL format some time ago and jobs that require it keep failing as the registry URL is not set. This should fix it. Release required.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)