### PR TITLE
Release 1.6.1 - 8th attempt

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 name: Quarkus QE Test Framework
 release:
-  current-version: 1.6.0
-  next-version: 1.6.1
+  current-version: 1.6.1
+  next-version: 1.6.2


### PR DESCRIPTION
### Summary

https://github.com/quarkus-qe/quarkus-test-framework/pull/1554 release workflow failed again https://github.com/quarkus-qe/quarkus-test-framework/actions/runs/14145270258. I am getting annoyed so I just completely rewrote the release workflow with 3cc0b067.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [x] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)