### PR TITLE
S2I ca certs: add better repo URL condition

### DIFF
--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftS2iGitRepositoryQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftS2iGitRepositoryQuarkusApplicationManagedResource.java
@@ -153,7 +153,7 @@ public class OpenShiftS2iGitRepositoryQuarkusApplicationManagedResource
         String replaceJavaCaCertsAsString = REPLACE_JAVA_CA_CERTS.get(model.getContext());
         if (replaceJavaCaCertsAsString == null || replaceJavaCaCertsAsString.isEmpty()) {
             // property not set; by default recognize own repository so that we don't need to set it everywhere
-            return remoteRepo.contains(".quarkus-qe.");
+            return remoteRepo.contains("eng.redhat.com") || remoteRepo.contains("engineering.redhat.com");
         }
         return Boolean.parseBoolean(replaceJavaCaCertsAsString);
     }


### PR DESCRIPTION
### Summary

* Making the determination if the ca certs should be copied into the deployment for source S2I based on Maven repository mirror URL more general.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)