### PR TITLE
Add google and aws mirror for docker to avoid pull rate limits

### DIFF
--- a/.github/actions/use-docker-mirror/action.yml
+++ b/.github/actions/use-docker-mirror/action.yml
@@ -1,0 +1,20 @@
+name: 'Use Google and AWS Docker mirrors'
+description: 'We hit Docker pull rate limits in past and using mirrors helps'
+runs:
+  using: "composite"
+  steps:
+    - name: Configure Docker mirror
+      shell: bash
+      run: |
+        cat << EOF > ./daemon.json
+        {
+          "registry-mirrors": ["https://mirror.gcr.io", "https://public.ecr.aws/docker"]
+        }
+        EOF
+        sudo bash -c 'cp ./daemon.json /etc/docker/daemon.json'
+        sudo bash -c 'systemctl restart docker'
+        # exit if mirror hasn't been configured
+        docker info > docker-info
+        # print Docker info so that we can visually check it
+        cat docker-info
+        (cat docker-info | grep -q 'mirror.gcr.io') && (cat docker-info | grep -q 'public.ecr.aws') || exit 1

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -24,6 +24,7 @@ jobs:
           cache: 'maven'
         id: install-jdk
       - uses: ./.github/actions/prepare-quarkus-cli
+      - uses: ./.github/actions/use-docker-mirror
       - name: Build
         run: |
           mvn -B --no-transfer-progress -fae clean install -Pframework,examples,coverage -Dvalidate-format -Drun-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli" -Dquarkus.platform.version="${{ matrix.quarkus-version }}"
@@ -55,6 +56,7 @@ jobs:
           java-version: ${{ matrix.java }}
           check-latest: true
           cache: 'maven'
+      - uses: ./.github/actions/use-docker-mirror
       - name: Build
         run: |
           if [[ "${{ matrix.quarkus-version }}" != current ]]; then

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -55,6 +55,7 @@ jobs:
           check-latest: true
           cache: 'maven'
       - uses: ./.github/actions/prepare-quarkus-cli
+      - uses: ./.github/actions/use-docker-mirror
       - name: Build in JVM mode
         run: |
           mvn -B --no-transfer-progress -fae clean install -Pframework,examples -Drun-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli" -Dquarkus.platform.version="${{ matrix.quarkus-version }}"
@@ -105,6 +106,7 @@ jobs:
           check-latest: true
           cache: 'maven'
       - uses: ./.github/actions/prepare-quarkus-cli
+      - uses: ./.github/actions/use-docker-mirror
       - name: Build
         run: |
           mvn -B --no-transfer-progress -fae -s .github/quarkus-snapshots-mvn-settings.xml clean install -Pframework,examples,native -Drun-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli" -Dquarkus.platform.version="${{ matrix.quarkus-version }}"


### PR DESCRIPTION
### Summary

Adding the google and aws mirror to Linux CI as I spotted the to many request here https://github.com/quarkus-qe/quarkus-test-framework/actions/runs/15950917690/job/44990765265.

The `use-docker-mirror` is same as in TS created by https://github.com/quarkus-qe/quarkus-test-suite/pull/2302

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)