### PR TITLE
[1.6.z] Release 1.6.1 - 5th attempt

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 name: Quarkus QE Test Framework
 release:
-  current-version: 1.6.0
-  next-version: 1.6.1
+  current-version: 1.6.1
+  next-version: 1.6.2


### PR DESCRIPTION
### Summary

Same as https://github.com/quarkus-qe/quarkus-test-framework/pull/1551 whose release failed here https://github.com/quarkus-qe/quarkus-test-framework/actions/runs/14144715567/job/39630653447. Now I finally figured that skipping tests in Maven release plugin requires propagating arguments via `-Darguments=` which I have done in ca33cab0.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [x] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)