### PR TITLE
Always pull new quarkus app image on OCP

### DIFF
--- a/quarkus-test-openshift/src/main/resources/quarkus-build-openshift-template.yml
+++ b/quarkus-test-openshift/src/main/resources/quarkus-build-openshift-template.yml
@@ -96,7 +96,7 @@ items:
                 - name: "JAVA_APP_JAR"
                   value: "/deployments/${ARTIFACT}"
               image: "${IMAGE_NAME}"
-              imagePullPolicy: "IfNotPresent"
+              imagePullPolicy: "Always"
               name: "${SERVICE_NAME}"
               ports:
                 - containerPort: ${INTERNAL_PORT}


### PR DESCRIPTION
### Summary

For quarkus-build apps, always pull new image. 

Old behaviour caused a lot of problems for me, when changing the tested app on OCP and working in same namespace. Because tests would actually build a new app image, but then OCP worker node would not download the new image, because it already has the old one in cache. 

As a bonus problom, every ocp worker node would eventually had different image version in cache (each test run produces new one and only one worker pull the image in each run). So in the end app behaviour would seem random, but actually based on which cache-poisoned worker is it running.

Please check the relevant options

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [X] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)