### PR TITLE
CLI dev command with enabled batch mode

### DIFF
--- a/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/QuarkusCliClient.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/QuarkusCliClient.java
@@ -251,18 +251,14 @@ public class QuarkusCliClient {
         // and in the end, we have build-time analytics disabled everywhere except for one module
         // so there is little space for failure; TL;DR; this is not perfect if someone comes with a new order
         ServiceContext serviceContext = (ServiceContext) context.getTestStore().get(CLI_SERVICE_CONTEXT_KEY);
-        if (commandSendsAnalytics(cmd) && QuarkusProperties.disableBuildAnalytics(serviceContext)) {
+        if (isBuildOrDevCommand(cmd) && QuarkusProperties.disableBuildAnalytics(serviceContext)) {
             cmd.add(createDisableBuildAnalyticsProperty());
         }
 
         // limit logs for build command
-        if (cmd.stream().anyMatch(commandPart -> BUILD.equalsIgnoreCase(commandPart))) {
+        if (isBuildOrDevCommand(cmd)) {
             cmd.addAll(List.of("--batch-mode"));
         }
-
-        // TODO limit logs for dev command
-        // quarkus dev doesn't support passing additional parameters to the build system
-        // https://github.com/quarkusio/quarkus/issues/47247
 
         Log.info(String.join(" ", cmd));
         try {
@@ -276,7 +272,7 @@ public class QuarkusCliClient {
         }
     }
 
-    private static boolean commandSendsAnalytics(List<String> commands) {
+    private static boolean isBuildOrDevCommand(List<String> commands) {
         return commands.stream().anyMatch(cmd -> BUILD.equalsIgnoreCase(cmd) || DEV.equalsIgnoreCase(cmd));
     }
 


### PR DESCRIPTION
### Summary

CLI dev command with enabled batch mode

Leverages https://github.com/quarkusio/quarkus/pull/47291 

Batch mode for CLI dev command is available since Quarkus 3.22 (in main since Apr 14th), thus this PR is not suitable for backport into 3.20 branch

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)