### PR TITLE
GH Actions: set K8s version to 1.32.4

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -105,7 +105,7 @@ jobs:
         uses: manusa/actions-setup-minikube@v2.14.0
         with:
           minikube version: 'v1.35.0'
-          kubernetes version: 'v1.33.0'
+          kubernetes version: 'v1.32.4'
           github token: ${{ secrets.GITHUB_TOKEN }}
       - name: Login to Docker Registry
         uses: docker/login-action@v3
@@ -155,7 +155,7 @@ jobs:
         uses: manusa/actions-setup-minikube@v2.14.0
         with:
           minikube version: 'v1.35.0'
-          kubernetes version: 'v1.33.0'
+          kubernetes version: 'v1.32.4'
           github token: ${{ secrets.GITHUB_TOKEN }}
       - name: Login to Docker Registry
         uses: docker/login-action@v3


### PR DESCRIPTION
### Summary

PR fixes daily pipeline Kubernetes tests failures
Latest Minikube 1.35.0 doesn't work with the latest Kubernetes 1.33.0 which contains some breaking API changes.

Example run with this change: https://github.com/gtroitsk/quarkus-test-framework/actions/runs/14832910635/workflow#L40

Please check the relevant options
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)