### PR TITLE
Use CLI based batch mode option as we can't detect maven build

### DIFF
--- a/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/QuarkusCliClient.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/QuarkusCliClient.java
@@ -257,7 +257,7 @@ public class QuarkusCliClient {
 
         // limit logs for build command
         if (cmd.stream().anyMatch(commandPart -> BUILD.equalsIgnoreCase(commandPart))) {
-            cmd.addAll(List.of("--", "--batch-mode", "--no-transfer-progress"));
+            cmd.addAll(List.of("--batch-mode"));
         }
 
         // TODO limit logs for dev command


### PR DESCRIPTION
### Summary

Use CLI based batch mode option as we can't detect maven build

Followup of https://github.com/quarkus-qe/quarkus-test-framework/pull/1568

Fixes regression for Gradle and JBang

I didn't copy https://github.com/quarkus-qe/quarkus-test-suite/blob/main/quarkus-cli/src/test/java/io/quarkus/ts/quarkus/cli/QuarkusCliCreateJvmApplicationIT.java#L122 from the TS as that would be just duplicate and we wouldn need additional helper methods like `runGradleDaemon`, `stopGradleDaemon`, `useQuarkusSnapshotFromSonatypeIfNeeded` and maybe more ...

TS passes:
```
mvn -e clean verify -f quarkus-cli -Dit.test=QuarkusCliCreateJvmApplicationIT#shouldCreateApplicationWithGradleOnJvm -Dreruns=0

mvn -e clean verify -f quarkus-cli -Dit.test=QuarkusCliCreateJvmApplicationIT#shouldCreateApplicationWithJbangOnJvm -Dreruns=0

```

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)