### PR TITLE
Expose TLS on keycloak without running on prod mode

### DIFF
--- a/quarkus-test-service-keycloak/src/main/java/io/quarkus/test/bootstrap/KeycloakService.java
+++ b/quarkus-test-service-keycloak/src/main/java/io/quarkus/test/bootstrap/KeycloakService.java
@@ -4,7 +4,7 @@ import static io.quarkus.test.security.certificate.Certificate.LOCAL_FS_CA_CERT_
 import static io.quarkus.test.security.certificate.Certificate.LOCAL_FS_TRUST_STORE_PATH;
 import static io.quarkus.test.services.containers.KeycloakContainerManagedResourceBuilder.CERTIFICATE_CONTEXT_KEY;
 import static io.quarkus.test.services.containers.KeycloakContainerManagedResourceBuilder.KEYCLOAK;
-import static io.quarkus.test.services.containers.KeycloakContainerManagedResourceBuilder.KEYCLOAK_PRODUCTION_MODE_KEY;
+import static io.quarkus.test.services.containers.KeycloakContainerManagedResourceBuilder.KEYCLOAK_TLS_ACTIVE_KEY;
 import static io.quarkus.test.utils.PropertiesUtils.RESOURCE_WITH_DESTINATION_PREFIX;
 
 import java.io.File;
@@ -72,8 +72,8 @@ public class KeycloakService extends BaseService<KeycloakService> {
     }
 
     public String getRealmUrl() {
-        boolean runKeycloakInProdMode = getPropertyFromContext(KEYCLOAK_PRODUCTION_MODE_KEY);
-        var host = runKeycloakInProdMode ? getURI(Protocol.HTTPS) : getURI(Protocol.HTTP);
+        boolean keycloakTlsOn = getPropertyFromContext(KEYCLOAK_TLS_ACTIVE_KEY);
+        var host = keycloakTlsOn ? getURI(Protocol.HTTPS) : getURI(Protocol.HTTP);
 
         // SMELL: Keycloak does not validate Token Issuers when URL contains the port 80.
         int port = host.getPort();

--- a/quarkus-test-service-keycloak/src/main/java/io/quarkus/test/services/KeycloakContainer.java
+++ b/quarkus-test-service-keycloak/src/main/java/io/quarkus/test/services/KeycloakContainer.java
@@ -28,6 +28,12 @@ public @interface KeycloakContainer {
 
     boolean runKeycloakInProdMode() default false;
 
+    /**
+     * Will expose Tls port on container or HTTPS route on OCP.
+     * But will not generate certificates, test needs to manage certificates on their own.
+     */
+    boolean exposeRawTls() default false;
+
     Certificate.Format certificateFormat() default Certificate.Format.PKCS12;
 
     Class<? extends ManagedResourceBuilder> builder() default KeycloakContainerManagedResourceBuilder.class;

--- a/quarkus-test-service-keycloak/src/main/java/io/quarkus/test/services/containers/KeycloakContainerManagedResourceBuilder.java
+++ b/quarkus-test-service-keycloak/src/main/java/io/quarkus/test/services/containers/KeycloakContainerManagedResourceBuilder.java
@@ -28,7 +28,7 @@ import io.quarkus.test.utils.PropertiesUtils;
 public class KeycloakContainerManagedResourceBuilder extends ContainerManagedResourceBuilder {
 
     public static final String CERTIFICATE_CONTEXT_KEY = "io.quarkus.test.services.containers.keycloak.certificate";
-    public static final String KEYCLOAK_PRODUCTION_MODE_KEY = "io.quarkus.test.services.keycloak.production.mode";
+    public static final String KEYCLOAK_TLS_ACTIVE_KEY = "io.quarkus.test.services.keycloak.tls.on";
     public static final String KEYCLOAK = "keycloak";
     private static final String MOUNTED_KEYSTORE_NAME = KEYCLOAK + "-keystore";
     private static final String KEYSTORE_DEST_PATH = "/opt/keycloak/conf/";
@@ -110,14 +110,15 @@ public class KeycloakContainerManagedResourceBuilder extends ContainerManagedRes
         this.certificateFormat = metadata.certificateFormat();
         // We want to set up sslEnable to same value as runKeycloakInProdMode as `isSslEnabled` is used to determine
         // if tls should be enabled
-        this.sslEnabled = metadata.runKeycloakInProdMode();
+        // but if we want to only enable tls and manage it manually, we can do it by exposing it raw
+        this.sslEnabled = metadata.runKeycloakInProdMode() || metadata.exposeRawTls();
     }
 
     @Override
     public ManagedResource build(ServiceContext context) {
         this.context = context;
 
-        context.put(KEYCLOAK_PRODUCTION_MODE_KEY, runKeycloakInProdMode);
+        context.put(KEYCLOAK_TLS_ACTIVE_KEY, sslEnabled);
 
         if (runKeycloakInProdMode) {
             setUpProdKeycloak();


### PR DESCRIPTION
### Summary

Enable the option to only expose HTTPS on keycloak service, without running the full prod mode setup.
Reason is use cases like mTLS testing with keycloak, where we want to use HTTPS but want to manage certificates (keystore/truststore) on our own.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [X] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)