### PR TITLE
Fix optional relocation of regenerated certificates

### DIFF
--- a/quarkus-test-core/src/main/java/io/quarkus/test/security/certificate/Certificate.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/security/certificate/Certificate.java
@@ -33,7 +33,6 @@ import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.condition.OS;
 
-import io.quarkus.test.utils.FileUtils;
 import io.quarkus.test.utils.TestExecutionProperties;
 import io.smallrye.certs.CertificateGenerator;
 import io.smallrye.certs.CertificateRequest;
@@ -509,7 +508,10 @@ public interface Certificate {
 
     private static String moveFileIfRequired(String newPath, String currentPath) {
         if (newPath != null) {
-            FileUtils.copyFileTo(currentPath, Path.of(newPath));
+            var fileMoved = new File(newPath).renameTo(new File(currentPath));
+            if (!fileMoved) {
+                throw new IllegalStateException("Failed to move certificate file '" + newPath + "' to '" + currentPath + "'");
+            }
             return newPath;
         }
         return currentPath;


### PR DESCRIPTION
### Summary

This PR fixes https://github.com/quarkus-qe/quarkus-test-framework/blob/4be4f721cc6bbf39a9df4a142c5d0a93f2fbea05/quarkus-test-core/src/main/java/io/quarkus/test/security/certificate/CertificateRequestCustomizer.java#L18 and https://github.com/quarkus-qe/quarkus-test-framework/blob/4be4f721cc6bbf39a9df4a142c5d0a93f2fbea05/quarkus-test-core/src/main/java/io/quarkus/test/security/certificate/CertificateRequestCustomizer.java#L20. They are currently not used by any of our tests, but the last week I was working with regenerated certificates and mentioned that I can't use these methods because `FileUtils.copyFileTo` accepts resource path, however regenerated certificate has always absolute path and is placed somewhere in a temporary directory.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)