### PR TITLE
Remove disabled test annotation on old version of Quarkus

### DIFF
--- a/examples/quarkus-cli/src/test/java/io/quarkus/qe/QuarkusCliTlsCommandIT.java
+++ b/examples/quarkus-cli/src/test/java/io/quarkus/qe/QuarkusCliTlsCommandIT.java
@@ -13,15 +13,7 @@ import io.quarkus.test.bootstrap.tls.GenerateCertOptions;
 import io.quarkus.test.bootstrap.tls.GenerateQuarkusCaOptions;
 import io.quarkus.test.bootstrap.tls.QuarkusTlsCommand;
 import io.quarkus.test.scenarios.QuarkusScenario;
-import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersion;
-import io.quarkus.test.scenarios.annotations.DisabledOnQuarkusVersions;
 
-@DisabledOnQuarkusVersions({
-        // disable on 3.9-3.13
-        @DisabledOnQuarkusVersion(version = "3\\.(9|10|11|12|13)\\..*", reason = "https://github.com/quarkusio/quarkus/issues/42752"),
-        // disable on 3.14.0 and 3.14.1 as the fix is going to be backported to the next release
-        @DisabledOnQuarkusVersion(version = "3\\.14\\.(0|1)", reason = "https://github.com/quarkusio/quarkus/issues/42752")
-})
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @Tag("quarkus-cli")
 @QuarkusScenario


### PR DESCRIPTION
### Summary

I believe this annotation is not needed on main anymore as it was mainly for people to know not to run it with older versions of Quarkus.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)