### PR TITLE
Proposal for TLS for OCP services

### DIFF
--- a/quarkus-test-containers/src/main/java/io/quarkus/test/services/Container.java
+++ b/quarkus-test-containers/src/main/java/io/quarkus/test/services/Container.java
@@ -28,4 +28,10 @@ public @interface Container {
     Class<? extends ManagedResourceBuilder> builder() default ContainerManagedResourceBuilder.class;
 
     Mount[] mounts() default {};
+
+    /**
+     * Enable TLS pass-through route on OpenShift. If yes state port to forward TLS traffic to.
+     * If set to 0, TLS will be disabled.
+     */
+    int ocpTlsPort() default 0;
 }

--- a/quarkus-test-containers/src/main/java/io/quarkus/test/services/containers/ContainerManagedResourceBuilder.java
+++ b/quarkus-test-containers/src/main/java/io/quarkus/test/services/containers/ContainerManagedResourceBuilder.java
@@ -25,6 +25,7 @@ public class ContainerManagedResourceBuilder implements ManagedResourceBuilder {
     private String[] command;
     private List<MountConfig> mounts = new ArrayList<>();
     private Integer port;
+    private Integer ocpTlsPort;
     private boolean portDockerHostToLocalhost;
 
     protected String getImage() {
@@ -43,6 +44,10 @@ public class ContainerManagedResourceBuilder implements ManagedResourceBuilder {
         return port;
     }
 
+    protected Integer getOcpTlsPort() {
+        return ocpTlsPort;
+    }
+
     protected ServiceContext getContext() {
         return context;
     }
@@ -50,18 +55,20 @@ public class ContainerManagedResourceBuilder implements ManagedResourceBuilder {
     @Override
     public void init(Annotation annotation) {
         Container metadata = (Container) annotation;
-        init(metadata.image(), metadata.command(), metadata.expectedLog(), metadata.port(),
+        init(metadata.image(), metadata.command(), metadata.expectedLog(), metadata.port(), metadata.ocpTlsPort(),
                 metadata.portDockerHostToLocalhost());
         this.mounts = Arrays.stream(metadata.mounts()).sequential()
                 .map(mount -> new MountConfig(mount.from(), mount.to()))
                 .toList();
     }
 
-    protected void init(String image, String[] command, String expectedLog, int port, boolean portDockerHostToLocalhost) {
+    protected void init(String image, String[] command, String expectedLog, int port, int ocpTlsPort,
+            boolean portDockerHostToLocalhost) {
         this.image = PropertiesUtils.resolveProperty(image);
         this.command = command;
         this.expectedLog = PropertiesUtils.resolveProperty(expectedLog);
         this.port = port;
+        this.ocpTlsPort = ocpTlsPort;
         this.portDockerHostToLocalhost = portDockerHostToLocalhost;
     }
 

--- a/quarkus-test-core/src/main/java/io/quarkus/test/configuration/Configuration.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/configuration/Configuration.java
@@ -156,6 +156,7 @@ public final class Configuration {
         KUBERNETES_EPHEMERAL_NAMESPACES("kubernetes.ephemeral.namespaces.enabled"),
         OPENSHIFT_DEPLOYMENT_SERVICE_PROPERTY("openshift.service"),
         OPENSHIFT_DEPLOYMENT_TEMPLATE_PROPERTY("openshift.template"),
+        OPENSHIFT_TLS_TEMPLATE_PROPERTY("openshift.tls.service.template"),
         OPENSHIFT_USE_INTERNAL_SERVICE_AS_URL_PROPERTY("openshift.use-internal-service-as-url"),
         OPENSHIFT_DELETE_AFTERWARDS("openshift.delete.project.after.all"),
         OPENSHIFT_PRINT_ON_ERROR("openshift.print.info.on.error"),

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/QuarkusApplication.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/QuarkusApplication.java
@@ -41,4 +41,11 @@ public @interface QuarkusApplication {
      * Enable GRPC configuration. This property will map the gPRC service to a random port.
      */
     boolean grpc() default false;
+
+    /**
+     * Enable TLS pass-through route on OpenShift. If yes state port to forward TLS traffic to.
+     * If set to 0, TLS will be disabled.
+     * This option does !not! configure the app to setup TLS, it just creates TLS route in OCP.
+     */
+    int ocpTlsPort() default 0;
 }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/ProdQuarkusApplicationManagedResourceBuilder.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/ProdQuarkusApplicationManagedResourceBuilder.java
@@ -46,6 +46,7 @@ public class ProdQuarkusApplicationManagedResourceBuilder extends ArtifactQuarku
         setGrpcEnabled(metadata.grpc());
         initAppClasses(metadata.classes());
         initForcedDependencies(metadata.dependencies());
+        setOcpTlsPort(metadata.ocpTlsPort());
         setCertificateBuilder(CertificateBuilder.of(metadata.certificates()));
     }
 

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusApplicationManagedResourceBuilder.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusApplicationManagedResourceBuilder.java
@@ -69,6 +69,7 @@ public abstract class QuarkusApplicationManagedResourceBuilder implements Manage
     private Set<String> detectedBuildTimeProperties;
     private boolean needsEnhancedApplicationProperties = false;
     private boolean s2iScenario = false;
+    private int ocpTlsPort = 0;
 
     protected abstract void build();
 
@@ -118,6 +119,14 @@ public abstract class QuarkusApplicationManagedResourceBuilder implements Manage
 
     protected void setCustomBuildRequired() {
         this.requiresCustomBuild = true;
+    }
+
+    protected int getOcpTlsPort() {
+        return ocpTlsPort;
+    }
+
+    protected void setOcpTlsPort(int ocpTlsPort) {
+        this.ocpTlsPort = ocpTlsPort;
     }
 
     @Override

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
@@ -333,6 +333,15 @@ public final class OpenShiftClient {
         }
     }
 
+    public void createTlsPassthroughRoute(String serviceName, String routeName, int port) {
+        try {
+            new Command(OC, "create", "route", "passthrough",
+                    routeName, "--service=" + serviceName, "--port=" + port).runAndWait();
+        } catch (Exception e) {
+            fail("Failed to create TLS passthrought route. Caused by " + e.getMessage());
+        }
+    }
+
     /**
      * Create a service for deployment.
      * Usually done automatically, or inside yamls, so this method should be used only in a very special cases,

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/containers/OpenShiftContainerManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/containers/OpenShiftContainerManagedResource.java
@@ -25,6 +25,7 @@ import io.quarkus.test.utils.FileUtils;
 public class OpenShiftContainerManagedResource implements ManagedResource {
 
     private static final String DEPLOYMENT_TEMPLATE_PROPERTY_DEFAULT = "/openshift-deployment-template.yml";
+    private static final String DEPLOYMENT_TLS_TEMPLATE_PROPERTY_DEFAULT = "/openshift-deployment-with-tls-template.yml";
     private static final String DEPLOYMENT = "openshift.yml";
 
     private static final int HTTP_PORT = 80;
@@ -51,7 +52,15 @@ public class OpenShiftContainerManagedResource implements ManagedResource {
             return;
         }
 
-        applyDeployment();
+        String deploymentFile;
+        if (model.getOcpTlsPort() != 0) {
+            deploymentFile = getConfiguration().getOrDefault(Configuration.Property.OPENSHIFT_TLS_TEMPLATE_PROPERTY,
+                    getTlsTemplateByDefault());
+        } else {
+            deploymentFile = getConfiguration().getOrDefault(Configuration.Property.OPENSHIFT_DEPLOYMENT_TEMPLATE_PROPERTY,
+                    getTemplateByDefault());
+        }
+        applyDeployment(deploymentFile);
         exposeService();
 
         client.scaleTo(model.getContext().getOwner(), 1);
@@ -105,6 +114,10 @@ public class OpenShiftContainerManagedResource implements ManagedResource {
         return DEPLOYMENT_TEMPLATE_PROPERTY_DEFAULT;
     }
 
+    protected String getTlsTemplateByDefault() {
+        return DEPLOYMENT_TLS_TEMPLATE_PROPERTY_DEFAULT;
+    }
+
     protected boolean useInternalServiceByDefault() {
         return false;
     }
@@ -131,15 +144,14 @@ public class OpenShiftContainerManagedResource implements ManagedResource {
         String args = Arrays.stream(model.getCommand()).map(cmd -> "\"" + cmd + "\"").collect(Collectors.joining(", "));
         return content.replaceAll(quote("${IMAGE}"), model.getImage())
                 .replaceAll(quote("${SERVICE_NAME}"), model.getContext().getName())
+                .replaceAll(quote("${TLS_PORT}"), "" + model.getOcpTlsPort())
                 .replaceAll(quote("${INTERNAL_PORT}"), "" + model.getPort())
                 .replaceAll(quote("${INTERNAL_INGRESS_PORT}"), "" + model.getPort())
                 .replaceAll(quote("${ARGS}"), args)
                 .replaceAll(quote("${CURRENT_NAMESPACE}"), client.project());
     }
 
-    private void applyDeployment() {
-        String deploymentFile = getConfiguration().getOrDefault(Configuration.Property.OPENSHIFT_DEPLOYMENT_TEMPLATE_PROPERTY,
-                getTemplateByDefault());
+    private void applyDeployment(String deploymentFile) {
         Path templateFile = model.getContext().getServiceFolder().resolve(DEPLOYMENT);
         client.applyServicePropertiesUsingTemplate(model.getContext().getOwner(),
                 deploymentFile,

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/TemplateOpenShiftQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/TemplateOpenShiftQuarkusApplicationManagedResource.java
@@ -71,6 +71,11 @@ public abstract class TemplateOpenShiftQuarkusApplicationManagedResource<T exten
                 this::internalReplaceDeploymentContent,
                 addExtraTemplateProperties(),
                 model.getContext().getServiceFolder().resolve(DEPLOYMENT));
+        if (model.getOcpTlsPort() != 0) {
+            client.createTlsPassthroughRoute(model.getContext().getName(),
+                    model.getContext().getName() + "-tls",
+                    model.getOcpTlsPort());
+        }
     }
 
     private String internalReplaceDeploymentContent(String content) {
@@ -86,6 +91,7 @@ public abstract class TemplateOpenShiftQuarkusApplicationManagedResource<T exten
         content = content.replaceAll(quote("${SERVICE_NAME}"), model.getContext().getName())
                 .replaceAll(quote("${INTERNAL_PORT}"), "" + getInternalPort())
                 .replaceAll(quote("${INTERNAL_INGRESS_PORT}"), "" + ingressInternalPort)
+                .replaceAll(quote("${TLS_PORT}"), "" + model.getOcpTlsPort())
                 .replace("${MANAGEMENT_PORT}", "" + model.getManagementPort());
 
         return replaceDeploymentContent(content);

--- a/quarkus-test-openshift/src/main/resources/openshift-deployment-with-tls-template.yml
+++ b/quarkus-test-openshift/src/main/resources/openshift-deployment-with-tls-template.yml
@@ -1,0 +1,60 @@
+---
+apiVersion: "v1"
+kind: "List"
+items:
+  - apiVersion: "v1"
+    kind: "Service"
+    metadata:
+      name: "${SERVICE_NAME}"
+    spec:
+      ports:
+        - name: "http"
+          port: ${INTERNAL_INGRESS_PORT}
+          targetPort: ${INTERNAL_PORT}
+        - name: "https"
+          port: 8443
+          targetPort: ${TLS_PORT}
+      selector:
+        deployment: "${SERVICE_NAME}"
+      type: "ClusterIP"
+  - apiVersion: "apps/v1"
+    kind: "Deployment"
+    metadata:
+      name: "${SERVICE_NAME}"
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          deployment: "${SERVICE_NAME}"
+      template:
+        metadata:
+          labels:
+            deployment: "${SERVICE_NAME}"
+        spec:
+          containers:
+            - image: "${IMAGE}"
+              args: [${ARGS}]
+              imagePullPolicy: "IfNotPresent"
+              name: "${SERVICE_NAME}"
+              ports:
+                - containerPort: ${INTERNAL_PORT}
+                  name: "http"
+                  protocol: "TCP"
+                - containerPort: ${TLS_PORT}
+                  name: "https"
+                  protocol: "TCP"
+      triggers:
+        - type: "ConfigChange"
+  - apiVersion: route.openshift.io/v1
+    kind: Route
+    metadata:
+      name: ${SERVICE_NAME}-tls
+    spec:
+      to:
+        kind: Service
+        name: ${SERVICE_NAME}
+      port:
+        targetPort: 8443
+      tls:
+        termination: passthrough
+      

--- a/quarkus-test-openshift/src/main/resources/quarkus-build-openshift-template.yml
+++ b/quarkus-test-openshift/src/main/resources/quarkus-build-openshift-template.yml
@@ -14,6 +14,9 @@ items:
         - name: "http"
           port: ${INTERNAL_INGRESS_PORT}
           targetPort: ${INTERNAL_PORT}
+        - name: "https"
+          port: "8443"
+          targetPort: ${TLS_PORT}
       selector:
         app.kubernetes.io/name: "${SERVICE_NAME}"
       type: "ClusterIP"
@@ -101,6 +104,9 @@ items:
               ports:
                 - containerPort: ${INTERNAL_PORT}
                   name: "http"
+                  protocol: "TCP"
+                - containerPort: ${TLS_PORT}
+                  name: "https"
                   protocol: "TCP"
       triggers:
         - imageChangeParams:

--- a/quarkus-test-service-database/src/main/java/io/quarkus/test/services/SqlServerContainer.java
+++ b/quarkus-test-service-database/src/main/java/io/quarkus/test/services/SqlServerContainer.java
@@ -19,4 +19,10 @@ public @interface SqlServerContainer {
      * Encrypt connections to SQL Server.
      */
     boolean tlsEnabled() default false;
+
+    /**
+     * Enable TLS pass-through route on OpenShift. If yes state port to forward TLS traffic to.
+     * If set to 0, TLS will be disabled.
+     */
+    int ocpTlsPort() default 0;
 }

--- a/quarkus-test-service-database/src/main/java/io/quarkus/test/services/containers/SqlServerManagedResourceBuilder.java
+++ b/quarkus-test-service-database/src/main/java/io/quarkus/test/services/containers/SqlServerManagedResourceBuilder.java
@@ -24,7 +24,7 @@ public final class SqlServerManagedResourceBuilder extends ContainerManagedResou
         if (annotation instanceof SqlServerContainer sqlServerContainer) {
             tlsEnabled = sqlServerContainer.tlsEnabled();
             init(sqlServerContainer.image(), new String[0], sqlServerContainer.expectedLog(), sqlServerContainer.port(),
-                    tlsEnabled);
+                    sqlServerContainer.ocpTlsPort(), tlsEnabled);
         } else {
             throw new IllegalStateException("Expected annotation SqlServerContainer, but got: " + annotation);
         }

--- a/quarkus-test-service-keycloak/src/main/java/io/quarkus/test/services/KeycloakContainer.java
+++ b/quarkus-test-service-keycloak/src/main/java/io/quarkus/test/services/KeycloakContainer.java
@@ -25,4 +25,10 @@ public @interface KeycloakContainer {
     long memoryLimitMiB() default 1000;
 
     Class<? extends ManagedResourceBuilder> builder() default KeycloakContainerManagedResourceBuilder.class;
+
+    /**
+     * Enable TLS pass-through route on OpenShift. If yes state port to forward TLS traffic to.
+     * If set to 0, TLS will be disabled.
+     */
+    int ocpTlsPort() default 0;
 }

--- a/quarkus-test-service-keycloak/src/main/java/io/quarkus/test/services/containers/KeycloakContainerManagedResourceBuilder.java
+++ b/quarkus-test-service-keycloak/src/main/java/io/quarkus/test/services/containers/KeycloakContainerManagedResourceBuilder.java
@@ -16,6 +16,7 @@ public class KeycloakContainerManagedResourceBuilder extends ContainerManagedRes
     private ServiceContext context;
     private String image;
     private int restPort;
+    private int ocpTlsPort;
     private String[] command;
     private String expectedLog;
     private long memoryLimitMiB;
@@ -28,6 +29,11 @@ public class KeycloakContainerManagedResourceBuilder extends ContainerManagedRes
     @Override
     protected Integer getPort() {
         return restPort;
+    }
+
+    @Override
+    protected Integer getOcpTlsPort() {
+        return ocpTlsPort;
     }
 
     @Override
@@ -54,6 +60,7 @@ public class KeycloakContainerManagedResourceBuilder extends ContainerManagedRes
         KeycloakContainer metadata = (KeycloakContainer) annotation;
         this.image = PropertiesUtils.resolveProperty(metadata.image());
         this.restPort = metadata.port();
+        this.ocpTlsPort = metadata.ocpTlsPort();
         this.expectedLog = PropertiesUtils.resolveProperty(metadata.expectedLog());
         this.command = metadata.command();
         this.memoryLimitMiB = metadata.memoryLimitMiB();


### PR DESCRIPTION
### Summary

This a proposal for how we could enable TLS in our OCP tests. Currently its just a POC of how it might work. It is far from finished.

I intend to support only creating TLS pass-through routes (TLS is terminated on the app). I don't see a point in doing any other OCP TLS termination types for our use cases.

Core idea is that app annotations will have a new parameter `ocpTlsPort`. In case it is set, FW will create a TLS passthrough route to that app. This will only setup a route, it will not setup the TLS in app or nothing else.

I really want to avoid changing the OCP yaml templates on the fly or any similar stuff. IMHO it would be a huge mess.

I tried two implementation approaches:

1. Currently implemented for keycloak (side effect also for other container based app). Where I currently have 2 OCP yaml templates and based on the `ocpTlsPort` param, it will take the one with TLS or without it. Positive of this is, that we don't create anything else on the OCP when we don't use TLS. Negative is, that we would have to maintain two templates and with any more branching, this can get out of control.
2. Currently for `@QuarkusApplication`. It will just create the TLS port and service every time and based on `ocpTlsPort` it will (not) expose the TLS (create/not the HTTPS route). It is simpler to implement and manage. IMHO create the TLS port on deployment/service while not using it is not that big of a deal. It creates some (possibly) unnecessary stuff, but I don't think 

Another way might be to actually adjust the OCP resources on fly, using OpenShiftClientImpl, but I'm not sure how well that is set up in the FW.


Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)