### PR TITLE
Enable WebSocket on OCP

### DIFF
--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftQuarkusApplicationManagedResource.java
@@ -98,7 +98,7 @@ public abstract class OpenShiftQuarkusApplicationManagedResource<T extends Quark
         final ServiceContext context = model.getContext();
         final boolean isServerless = client.isServerlessService(context.getName());
         final boolean isServingCertSslScenario = isServingCertificateScenario(context) && model.isSslEnabled();
-        if (protocol == Protocol.HTTPS && !isServerless && !isServingCertSslScenario) {
+        if ((protocol == Protocol.HTTPS || protocol == Protocol.WSS) && !isServerless && !isServingCertSslScenario) {
             fail("SSL is not supported for OpenShift tests yet");
         } else if (protocol == Protocol.GRPC) {
             fail("gRPC is not supported for OpenShift tests yet");
@@ -118,7 +118,7 @@ public abstract class OpenShiftQuarkusApplicationManagedResource<T extends Quark
                     () -> client.url(context.getOwner()).withPort(port),
                     AwaitilitySettings.defaults().withService(getContext().getOwner()));
         }
-        return uri;
+        return this.uri.withScheme(protocol.getValue());
     }
 
     public boolean isRunning() {


### PR DESCRIPTION
### Summary

Currently getURI() method on OCP always returns scheme HTTP:// ignoring the actual protocol requested. Changing it to use requested scheme. Should only make change for WS scheme as all other protocols are handled (or fail()ed) otherwise.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)