### PR TITLE
[1.6.z] Use publisher portal instead of s01.ossrh

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -1,9 +1,6 @@
 name: 'Deploy Quarkus QE Test Framework'
 description: 'Deploys Quarkus QE Test Framework'
 inputs:
-  repository-id:
-    description: 'Must match a repository id present in of the POM file distributionManagement repositories'
-    required: true
   release-version:
     description: 'Version under which should this framework be released'
   ossrh-username:
@@ -23,7 +20,7 @@ runs:
         distribution: 'temurin'
         java-version: 17
         check-latest: true
-        server-id: ${{ inputs.repository-id }}
+        server-id: 'central'
         server-username: MAVEN_USERNAME
         server-password: MAVEN_PASSWORD
         gpg-private-key: ${{ inputs.gpg-private-key }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,6 @@ jobs:
           metadata-file-path: '.github/project.yml'
       - uses: ./.github/actions/deploy
         with:
-          repository-id: 'oss.sonatype'
           release-version: ${{steps.metadata.outputs.current-version}}
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           ossrh-token: ${{ secrets.OSSRH_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -643,7 +643,6 @@
                         <configuration>
                             <publishingServerId>central</publishingServerId>
                             <autoPublish>true</autoPublish>
-                            <waitUntil>published</waitUntil>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <maven-gpg-plugin.version>3.2.7</maven-gpg-plugin.version>
         <maven-javadoc-plugin.version>3.11.2</maven-javadoc-plugin.version>
         <maven-release-plugin.version>3.1.1</maven-release-plugin.version>
-        <nexus-staging-maven-plugin.version>1.7.0</nexus-staging-maven-plugin.version>
+        <central-publishing-maven-plugin.version>0.7.0</central-publishing-maven-plugin.version>
         <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
@@ -636,15 +636,14 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>${nexus-staging-maven-plugin.version}</version>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>${central-publishing-maven-plugin.version}</version>
                         <extensions>true</extensions>
                         <configuration>
-                            <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-                            <serverId>oss.sonatype</serverId>
-                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                            <stagingProgressTimeoutMinutes>60</stagingProgressTimeoutMinutes>
+                            <publishingServerId>central</publishingServerId>
+                            <autoPublish>true</autoPublish>
+                            <waitUntil>published</waitUntil>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
### Summary

* io.quarkus namespace has been moved to publishing on publisher portal last weekend, so the old actions do not work proper. Updating the plugin and server ID to follow the migration to publisher portal guide (cherry picked from commit d3efa4fdf234d99d3067c671c20b19951e209687)
* Removing the wait for the bundle to be published in publisher portal as the default is far too low and we do not need to block an executor  to wait for that (cherry picked from commit dc230681ac4e9864936c03c422642585f48614cd)

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)