### PR TITLE
Fail if explicitly added `properties` file doesn't exist

### DIFF
--- a/examples/greetings/src/test/java/io/quarkus/qe/GreetingResourceUsingPropertiesFileIT.java
+++ b/examples/greetings/src/test/java/io/quarkus/qe/GreetingResourceUsingPropertiesFileIT.java
@@ -19,6 +19,16 @@ public class GreetingResourceUsingPropertiesFileIT {
     static final RestService joseApp = new RestService().withProperties("jose.properties");
     @QuarkusApplication
     static final RestService manuelApp = new RestService().withProperties("manuel.properties");
+    @QuarkusApplication(properties = "jose.properties")
+    static final RestService fileApp = new RestService();
+    @QuarkusApplication
+    static final RestService victorApp = new RestService();
+    /*
+     * This app can not be built:
+     *
+     * @QuarkusApplication(properties = "non-existing.properties")
+     * static final RestService failApp = new RestService();
+     */
 
     @Test
     public void shouldSayJose() {
@@ -30,4 +40,13 @@ public class GreetingResourceUsingPropertiesFileIT {
         manuelApp.given().get("/greeting").then().statusCode(HttpStatus.SC_OK).body(is("Hello, I'm " + MANUEL_NAME));
     }
 
+    @Test
+    public void shouldAlsoSayJose() {
+        fileApp.given().get("/greeting").then().statusCode(HttpStatus.SC_OK).body(is("Hello, I'm " + JOSE_NAME));
+    }
+
+    @Test
+    public void shouldSayVictor() {
+        victorApp.given().get("/greeting").then().statusCode(HttpStatus.SC_OK).body(is("Hello, I'm victor"));
+    }
 }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusApplicationManagedResourceBuilder.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusApplicationManagedResourceBuilder.java
@@ -278,6 +278,11 @@ public abstract class QuarkusApplicationManagedResourceBuilder implements Manage
                 needsEnhancedApplicationProperties = true;
             }
             map.putAll(sourceAppPropsMap);
+        } else if (!propertiesFile.equalsIgnoreCase(APPLICATION_PROPERTIES)) {
+            // This branch means, that the user added custom file name, but the file doesn't exist.
+            // I presume, that situation, where user explicitly adds default file name(ie `application.properties`)
+            // but the file doesn't exist, is too rare to be considered seriously.
+            throw new IllegalStateException("Requested properties file " + sourceApplicationProperties + " doesn't exist");
         }
 
         // Then add the service properties


### PR DESCRIPTION
### Summary

Fixes https://github.com/quarkus-qe/quarkus-test-framework/issues/1285

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)