### PR TITLE
Remove UBI 8 and Java 17 sub-job for Kubernetes in native

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -135,9 +135,6 @@ jobs:
           - quarkus-version: "999-SNAPSHOT"
             java: 21
           - quarkus-version: "999-SNAPSHOT"
-            java: 17 # test 'quarkus-container-image-jib' with images based on UBI8 and Java 17
-            extra-maven-args: '-pl examples/pingpong/ -Dtest-ubi8-compatibility -Dquarkus.jib.base-native-image=quay.io/quarkus/quarkus-micro-image:2.0 -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-17'
-          - quarkus-version: "999-SNAPSHOT"
             java: 21 # test 'quarkus-container-image-jib' with images based on UBI8 and Java 21
             extra-maven-args: '-pl examples/pingpong/ -Dtest-ubi8-compatibility -Dquarkus.jib.base-native-image=quay.io/quarkus/quarkus-micro-image:2.0 -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-21'
     steps:


### PR DESCRIPTION
### Summary

This PR fixes our Kubernetes Native CI, so drops UBI 8 compatibility job with JDK17-based Mandel image, that is unsupported for the last Quarkus 

`[INFO] [io.quarkus.deployment.pkg.steps.NativeImageBuildStep] Running Quarkus native-image plugin on MANDREL 23.0.6.0 JDK 17.0.13+11
Warning:  [io.quarkus.deployment.pkg.steps.NativeImageBuildStep] You are using an older version of GraalVM or Mandrel : 23.0.6.0. Quarkus currently supports 23.1.0. Please upgrade to this version.`

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)