### PR TITLE
Update deprecated `quarkus.hibernate-orm` property

### DIFF
--- a/examples/database-mysql/src/main/resources/application.properties
+++ b/examples/database-mysql/src/main/resources/application.properties
@@ -1,3 +1,3 @@
 quarkus.datasource.db-kind=mysql
 quarkus.hibernate-orm.sql-load-script=import.sql
-quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.hibernate-orm.schema-management.strategy=drop-and-create

--- a/examples/database-oracle/src/main/resources/application.properties
+++ b/examples/database-oracle/src/main/resources/application.properties
@@ -1,3 +1,3 @@
 quarkus.datasource.db-kind=oracle
 quarkus.hibernate-orm.sql-load-script=import.sql
-quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.hibernate-orm.schema-management.strategy=drop-and-create

--- a/examples/database-postgresql/src/main/resources/application.properties
+++ b/examples/database-postgresql/src/main/resources/application.properties
@@ -1,3 +1,3 @@
 quarkus.datasource.db-kind=postgresql
 quarkus.hibernate-orm.sql-load-script=import.sql
-quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.hibernate-orm.schema-management.strategy=drop-and-create


### PR DESCRIPTION
### Summary

Changing `quarkus.hibernate-orm.database.generation` to `quarkus.hibernate-orm.schema-management.strategy`

This change happen in Quarkus 3.23 https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.23#hibernate-orm

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)