### PR TITLE
Migrate strimzi operator from zookeper to kraft

### DIFF
--- a/quarkus-test-service-kafka/src/main/resources/strimzi-operator-kafka-instance.yaml
+++ b/quarkus-test-service-kafka/src/main/resources/strimzi-operator-kafka-instance.yaml
@@ -1,7 +1,32 @@
+# Based on https://github.com/strimzi/strimzi-kafka-operator/blob/release-0.46.x/examples/kafka/kafka-single-node.yaml
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaNodePool
+metadata:
+  name: dual-role
+  labels:
+    strimzi.io/cluster: kafka-instance
+spec:
+  replicas: 1
+  roles:
+    - controller
+    - broker
+  storage:
+    type: jbod
+    volumes:
+      - id: 0
+        type: persistent-claim
+        size: 100Mi
+        deleteClaim: true
+        kraftMetadata: shared
+---
+
 apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
   name: kafka-instance
+  annotations:
+    strimzi.io/node-pools: enabled
+    strimzi.io/kraft: enabled
 spec:
   kafka:
     version: 3.9.0
@@ -19,20 +44,6 @@ spec:
       offsets.topic.replication.factor: 1
       transaction.state.log.replication.factor: 1
       transaction.state.log.min.isr: 1
-      log.message.format.version: "3.1-IV0"
-    storage:
-      type: jbod
-      volumes:
-        - id: 0
-          type: persistent-claim
-          size: 100Mi
-          deleteClaim: true
-  zookeeper:
-    replicas: 1
-    storage:
-      type: persistent-claim
-      size: 100Mi
-      deleteClaim: true
   entityOperator:
     topicOperator: {}
     userOperator: {}


### PR DESCRIPTION
### Summary

This PR fixing `OpenShiftStrimziOperatorKafkaWithoutRegistryMessagingIT`

Moving the strimzi operator from Zookeper to KRaft.

Also removing `log.message.format.version` as by docs https://kafka.apache.org/40/documentation.html it was removed in kafka 4.0 (same as zookeper). I keep the Kafka on 3.9.0 version atm as we using it on other places.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)