### PR TITLE
Switch Playwright browser from Chromium to Firefox

### DIFF
--- a/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/DevModeQuarkusService.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/DevModeQuarkusService.java
@@ -51,7 +51,7 @@ public class DevModeQuarkusService extends RestService {
 
             // go to 'continuous-testing' page and click on 'Start' button which enables continuous testing
             try (Playwright playwright = Playwright.create()) {
-                try (Browser browser = playwright.chromium().launch()) {
+                try (Browser browser = playwright.firefox().launch()) {
                     Page page = browser.newContext().newPage();
                     page.navigate(getContinuousTestingPath());
                     var locatorOptions = new Page.LocatorOptions();


### PR DESCRIPTION
### Summary

After bumping `com.microsoft.playwright:playwright` from 1.52.0 to 1.53.0 in https://github.com/quarkus-qe/quarkus-test-framework/pull/1620, new version of Chromium doesn't work with latest available Podman 4.9.4 on RHEL 8

I don't know why exactly podman or RHEL 8 itself has problems with Chromium. I see no problem switching to Firefox.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)