### PR TITLE
GH Actions: bump K8s to 1.33.1 and minikube to 1.36.0

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -106,8 +106,8 @@ jobs:
       - name: Set up Minikube-Kubernetes
         uses: manusa/actions-setup-minikube@v2.14.0
         with:
-          minikube version: 'v1.35.0'
-          kubernetes version: 'v1.32.4'
+          minikube version: 'v1.36.0'
+          kubernetes version: 'v1.33.1'
           github token: ${{ secrets.GITHUB_TOKEN }}
       - name: Login to Docker Registry
         uses: docker/login-action@v3
@@ -153,8 +153,8 @@ jobs:
       - name: Set up Minikube-Kubernetes
         uses: manusa/actions-setup-minikube@v2.14.0
         with:
-          minikube version: 'v1.35.0'
-          kubernetes version: 'v1.32.4'
+          minikube version: 'v1.36.0'
+          kubernetes version: 'v1.33.1'
           github token: ${{ secrets.GITHUB_TOKEN }}
       - name: Login to Docker Registry
         uses: docker/login-action@v3


### PR DESCRIPTION
### Summary

Update daily k8s CI to the latest minikube version with latest supported K8s 1.33.1

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)