### PR TITLE
Use targetPath instead of currentPath for better clarity in Certificate#moveFileIfRequired

### DIFF
--- a/quarkus-test-core/src/main/java/io/quarkus/test/security/certificate/Certificate.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/security/certificate/Certificate.java
@@ -506,14 +506,14 @@ public interface Certificate {
         }
     }
 
-    private static String moveFileIfRequired(String newPath, String currentPath) {
+    private static String moveFileIfRequired(String newPath, String targetPath) {
         if (newPath != null) {
-            var fileMoved = new File(newPath).renameTo(new File(currentPath));
+            var fileMoved = new File(newPath).renameTo(new File(targetPath));
             if (!fileMoved) {
-                throw new IllegalStateException("Failed to move certificate file '" + newPath + "' to '" + currentPath + "'");
+                throw new IllegalStateException("Failed to move certificate file '" + newPath + "' to '" + targetPath + "'");
             }
             return newPath;
         }
-        return currentPath;
+        return targetPath;
     }
 }


### PR DESCRIPTION
### Summary

Use targetPath instead of currentPath for better clarity in Certificate#moveFileIfRequired

Triggered by review of https://github.com/quarkus-qe/quarkus-test-framework/pull/1580/files

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)