### PR TITLE
Add optional readiness checks for remote DEV mode to stabilise Windows runs

### DIFF
--- a/examples/greetings/src/test/java/io/quarkus/qe/RemoteDevModeGreetingResourceIT.java
+++ b/examples/greetings/src/test/java/io/quarkus/qe/RemoteDevModeGreetingResourceIT.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.DevModeQuarkusService;
 import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.IsRunningCheck;
 import io.quarkus.test.services.RemoteDevModeQuarkusApplication;
 import io.quarkus.test.utils.AwaitilityUtils;
 
@@ -18,7 +19,7 @@ public class RemoteDevModeGreetingResourceIT {
     static final String HELLO_IN_ENGLISH = "Hello";
     static final String HELLO_IN_SPANISH = "Hola";
 
-    @RemoteDevModeQuarkusApplication
+    @RemoteDevModeQuarkusApplication(isRunningCheck = IsRunningCheck.IsBasePathReachableCheck.class)
     static final DevModeQuarkusService app = new DevModeQuarkusService();
 
     @Test

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/IsRunningCheck.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/IsRunningCheck.java
@@ -1,0 +1,84 @@
+package io.quarkus.test.services;
+
+import org.apache.http.HttpStatus;
+import org.hamcrest.Matchers;
+
+import io.quarkus.test.bootstrap.Protocol;
+import io.quarkus.test.logging.Log;
+import io.restassured.RestAssured;
+
+/**
+ * A check that can mark the resource as running. All implementors must have single public no-args constructor.
+ */
+public interface IsRunningCheck {
+
+    boolean isRunning(IsRunningCheckContext context);
+
+    interface IsRunningCheckContext {
+        URILike getURI(Protocol protocol);
+    }
+
+    final class AlwaysFail implements IsRunningCheck {
+
+        public AlwaysFail() {
+        }
+
+        @Override
+        public boolean isRunning(IsRunningCheckContext context) {
+            return false;
+        }
+    }
+
+    /**
+     * The Quarkus QE Framework will treat this service as 'running' if
+     * and only if request to given path responds with 4xx, 3xx or 2xx response code.
+     * Please use this option with caution because result is intentionally not cached (it would be complex for DEV mode
+     * scenarios) and the request could be executed as often as every time
+     * the {@link io.quarkus.test.bootstrap.BaseService#isRunning()} is called.
+     */
+    abstract class IsPathReachableCheck implements IsRunningCheck {
+
+        static final String BASE_PATH = "/";
+        private final Protocol protocol;
+        private final String path;
+
+        protected IsPathReachableCheck(Protocol protocol, String path) {
+            this.protocol = protocol;
+            this.path = path;
+        }
+
+        @Override
+        public boolean isRunning(IsRunningCheckContext context) {
+            try {
+                var host = context.getURI(protocol);
+                int statusCode = RestAssured.given()
+                        .baseUri(host.getRestAssuredStyleUri())
+                        .basePath(BASE_PATH)
+                        .port(host.getPort())
+                        .get(path)
+                        .then()
+                        .statusCode(Matchers.allOf(Matchers.greaterThanOrEqualTo(HttpStatus.SC_OK),
+                                Matchers.lessThan(HttpStatus.SC_INTERNAL_SERVER_ERROR)))
+                        .extract().statusCode();
+                Log.debug("Readiness check for path '%s' and protocol '%s' passed with response status '%s'", path, protocol,
+                        statusCode);
+            } catch (Throwable t) {
+                Log.debug("Service is not yet ready: ", t);
+                return false;
+            }
+            return true;
+        }
+    }
+
+    /**
+     * This is {@link IsPathReachableCheck} for the "/" path and the {@link Protocol#HTTP} protocol.
+     *
+     * @see IsPathReachableCheck for more information
+     */
+    final class IsBasePathReachableCheck extends IsPathReachableCheck {
+
+        public IsBasePathReachableCheck() {
+            super(Protocol.HTTP, IsPathReachableCheck.BASE_PATH);
+        }
+    }
+}

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/RemoteDevModeQuarkusApplication.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/RemoteDevModeQuarkusApplication.java
@@ -5,6 +5,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import io.quarkus.test.services.IsRunningCheck.AlwaysFail;
+
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface RemoteDevModeQuarkusApplication {
@@ -14,4 +16,13 @@ public @interface RemoteDevModeQuarkusApplication {
      * @return the properties file to use to configure the Quarkus application.
      */
     String properties() default "application.properties";
+
+    /**
+     * Please note that this feature is currently implemented for bare-metal scenarios only and the check will be
+     * ignored for OpenShift and Kubernetes scenarios.
+     *
+     * @return {@link IsRunningCheck} that can mark the service as running even if default log-based check fails.
+     */
+    Class<? extends IsRunningCheck> isRunningCheck() default AlwaysFail.class;
+
 }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/RemoteDevModeLocalhostQuarkusApplicationManagedResource.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/RemoteDevModeLocalhostQuarkusApplicationManagedResource.java
@@ -35,8 +35,15 @@ public class RemoteDevModeLocalhostQuarkusApplicationManagedResource extends Loc
                 startRemoteDevProcess();
             }
 
+            Log.debug("Testing if logs contain expected output '%s'", EXPECTED_OUTPUT_FROM_REMOTE_DEV_DAEMON);
             if (getLoggingHandler().logsContains(EXPECTED_OUTPUT_FROM_REMOTE_DEV_DAEMON)) {
+                Log.debug("Logs contain expected output '%s'", EXPECTED_OUTPUT_FROM_REMOTE_DEV_DAEMON);
                 getLoggingHandler().flush();
+                return true;
+            }
+            Log.debug("Logs don't contain expected output '%s'", EXPECTED_OUTPUT_FROM_REMOTE_DEV_DAEMON);
+            if (model.getIsRunningCheck().isRunning(this::getURI)) {
+                Log.debug("'%s' check marked the resource as running", model.getIsRunningCheck().getClass().getName());
                 return true;
             }
         }


### PR DESCRIPTION
### Summary

I find current `RemoteDevModeLocalhostQuarkusApplicationManagedResource` "is running" check very unreliable. I started looking at it because of Windows runs in Jenkins often fails (but not always) and as I was adding debug messages and stuff, I mentioned that it is often failing even on my Fedora locally. It is not just that https://github.com/quarkusio/quarkus/blob/main/extensions/vertx-http/deployment/src/main/java/io/quarkus/vertx/http/deployment/devmode/HttpRemoteDevClient.java is not going to print the `Connected to remote server` log message every time we make changes (which I am still not sure if it is a bug or not, does it needs to re-connect every time we make changes? honestly don't know even though I read its code :disappointed: ), but we flush logs when `isRunning` is successful in there, which I don't know why, probably so that restart works? But `isRunning` can be called multiple times.

TL;DR; I was looking at it most of today and I am still worried to change the default check, so I'd like to add option for additional check that can mark the resource as ready, because there is no bug in Quarkus as far as I can tell. I have experienced countless times situation when I can `curl` the app and the app is updated with changes, yet our resource is thinking that it is not ready.

My plan is to add this new check to https://github.com/quarkus-qe/quarkus-test-suite/blob/main/http/http-advanced/src/test/java/io/quarkus/ts/http/advanced/RemoteDevModeHttpAdvancedIT.java and https://github.com/quarkus-qe/quarkus-test-suite/blob/main/http/http-advanced-reactive/src/test/java/io/quarkus/ts/http/advanced/reactive/RemoteDevModeHttpAdvancedReactiveIT.java. If it helps in a long-term we can discuss whether to make it default or not. If not, we just drop it and report the bug.

By the way, the test I am changing is notoriously flaky, e.g. here https://github.com/quarkus-qe/quarkus-test-framework/pull/1622#issuecomment-3037472844 and here (from today) https://github.com/quarkus-qe/quarkus-test-framework/pull/1635#issuecomment-3165592397 and (also from today) https://github.com/quarkus-qe/quarkus-test-framework/pull/1647#issuecomment-3165599754, which IMHO is always good prove that somethings wrong.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)