### PR TITLE
Rename Quarkus properties from enable to enabled

### DIFF
--- a/examples/kafka-streams/src/main/resources/application.properties
+++ b/examples/kafka-streams/src/main/resources/application.properties
@@ -16,7 +16,7 @@ quarkus.kafka-streams.application-id=login-denied-aggregator
 quarkus.kafka-streams.application-server=localhost:8080
 quarkus.kafka-streams.topics=login-http-response-values
 login.denied.windows.sec=2
-quarkus.log.console.enable=true
+quarkus.log.console.enabled=true
 quarkus.log.console.level=INFO
 # pass-through options
 kafka-streams.cache.max.bytes.buffering=10240

--- a/quarkus-test-core/src/main/resources/deployment-build-props.txt
+++ b/quarkus-test-core/src/main/resources/deployment-build-props.txt
@@ -852,6 +852,7 @@ quarkus.native.auto-service-loader-registration
 quarkus.openshift.liveness-probe.failure-threshold
 quarkus.smallrye-openapi.auto-add-server
 quarkus.snapstart.enable
+quarkus.snapstart.enabled
 quarkus.kubernetes.azure-disk-volumes."azure-disk-volumes".fs-type
 quarkus.keycloak.devservices.resource-aliases."alias-name"
 quarkus.lambda.mock-event-server.test-port


### PR DESCRIPTION
### Summary

For 3.26 the enable/enabled properties were unified see https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.26#enable--enabled-in-configuration-properties-gear-white_check_mark

The addition to deployment-build-props.txt is to support both property atm.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)