### PR TITLE
Fix RHBQ version check in Quarkus CLI tests

### DIFF
--- a/quarkus-test-cli/src/test/java/io/quarkus/test/QuarkusCLIUtilsTest.java
+++ b/quarkus-test-cli/src/test/java/io/quarkus/test/QuarkusCLIUtilsTest.java
@@ -1,0 +1,38 @@
+package io.quarkus.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.util.QuarkusCLIUtils;
+
+public class QuarkusCLIUtilsTest {
+
+    @Test
+    public void testGetQuarkusAppVersion() {
+        DefaultArtifactVersion communityVersion3Dots = QuarkusCLIUtils.getQuarkusAppVersion("3.15.3");
+        assertEquals("3.15.3", communityVersion3Dots.toString());
+        assertEquals(3, communityVersion3Dots.getMajorVersion());
+        assertEquals(15, communityVersion3Dots.getMinorVersion());
+        assertEquals(3, communityVersion3Dots.getIncrementalVersion());
+        DefaultArtifactVersion productVersion3Dots = QuarkusCLIUtils.getQuarkusAppVersion("3.15.4.redhat-00001");
+        assertEquals("3.15.4.redhat-00001", productVersion3Dots.toString());
+        assertEquals(3, productVersion3Dots.getMajorVersion());
+        assertEquals(15, productVersion3Dots.getMinorVersion());
+        assertEquals(4, productVersion3Dots.getIncrementalVersion());
+        assertTrue(productVersion3Dots.toString().contains("redhat"));
+        DefaultArtifactVersion communityVersion4Dots = QuarkusCLIUtils.getQuarkusAppVersion("3.15.3.1");
+        assertEquals("3.15.3", communityVersion4Dots.toString());
+        assertEquals(3, communityVersion4Dots.getMajorVersion());
+        assertEquals(15, communityVersion4Dots.getMinorVersion());
+        assertEquals(3, communityVersion4Dots.getIncrementalVersion());
+        DefaultArtifactVersion productVersion4Dots = QuarkusCLIUtils.getQuarkusAppVersion("3.15.3.1.redhat-00001");
+        assertEquals("3.15.3.redhat-00001", productVersion4Dots.toString());
+        assertEquals(3, productVersion4Dots.getMajorVersion());
+        assertEquals(15, productVersion4Dots.getMinorVersion());
+        assertEquals(3, productVersion4Dots.getIncrementalVersion());
+        assertTrue(productVersion4Dots.toString().contains("redhat"));
+    }
+}


### PR DESCRIPTION
### Summary

After https://github.com/quarkus-qe/quarkus-test-framework/pull/1515 RHBQ version checks started failing as "redhat" qualifier is not present in parsed Quarkus platform version anymore.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)