### PR TITLE
Adapt OCP serving certificate support for keystore provider

### DIFF
--- a/quarkus-test-core/src/main/java/io/quarkus/test/security/certificate/CertificateBuilder.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/security/certificate/CertificateBuilder.java
@@ -75,6 +75,9 @@ public interface CertificateBuilder {
                     if (servingCertificate.injectCABundle()) {
                         svcCertConfigBuilder.withInjectCABundle(true);
                     }
+                    if (servingCertificate.useKeyStoreProvider()) {
+                        svcCertConfigBuilder.withUseKeyStoreProvider(true);
+                    }
                 }
                 if (!DEFAULT_CONFIG.equals(cert.tlsConfigName())) {
                     svcCertConfigBuilder.withTlsConfigName(cert.tlsConfigName());

--- a/quarkus-test-core/src/main/java/io/quarkus/test/security/certificate/ServingCertificateConfig.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/security/certificate/ServingCertificateConfig.java
@@ -2,7 +2,8 @@ package io.quarkus.test.security.certificate;
 
 import io.quarkus.test.bootstrap.ServiceContext;
 
-public record ServingCertificateConfig(boolean injectCABundle, boolean addServiceCertificate, String tlsConfigName) {
+public record ServingCertificateConfig(boolean injectCABundle, boolean addServiceCertificate, String tlsConfigName,
+        boolean useKeyStoreProvider) {
 
     public static final String SERVING_CERTIFICATE_KEY = "serving-certificate-config-key";
 
@@ -25,6 +26,7 @@ public record ServingCertificateConfig(boolean injectCABundle, boolean addServic
 
         private boolean injectCABundle = false;
         private boolean addServiceCertificate = false;
+        private boolean useKeyStoreProvider = false;
         private String tlsConfigName = null;
 
         private ServingCertificateConfigBuilder() {
@@ -45,9 +47,14 @@ public record ServingCertificateConfig(boolean injectCABundle, boolean addServic
             return this;
         }
 
+        ServingCertificateConfigBuilder withUseKeyStoreProvider(boolean useKeyStoreProvider) {
+            this.useKeyStoreProvider = useKeyStoreProvider;
+            return this;
+        }
+
         ServingCertificateConfig build() {
             if (injectCABundle || addServiceCertificate) {
-                return new ServingCertificateConfig(injectCABundle, addServiceCertificate, tlsConfigName);
+                return new ServingCertificateConfig(injectCABundle, addServiceCertificate, tlsConfigName, useKeyStoreProvider);
             }
             return null;
         }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/Certificate.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/Certificate.java
@@ -160,6 +160,12 @@ public @interface Certificate {
          */
         boolean addServiceCertificate() default false;
 
+        /**
+         * By default, when the service certificate is added, we configure the TLS registry
+         * with PEM certificate paths. However, when we want to test Quarkus TLS Registry KeyStore provider,
+         * we shouldn't configure the PEM certificates paths, so that the provider is used.
+         */
+        boolean useKeyStoreProvider() default false;
     }
 
 }

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
@@ -1294,4 +1294,8 @@ public final class OpenShiftClient {
                 .forEach(container -> container.getVolumeMounts()
                         .add(createVolumeMount(volumeName, volume)));
     }
+
+    public io.fabric8.openshift.client.OpenShiftClient getFabric8Client() {
+        return client;
+    }
 }

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftQuarkusApplicationManagedResource.java
@@ -204,16 +204,18 @@ public abstract class OpenShiftQuarkusApplicationManagedResource<T extends Quark
                 var mountSecretVal = buildMountSecretProp(SERVING_CERTS_SECRET_NAME, "/etc/tls");
                 var mountSecretKey = createSecretPropertyKey();
                 ctx.withTestScopeConfigProperty(mountSecretKey, mountSecretVal);
-                // configure TLS registry with mounted secret
-                if (config.tlsConfigName() == null) {
-                    ctx.withTestScopeConfigProperty("quarkus.tls.key-store.pem.acme.cert", "/etc/tls/tls.crt");
-                    ctx.withTestScopeConfigProperty("quarkus.tls.key-store.pem.acme.key", "/etc/tls/tls.key");
-                } else {
-                    ctx.withTestScopeConfigProperty("quarkus.tls." + config.tlsConfigName() + ".key-store.pem.acme.cert",
-                            "/etc/tls/tls.crt");
-                    ctx.withTestScopeConfigProperty("quarkus.tls." + config.tlsConfigName() + ".key-store.pem.acme.key",
-                            "/etc/tls/tls.key");
-                    ctx.withTestScopeConfigProperty("quarkus.http.tls-configuration-name", config.tlsConfigName());
+                if (!config.useKeyStoreProvider()) {
+                    // configure TLS registry with mounted secret
+                    if (config.tlsConfigName() == null) {
+                        ctx.withTestScopeConfigProperty("quarkus.tls.key-store.pem.acme.cert", "/etc/tls/tls.crt");
+                        ctx.withTestScopeConfigProperty("quarkus.tls.key-store.pem.acme.key", "/etc/tls/tls.key");
+                    } else {
+                        ctx.withTestScopeConfigProperty("quarkus.tls." + config.tlsConfigName() + ".key-store.pem.acme.cert",
+                                "/etc/tls/tls.crt");
+                        ctx.withTestScopeConfigProperty("quarkus.tls." + config.tlsConfigName() + ".key-store.pem.acme.key",
+                                "/etc/tls/tls.key");
+                        ctx.withTestScopeConfigProperty("quarkus.http.tls-configuration-name", config.tlsConfigName());
+                    }
                 }
             }
             if (config.injectCABundle()) {


### PR DESCRIPTION
### Summary

I need to be able to use delegating Fabric8 client and avoid configuring TLS configuration PEM paths when KeyStore provider is used.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)