### PR TITLE
[1.6.z] Release 1.6.1 - 2nd attempt

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 name: Quarkus QE Test Framework
 release:
-  current-version: 1.6.0
-  next-version: 1.6.1
+  current-version: 1.6.1
+  next-version: 1.6.2


### PR DESCRIPTION
### Summary

This change has been approved here https://github.com/quarkus-qe/quarkus-test-framework/pull/1547 but release workflow failed over missing plugin (test preparer) in Maven central as you can see here https://github.com/quarkus-qe/quarkus-test-framework/actions/runs/14140352853. I hope we can avoid this failure by skipping tests, it makes no sense to run tests during the release anyway, so I pushed commit that is skipping them here https://github.com/quarkus-qe/quarkus-test-framework/commit/9c07318e54a55f5833567ca0ec4e2e9ccb3f4023 and now I am trying to make release again.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [x] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)