### PR TITLE
Remove `LaunchMode` from `initConfiguration`

### DIFF
--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusApplicationManagedResourceBuilder.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusApplicationManagedResourceBuilder.java
@@ -27,7 +27,6 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import io.quarkus.deployment.configuration.BuildTimeConfigurationReader;
-import io.quarkus.runtime.LaunchMode;
 import io.quarkus.test.bootstrap.ManagedResourceBuilder;
 import io.quarkus.test.bootstrap.ServiceContext;
 import io.quarkus.test.security.certificate.CertificateBuilder;
@@ -322,8 +321,7 @@ public abstract class QuarkusApplicationManagedResourceBuilder implements Manage
             // this must always be set as Quarkus sets and config expansions would fail
             buildSystemProps.put("platform.quarkus.native.builder-image", "<<ignored>>");
 
-            var config = buildTimeConfigReader.initConfiguration(LaunchMode.NORMAL, buildSystemProps, new Properties(),
-                    Map.of());
+            var config = buildTimeConfigReader.initConfiguration(buildSystemProps, new Properties(), Map.of());
             var readResult = buildTimeConfigReader.readConfiguration(config);
             var buildTimeConfigKeys = new HashSet<String>();
             buildTimeConfigKeys.addAll(readResult.getAllBuildTimeValues().keySet());


### PR DESCRIPTION
### Summary

The `initConfiguration` method was changed in https://github.com/quarkusio/quarkus/pull/48926 and removed `LaunchMode` as it was not needed anymore

Latest daily deploy not failed with this, but probably next will fail

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)