### PR TITLE
CLI build command with enabled batch mode and no transfer progress

### DIFF
--- a/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/QuarkusCliClient.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/QuarkusCliClient.java
@@ -76,7 +76,7 @@ public class QuarkusCliClient {
 
     public Process runOnDev(Path servicePath, File logOutput, Map<String, String> arguments) {
         List<String> cmd = new ArrayList<>();
-        cmd.add("dev");
+        cmd.add(DEV);
         cmd.addAll(arguments.entrySet().stream()
                 .map(e -> "-D" + e.getKey() + "=" + e.getValue())
                 .toList());
@@ -254,6 +254,15 @@ public class QuarkusCliClient {
         if (commandSendsAnalytics(cmd) && QuarkusProperties.disableBuildAnalytics(serviceContext)) {
             cmd.add(createDisableBuildAnalyticsProperty());
         }
+
+        // limit logs for build command
+        if (cmd.stream().anyMatch(commandPart -> BUILD.equalsIgnoreCase(commandPart))) {
+            cmd.addAll(List.of("--", "--batch-mode", "--no-transfer-progress"));
+        }
+
+        // TODO limit logs for dev command
+        // quarkus dev doesn't support passing additional parameters to the build system
+        // https://github.com/quarkusio/quarkus/issues/47247
 
         Log.info(String.join(" ", cmd));
         try {


### PR DESCRIPTION
### Summary

CLI build command with enabled batch mode and no transfer progress

This helps to reduce logs verbosity in GH Actions and Jenkins  runs

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)