### PR TITLE
Catch ExtensionContextException in QuarkusCliRestService.close()

### DIFF
--- a/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/QuarkusCliRestService.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/QuarkusCliRestService.java
@@ -9,6 +9,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import org.junit.jupiter.api.extension.ExtensionContextException;
+
 public class QuarkusCliRestService extends RestService {
 
     private final QuarkusCliClient cliClient;
@@ -83,7 +85,12 @@ public class QuarkusCliRestService extends RestService {
     public void close() {
         var storedContext = context.getScenarioContext().getTestStore().get(QuarkusCliClient.CLI_SERVICE_CONTEXT_KEY);
         if (storedContext == context) {
-            context.getScenarioContext().getTestStore().put(QuarkusCliClient.CLI_SERVICE_CONTEXT_KEY, null);
+            try {
+                context.getScenarioContext().getTestStore().put(QuarkusCliClient.CLI_SERVICE_CONTEXT_KEY, null);
+            } catch (ExtensionContextException ex) {
+                // we can't detect if the store is closed when calling this from NamespacedHierarchicalStore.close
+                // details in https://github.com/quarkus-qe/quarkus-test-suite/issues/2376
+            }
         }
         super.close();
     }


### PR DESCRIPTION
Catch ExtensionContextException in QuarkusCliRestService.close()

We can't detect that the NamespacedHierarchicalStore is closed when QuarkusCliRestService.close() is called from NamespacedHierarchicalStore.close()

Fixes https://github.com/quarkus-qe/quarkus-test-suite/issues/2376

Please check the relevant options

Stats from TS cli module execution:
```
  30 QuarkusCliRestService - calling close
   3 QuarkusCliRestService - ExtensionContextException
```
So it's better to just catch the exception than just fully removing the method

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)