### PR TITLE
Omit default HTTPS port in keycloak service

### DIFF
--- a/quarkus-test-service-keycloak/src/main/java/io/quarkus/test/bootstrap/KeycloakService.java
+++ b/quarkus-test-service-keycloak/src/main/java/io/quarkus/test/bootstrap/KeycloakService.java
@@ -44,6 +44,7 @@ public class KeycloakService extends BaseService<KeycloakService> {
     private static final String USER = "admin";
     private static final String PASSWORD = "admin";
     private static final int HTTP_80 = 80;
+    private static final int HTTPS_443 = 443;
 
     private String realmBasePath = "realms";
     private final String realm;
@@ -75,9 +76,9 @@ public class KeycloakService extends BaseService<KeycloakService> {
         boolean keycloakTlsOn = getPropertyFromContext(KEYCLOAK_TLS_ACTIVE_KEY);
         var host = keycloakTlsOn ? getURI(Protocol.HTTPS) : getURI(Protocol.HTTP);
 
-        // SMELL: Keycloak does not validate Token Issuers when URL contains the port 80.
+        // SMELL: Keycloak does not validate Token Issuers when URL contains the port 80 (or 443 for HTTPS).
         int port = host.getPort();
-        if (port == HTTP_80) {
+        if (port == HTTP_80 || port == HTTPS_443) {
             port = -1;
         }
         try {


### PR DESCRIPTION
### Summary

Omit implicit HTTPS port 443 from keycloak URI when generated. The port causes problems when validating issuer of keycloak-generated JWT, same as for HTTP and port 80.

Please check the relevant options

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [X] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)