### PR TITLE
Update Hibernate ORM validation property in the build properties list

### DIFF
--- a/quarkus-test-core/src/main/resources/deployment-build-props.txt
+++ b/quarkus-test-core/src/main/resources/deployment-build-props.txt
@@ -1017,7 +1017,7 @@ quarkus.rabbitmq.devservices.queues."queue-name".auto-delete
 quarkus.kubernetes.env.secrets
 quarkus.openshift.sidecars."sidecars".mounts."mounts".sub-path
 quarkus.knative.rbac.service-accounts."service-accounts".use-as-default
-quarkus.hibernate-orm.validation.enabled
+quarkus.hibernate-orm.validation.mode
 quarkus.jib.base-image-layers-cache
 quarkus.knative.liveness-probe.http-action-path
 quarkus.openshift.sidecars."sidecars".resources.requests.cpu


### PR DESCRIPTION
### Summary

Quarkus Hibernate ORM Validator property changed in Quarkus 3.20
`uarkus.hibernate-orm.validation.enabled` to `quarkus.hibernate-orm.validation.mode`

https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.19#bean-validation-integration

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)