### PR TITLE
Adding not redirect when checking if route is reachable

### DIFF
--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftQuarkusApplicationManagedResource.java
@@ -201,8 +201,8 @@ public abstract class OpenShiftQuarkusApplicationManagedResource<T extends Quark
 
     private boolean routeIsReachable(Protocol protocol) {
         var url = getURI(protocol);
-        return given().relaxedHTTPSValidation().baseUri(url.getRestAssuredStyleUri()).basePath("/").port(url.getPort()).get()
-                .getStatusCode() != HttpStatus.SC_SERVICE_UNAVAILABLE;
+        return given().relaxedHTTPSValidation().baseUri(url.getRestAssuredStyleUri()).basePath("/").port(url.getPort())
+                .redirects().follow(false).get().getStatusCode() != HttpStatus.SC_SERVICE_UNAVAILABLE;
     }
 
     private void configureServingCertificates() {


### PR DESCRIPTION
### Summary

There can be usecases where the base path will be redirected to secured resource. This resource can be secured by self-sign certificate and this check will throw `SSLHandshakeException`.

For example when the OIDC is set as `quarkus.oidc.application-type=web-app` the default behavioral is to redirect to secured resources. The KC in this case is secured by self-sign certificate and this redirection to secured resource cause `SSLHandshakeException`.

If the request to check the route return redirect, it should be enough to know that route is reachable, we don't need to follow it.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)