### PR TITLE
Use HTTPS port for WSS in getURI

### DIFF
--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/LocalhostQuarkusApplicationManagedResource.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/LocalhostQuarkusApplicationManagedResource.java
@@ -89,13 +89,13 @@ public abstract class LocalhostQuarkusApplicationManagedResource extends Quarkus
 
     @Override
     public URILike getURI(Protocol protocol) {
-        if (protocol == Protocol.HTTPS && !model.isSslEnabled()) {
+        if ((protocol == Protocol.HTTPS || protocol == Protocol.WSS) && !model.isSslEnabled()) {
             fail("SSL was not enabled. Use: `@QuarkusApplication(ssl = true)`");
         } else if (protocol == Protocol.GRPC && !model.isGrpcEnabled()) {
             fail("gRPC was not enabled. Use: `@QuarkusApplication(grpc = true)`");
         }
         int port = switch (protocol) {
-            case HTTPS -> assignedHttpsPort;
+            case HTTPS, WSS -> assignedHttpsPort;
             case GRPC -> assignedGrpcPort;
             default -> assignedHttpPort;
         };


### PR DESCRIPTION
### Summary

Currently WSS (WebSocket Secure = websocket over TLS) is defaulting to use plaintext HTTP port. This PR changes it, that WSS gets secure HTTPS port, when resolving URI.

Please check the relevant options

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)