### PR TITLE
Allow multiple certificates on OCP deployments

### DIFF
--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/TemplateOpenShiftQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/TemplateOpenShiftQuarkusApplicationManagedResource.java
@@ -92,10 +92,14 @@ public abstract class TemplateOpenShiftQuarkusApplicationManagedResource<T exten
         CertificateBuilder certificateBuilder = model.getContext().get(CertificateBuilder.INSTANCE_KEY);
         if (certificateBuilder != null && !certificateBuilder.certificates().isEmpty()) {
             String appName = model.getContext().getName();
-            client.mountSecretToDeployment(appName, model.getContext().get(PROPERTY_KEYSTORE_SECRET_NAME),
-                    KEYSTORE_MOUNT_PATH);
-            client.mountSecretToDeployment(appName, model.getContext().get(PROPERTY_TRUSTSTORE_SECRET_NAME),
-                    TRUSTSTORE_MOUNT_PATH);
+            if (model.getContext().get(PROPERTY_KEYSTORE_SECRET_NAME) != null) {
+                client.mountSecretToDeployment(appName, model.getContext().get(PROPERTY_KEYSTORE_SECRET_NAME),
+                        KEYSTORE_MOUNT_PATH);
+            }
+            if (model.getContext().get(PROPERTY_TRUSTSTORE_SECRET_NAME) != null) {
+                client.mountSecretToDeployment(appName, model.getContext().get(PROPERTY_TRUSTSTORE_SECRET_NAME),
+                        TRUSTSTORE_MOUNT_PATH);
+            }
         }
     }
 


### PR DESCRIPTION
### Summary

**This PR is based on changes from** https://github.com/quarkus-qe/quarkus-test-framework/pull/1642 I will rebase it on main, once that PR is done.

Allow multiple certificates in OCP deployments. Don't require both keystore and truststore on every certificate.

Requiring only 1 certificate on OCP led to failures in some tests. Having multiple certs is rare case, where the test handles the certificates somehow on it's own, so no big additional support is required.

Please check the relevant options

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [X] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)