### PR TITLE
Move daily build after daily upstream build is deployed to snapshot repository

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -2,7 +2,7 @@ name: "Daily Build"
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 23 * * *'
+    - cron: '20 1 * * *'
 jobs:
   linux-build-jvm-latest:
     name: Linux JVM


### PR DESCRIPTION
### Summary

This should increase a chance that the daily build of this framework is tested with the latest Quarkus which is scheduled to be built after midnight https://github.com/quarkusio/quarkus/pull/48054. It may not be always the case because the daily build of this framework takes more than 2 hours and I don't want to have big overlap with the Quarkus QE Test Suite daily build scheduled after 2:30 AM https://github.com/quarkus-qe/quarkus-test-suite/pull/2479. We can't take these times literally because runs are not triggered immediately and we can't be sure how long we need before artifacts are available.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)