### PR TITLE
Replace `CloseableResource` with `AutoCloseable` as it was deprecated

### DIFF
--- a/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/Service.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/Service.java
@@ -5,12 +5,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import org.junit.jupiter.api.extension.ExtensionContext;
-
 import io.quarkus.test.configuration.Configuration;
 import io.quarkus.test.utils.LogsVerifier;
 
-public interface Service extends ExtensionContext.Store.CloseableResource {
+public interface Service extends AutoCloseable {
 
     String getScenarioId();
 


### PR DESCRIPTION
### Summary

When running tests I spot this warning `Type implements CloseableResource but not AutoCloseable: io.quarkus.test.bootstrap.RestService`. Only see it when test fail.

Looking at it the Junit mark it as deprecated [1] and recommend to use `AutoCloseable` directly

Reading more from 5.13 the resources stored in `ExtensionContext.Store` which implements `AutoCloseable` are closed automatically and `ExtensionContext.Store.CloseableResource` are deprecated.

If I'm looking correctly we consume the Junit version from Quarkus. So updating this won't close the services when using Quarkus 3.23 or older. If we want we can still support it for older version of Quarkus (without defining Junit version) we can implement both `ExtensionContext.Store.CloseableResource`  and `AutoCloseable`, at least that Junit recommendations.


[1] https://docs.junit.org/5.13.0/api/org.junit.jupiter.api/org/junit/jupiter/api/extension/ExtensionContext.Store.CloseableResource.html

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)