### PR TITLE
Propagate Hibernate Processor in DEV mode into service custom build

### DIFF
--- a/checkstyle-suppressions.xml
+++ b/checkstyle-suppressions.xml
@@ -7,5 +7,5 @@
 <suppressions>
     <suppress checks="LineLength"
               files="PreparePomMojo.java"
-              lines="30"/>
+              lines="31"/>
 </suppressions>


### PR DESCRIPTION
### Summary

- Jakarta Data require Hibernate Processor https://quarkus.io/guides/hibernate-orm#jakarta-data but framework didn't use "configuration" of the Maven Compiler plugin, this is fixed. Custom build is always required in DEV mode, so this fix is required
- postpone `@LookupService` for Quarkus applications until databases, Keycloak and other containers are started, otherwise we can't lookup Quarkus app that requires them

I have test cases for this in my PR in QE TS, I think I will not add dedicated tests here unless required.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)