### PR TITLE
Update CI pipeline name to match 3.15.6

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -66,7 +66,7 @@ jobs:
           path: maven-repo.tgz
           retention-days: 1
   linux-build-jvm-released:
-    name: Linux - JVM build - 3.15.4
+    name: Linux - JVM build - 3.15.6
     runs-on: ubuntu-latest
     needs: validate-format
     strategy:


### PR DESCRIPTION
### Summary

Quarkus version in CI pipeline is already changed, but name of the pipeline is still 3.15.4. Bump it to match reality

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)