### PR TITLE
[1.6.z] Backports as of March 27

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ And also build plugin that prepares Quarkus application:
         <plugin>
             <groupId>io.quarkus.qe</groupId>
             <artifactId>quarkus-test-preparer</artifactId>
+            <version>${quarkus.qe.framework.version}</version>
             <executions>
                 <execution>
                     <goals>

--- a/README.md
+++ b/README.md
@@ -72,6 +72,26 @@ Now, we can add the core dependency in the `pom.xml` file:
 </dependency>
 ```
 
+And also build plugin that prepares Quarkus application:
+
+```xml
+<build>
+    <plugins>
+        <plugin>
+            <groupId>io.quarkus.qe</groupId>
+            <artifactId>quarkus-test-preparer</artifactId>
+            <executions>
+                <execution>
+                    <goals>
+                        <goal>prepare-pom-mojo</goal>
+                    </goals>
+                </execution>
+            </executions>
+        </plugin>
+    </plugins>
+</build>
+```
+
 And finally, let's write our first scenario:
 
 ```java

--- a/quarkus-test-containers/src/main/java/io/quarkus/test/services/containers/DockerContainerManagedResource.java
+++ b/quarkus-test-containers/src/main/java/io/quarkus/test/services/containers/DockerContainerManagedResource.java
@@ -1,6 +1,7 @@
 package io.quarkus.test.services.containers;
 
 import static io.quarkus.test.bootstrap.BaseService.SERVICE_STARTUP_TIMEOUT_DEFAULT;
+import static io.quarkus.test.utils.PropertiesUtils.DESTINATION_TO_FILENAME_SEPARATOR;
 import static io.quarkus.test.utils.PropertiesUtils.RESOURCE_PREFIX;
 import static io.quarkus.test.utils.PropertiesUtils.RESOURCE_WITH_DESTINATION_PREFIX;
 import static io.quarkus.test.utils.PropertiesUtils.RESOURCE_WITH_DESTINATION_PREFIX_MATCHER;
@@ -140,6 +141,7 @@ public abstract class DockerContainerManagedResource implements ManagedResource 
                 String destinationPath = value.split(RESOURCE_WITH_DESTINATION_SPLIT_CHAR)[0];
                 String fileName = value.split(RESOURCE_WITH_DESTINATION_SPLIT_CHAR)[1];
                 addFileToContainer(destinationPath, fileName);
+                value = value.replace(DESTINATION_TO_FILENAME_SEPARATOR, "");
             } else if (isResourceWithDestinationPath(entry.getValue())) {
                 value = entry.getValue().replace(RESOURCE_WITH_DESTINATION_PREFIX, StringUtils.EMPTY);
                 if (!value.matches(RESOURCE_WITH_DESTINATION_PREFIX_MATCHER)) {
@@ -151,6 +153,7 @@ public abstract class DockerContainerManagedResource implements ManagedResource 
                 String destinationPath = value.split(RESOURCE_WITH_DESTINATION_SPLIT_CHAR)[0];
                 String fileName = value.split(RESOURCE_WITH_DESTINATION_SPLIT_CHAR)[1];
                 addFileToContainer(destinationPath, fileName);
+                value = value.replace(DESTINATION_TO_FILENAME_SEPARATOR, "");
             } else if (isSecret(entry.getValue())) {
                 value = entry.getValue().replace(SECRET_PREFIX, StringUtils.EMPTY);
                 addFileToContainer(value);

--- a/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/Protocol.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/Protocol.java
@@ -5,6 +5,8 @@ public enum Protocol {
     HTTPS("https", 8443),
     GRPC("grpc", 9000),
     MANAGEMENT("management", 9000), //can be either http or https
+    WS("ws", 8080),
+    WSS("wss", 8443),
     NONE(null, -1);
 
     private final String value;

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/LocalhostQuarkusApplicationManagedResource.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/LocalhostQuarkusApplicationManagedResource.java
@@ -89,13 +89,13 @@ public abstract class LocalhostQuarkusApplicationManagedResource extends Quarkus
 
     @Override
     public URILike getURI(Protocol protocol) {
-        if (protocol == Protocol.HTTPS && !model.isSslEnabled()) {
+        if ((protocol == Protocol.HTTPS || protocol == Protocol.WSS) && !model.isSslEnabled()) {
             fail("SSL was not enabled. Use: `@QuarkusApplication(ssl = true)`");
         } else if (protocol == Protocol.GRPC && !model.isGrpcEnabled()) {
             fail("gRPC was not enabled. Use: `@QuarkusApplication(grpc = true)`");
         }
         int port = switch (protocol) {
-            case HTTPS -> assignedHttpsPort;
+            case HTTPS, WSS -> assignedHttpsPort;
             case GRPC -> assignedGrpcPort;
             default -> assignedHttpPort;
         };

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusMavenPluginBuildHelper.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusMavenPluginBuildHelper.java
@@ -250,7 +250,8 @@ public final class QuarkusMavenPluginBuildHelper {
     private File getPomFileCreatedByOurPlugin() {
         var pomFileCreatedByOurPlugin = Path.of(TARGET).resolve(isS2iScenario() ? POM_XML : TARGET_POM).toFile();
         if (!pomFileCreatedByOurPlugin.exists()) {
-            throw new RuntimeException("Could not find '%s' POM file, please add 'io.quarkus.qe:quarkus-test-preparer' plugin");
+            throw new RuntimeException(("Could not find '%s' POM file, please add 'io.quarkus.qe:quarkus-test-preparer'"
+                    + " plugin").formatted(pomFileCreatedByOurPlugin));
         }
         return pomFileCreatedByOurPlugin;
     }

--- a/quarkus-test-core/src/main/resources/deployment-build-props.txt
+++ b/quarkus-test-core/src/main/resources/deployment-build-props.txt
@@ -565,6 +565,9 @@ quarkus.knative.readiness-probe.tcp-socket-action
 quarkus.kubernetes.liveness-probe.tcp-socket-action
 quarkus.pulsar.devservices.shared
 quarkus.openshift.init-tasks."init-tasks".wait-for-container.image
+quarkus.openshift.init-tasks."init-tasks".wait-for-container.image-pull-policy
+quarkus.openshift.init-tasks.flyway.wait-for-container.image
+quarkus.openshift.init-tasks.flyway.wait-for-container.image-pull-policy
 quarkus.kubernetes.sidecars."sidecars".ports."ports".tls
 quarkus.smallrye-openapi.info-version
 quarkus.openshift.ports."ports".host-port

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftQuarkusApplicationManagedResource.java
@@ -98,7 +98,7 @@ public abstract class OpenShiftQuarkusApplicationManagedResource<T extends Quark
         final ServiceContext context = model.getContext();
         final boolean isServerless = client.isServerlessService(context.getName());
         final boolean isServingCertSslScenario = isServingCertificateScenario(context) && model.isSslEnabled();
-        if (protocol == Protocol.HTTPS && !isServerless && !isServingCertSslScenario) {
+        if ((protocol == Protocol.HTTPS || protocol == Protocol.WSS) && !isServerless && !isServingCertSslScenario) {
             fail("SSL is not supported for OpenShift tests yet");
         } else if (protocol == Protocol.GRPC) {
             fail("gRPC is not supported for OpenShift tests yet");
@@ -118,7 +118,7 @@ public abstract class OpenShiftQuarkusApplicationManagedResource<T extends Quark
                     () -> client.url(context.getOwner()).withPort(port),
                     AwaitilitySettings.defaults().withService(getContext().getOwner()));
         }
-        return uri;
+        return this.uri.withScheme(protocol.getValue());
     }
 
     public boolean isRunning() {


### PR DESCRIPTION
### Summary

Backports PRs currently marked for 1.6.z backport https://github.com/quarkus-qe/quarkus-test-framework/pulls?q=is%3Apr+is%3Aclosed+label%3Atriage%2Fbackport-1.6%3F :

- https://github.com/quarkus-qe/quarkus-test-framework/pull/1540
- https://github.com/quarkus-qe/quarkus-test-framework/pull/1539
- https://github.com/quarkus-qe/quarkus-test-framework/pull/1534
- https://github.com/quarkus-qe/quarkus-test-framework/pull/1532
- https://github.com/quarkus-qe/quarkus-test-framework/pull/1530
- https://github.com/quarkus-qe/quarkus-test-framework/pull/1526
- https://github.com/quarkus-qe/quarkus-test-framework/pull/1523


Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Backports
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)