### PR TITLE
Add SAN into certificate options

### DIFF
--- a/examples/https/src/test/java/io/quarkus/qe/TlsSANReloadIT.java
+++ b/examples/https/src/test/java/io/quarkus/qe/TlsSANReloadIT.java
@@ -1,0 +1,47 @@
+package io.quarkus.qe;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Arrays;
+import java.util.concurrent.CompletionException;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.Protocol;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.security.certificate.CertificateBuilder;
+import io.quarkus.test.services.Certificate;
+import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.test.utils.AwaitilityUtils;
+
+@QuarkusScenario
+public class TlsSANReloadIT {
+    private static final String CERT_PREFIX = "reload-test";
+
+    @QuarkusApplication(ssl = true, certificates = @Certificate(configureTruststore = true, configureHttpServer = true, configureKeystore = true, prefix = CERT_PREFIX))
+    static final RestService app = new RestService()
+            .withProperty("quarkus.tls.reload-period", "2s");
+
+    @Test
+    public void testRegenerateCertWithAlternativeNames() {
+        int httpsPort = app.getURI(Protocol.HTTPS).getPort();
+        // IP 127.0.0.1 (localhost) ir originally not listed in certificate, so request should fail on SSLCreation problem
+        assertThrows(CompletionException.class,
+                () -> app.mutinyHttps().get(httpsPort, "127.0.0.1", "/greeting").sendAndAwait(),
+                "TLS connection should fail");
+
+        // Add IP 127.0.0.1 as SAN so it should be trusted from now on
+        app
+                .<CertificateBuilder> getPropertyFromContext(CertificateBuilder.INSTANCE_KEY)
+                .regenerateCertificate(CERT_PREFIX,
+                        certReq -> certReq.withSubjectAlternativeNames(Arrays.asList("IP:127.0.0.1", "app", "randomString")));
+
+        // after certificate is reloaded connection should be created as 127.0.0.1 is now in certificate
+        AwaitilityUtils.untilAsserted(() -> {
+            var response = app.mutinyHttps().get(httpsPort, "127.0.0.1", "/greeting").sendAndAwait();
+            assertEquals("Hello World!", response.bodyAsString());
+        });
+    }
+}

--- a/quarkus-test-core/src/main/java/io/quarkus/test/security/certificate/CertificateBuilder.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/security/certificate/CertificateBuilder.java
@@ -58,7 +58,8 @@ public interface CertificateBuilder {
                     cert.password(), cert.configureKeystore(), cert.configureTruststore(),
                     cert.configureManagementInterface(),
                     clientCertReqs, createCertsTempDir(cert.prefix()), new DefaultContainerMountStrategy(cert.prefix()),
-                    false, null, null, null, null, cert.useTlsRegistry(), cert.tlsConfigName(), cert.configureHttpServer())));
+                    false, null, null, null, null, cert.useTlsRegistry(), cert.tlsConfigName(), cert.configureHttpServer(),
+                    null)));
         }
         return new CertificateBuilderImpl(List.copyOf(generatedCerts), svcCertConfigBuilder.build());
     }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/security/certificate/CertificateOptions.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/security/certificate/CertificateOptions.java
@@ -1,12 +1,13 @@
 package io.quarkus.test.security.certificate;
 
 import java.nio.file.Path;
+import java.util.List;
 
 public record CertificateOptions(String prefix, io.quarkus.test.services.Certificate.Format format, String password,
         boolean keystoreProps, boolean truststoreProps, boolean configureManagementInterface,
         ClientCertificateRequest[] clientCertificates, Path localTargetDir,
         ContainerMountStrategy containerMountStrategy, boolean createPkcs12TsForPem,
         String serverTrustStoreLocation, String serverKeyStoreLocation, String keyLocation, String certLocation,
-        boolean tlsRegistryEnabled, String tlsConfigName, boolean configureHttpServer) {
+        boolean tlsRegistryEnabled, String tlsConfigName, boolean configureHttpServer, List<String> subjectAlternativeNames) {
 
 }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/security/certificate/CertificateRequestCustomizer.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/security/certificate/CertificateRequestCustomizer.java
@@ -1,6 +1,7 @@
 package io.quarkus.test.security.certificate;
 
 import java.nio.file.Path;
+import java.util.List;
 
 public interface CertificateRequestCustomizer {
 
@@ -20,6 +21,8 @@ public interface CertificateRequestCustomizer {
         CertificateRequest withPemCertLocation(String certLocation);
 
         CertificateRequest withBaseDirForAllCerts(Path localTargetDir);
+
+        CertificateRequest withSubjectAlternativeNames(List<String> subjectAlternativeNames);
     }
 
     final class CertificateRequestImpl implements CertificateRequest {
@@ -32,6 +35,7 @@ public interface CertificateRequestCustomizer {
         private String serverKeyStoreLocation = null;
         private String keyLocation = null;
         private String certLocation = null;
+        private List<String> subjectAlternativeNames = null;
 
         CertificateRequestImpl(CertificateOptions originalOpts) {
             this.certificateOptions = originalOpts;
@@ -47,7 +51,7 @@ public interface CertificateRequestCustomizer {
                     certificateOptions.containerMountStrategy(), certificateOptions.createPkcs12TsForPem(),
                     serverTrustStoreLocation, serverKeyStoreLocation, keyLocation, certLocation,
                     certificateOptions.tlsRegistryEnabled(), certificateOptions.tlsConfigName(),
-                    certificateOptions.configureHttpServer());
+                    certificateOptions.configureHttpServer(), subjectAlternativeNames);
             return certificateOptions;
         }
 
@@ -90,6 +94,12 @@ public interface CertificateRequestCustomizer {
         @Override
         public CertificateRequest withBaseDirForAllCerts(Path localTargetDir) {
             this.localTargetDir = localTargetDir;
+            return this;
+        }
+
+        @Override
+        public CertificateRequest withSubjectAlternativeNames(List<String> subjectAlternativeNames) {
+            this.subjectAlternativeNames = subjectAlternativeNames;
             return this;
         }
 


### PR DESCRIPTION
### Summary

Add possibility to have custom SubjectAlternateName in a certificate. This will be required for certificates on OCP (https://github.com/quarkus-qe/quarkus-test-framework/pull/1601), where we have dynamic route names and need to have them in cert.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [X] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)