### PR TITLE
Configure multiple certs properties on OCP, even if not using ssl=true

### DIFF
--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftQuarkusApplicationCertificateConfigurator.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftQuarkusApplicationCertificateConfigurator.java
@@ -8,7 +8,8 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.commons.io.FilenameUtils;
 
@@ -77,16 +78,17 @@ public abstract class OpenShiftQuarkusApplicationCertificateConfigurator {
      */
     private static void overridePaths(Map<String, String> configProperties, String keystorePath, String truststorePath) {
         // it is not necessary to have keystore and/or truststore configured
+        // but there can also be multiple properties using keystore or truststore (like HTTP and Management ports)
         // replace paths only for those, that are configured
-        Optional<String> keystorePropertyName = configProperties.keySet().stream()
+        Set<String> keystorePropertyNames = configProperties.keySet().stream()
                 .filter(string -> string.contains("key-store") && (string.endsWith("path") || string.endsWith("file")))
-                .findFirst();
-        keystorePropertyName.ifPresent(s -> configProperties.put(s, keystorePath));
+                .collect(Collectors.toSet());
+        keystorePropertyNames.forEach(s -> configProperties.put(s, keystorePath));
 
-        Optional<String> truststorePropertyName = configProperties.keySet().stream()
+        Set<String> truststorePropertyNames = configProperties.keySet().stream()
                 .filter(string -> string.contains("trust-store") && (string.endsWith("path") || string.endsWith("file")))
-                .findFirst();
-        truststorePropertyName.ifPresent(s -> configProperties.put(s, truststorePath));
+                .collect(Collectors.toSet());
+        truststorePropertyNames.forEach(s -> configProperties.put(s, truststorePath));
     }
 
     /**

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/TemplateOpenShiftQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/TemplateOpenShiftQuarkusApplicationManagedResource.java
@@ -85,16 +85,17 @@ public abstract class TemplateOpenShiftQuarkusApplicationManagedResource<T exten
             client.createTlsPassthroughRoute(model.getContext().getName() + TLS_ROUTE_SUFFIX,
                     model.getContext().getName() + TLS_ROUTE_SUFFIX,
                     model.getOcpTlsPort());
+        }
 
-            // if certificate builder is set, there should be secrets set
-            // properties are set to context by OpenShiftQuarkusApplicationCertificateConfigurator
-            if (model.getContext().get(CertificateBuilder.INSTANCE_KEY) != null) {
-                String appName = model.getContext().getName();
-                client.mountSecretToDeployment(appName, model.getContext().get(PROPERTY_KEYSTORE_SECRET_NAME),
-                        KEYSTORE_MOUNT_PATH);
-                client.mountSecretToDeployment(appName, model.getContext().get(PROPERTY_TRUSTSTORE_SECRET_NAME),
-                        TRUSTSTORE_MOUNT_PATH);
-            }
+        // if certificate builder is set, there should be secrets set
+        // properties are set to context by OpenShiftQuarkusApplicationCertificateConfigurator
+        CertificateBuilder certificateBuilder = model.getContext().get(CertificateBuilder.INSTANCE_KEY);
+        if (certificateBuilder != null && !certificateBuilder.certificates().isEmpty()) {
+            String appName = model.getContext().getName();
+            client.mountSecretToDeployment(appName, model.getContext().get(PROPERTY_KEYSTORE_SECRET_NAME),
+                    KEYSTORE_MOUNT_PATH);
+            client.mountSecretToDeployment(appName, model.getContext().get(PROPERTY_TRUSTSTORE_SECRET_NAME),
+                    TRUSTSTORE_MOUNT_PATH);
         }
     }
 


### PR DESCRIPTION
### Summary

Should fix problems with OpenShiftOptionsIT failures.  There were two problems:

1. TLS deployment used `@Certificate` but didn't configure `ssl=true`. FW was confused by this and did configure the app properties, but didn't actually mount OCP secrets.
2. Keystore is present in multiple app properties, originally FW did override just first one for actual OCP value.

Now it will mount OCP secrets is any certificate is present - same condition as CertificateConfigurator uses to override app properties.

Please check the relevant options

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [X] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)