### PR TITLE
Wait till `\greeting` path is ready instead of the `\` path in RemoteDevModeGreetingResourceIT to safely determine when to start testing

### DIFF
--- a/examples/greetings/src/test/java/io/quarkus/qe/RemoteDevModeGreetingResourceIT.java
+++ b/examples/greetings/src/test/java/io/quarkus/qe/RemoteDevModeGreetingResourceIT.java
@@ -6,6 +6,7 @@ import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.bootstrap.DevModeQuarkusService;
+import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.services.IsRunningCheck;
 import io.quarkus.test.services.RemoteDevModeQuarkusApplication;
@@ -19,7 +20,7 @@ public class RemoteDevModeGreetingResourceIT {
     static final String HELLO_IN_ENGLISH = "Hello";
     static final String HELLO_IN_SPANISH = "Hola";
 
-    @RemoteDevModeQuarkusApplication(isRunningCheck = IsRunningCheck.IsBasePathReachableCheck.class)
+    @RemoteDevModeQuarkusApplication(isRunningCheck = IsGreetingPathReachableCheck.class)
     static final DevModeQuarkusService app = new DevModeQuarkusService();
 
     @Test
@@ -40,5 +41,12 @@ public class RemoteDevModeGreetingResourceIT {
     @Test
     public void shouldLoadResources() {
         app.given().get("/greeting/file").then().statusCode(HttpStatus.SC_OK).body(is("found!"));
+    }
+
+    public static final class IsGreetingPathReachableCheck extends IsRunningCheck.IsPathReachableCheck {
+
+        public IsGreetingPathReachableCheck() {
+            super(Protocol.HTTP, "/greeting", VICTOR_NAME);
+        }
     }
 }


### PR DESCRIPTION
### Summary

I was analyzing this flakiness https://github.com/quarkus-qe/quarkus-test-framework/pull/1657#issuecomment-3195862644 that comes on notoriously flaky test. However lately I thought I fixed or improved that flakiness here https://github.com/quarkus-qe/quarkus-test-framework/pull/1646. And indeed,  you can see that the flakiness error has completely changed, the Quarkus app is queried instead of waiting endlessly for the remote DEV to start. But now flakiness is like this:

```
Expected: is "Hola, I'm victor"   Actual: Hello, I'm victor  within 30 seconds.
```

Which means that 30 seconds passed after the code was changed and no change was reflected. That isn't due to the `isRunningCheck` because that is only used on start, while of this "file modification" is our FW not aware. Now look at the logs before and right after the file modification:

```
2025-08-18T07:37:47.2420176Z 07:37:47,213 INFO  [app] 07:37:43,600 examples-greetings stopped in 0.006s
2025-08-18T07:37:47.2420974Z 07:37:47,213 INFO  [app] 07:37:43,612 interrupted [Error Occurred After Shutdown]: java.lang.InterruptedException
2025-08-18T07:37:47.2421800Z 07:37:47,213 INFO  [app] 	at java.base/java.lang.Object.wait(Native Method)
2025-08-18T07:37:47.2422456Z 07:37:47,213 INFO  [app] 	at io.quarkus.vertx.http.runtime.devmode.RemoteSyncHandler.doPreScan(RemoteSyncHandler.java:69)
2025-08-18T07:37:47.2423387Z 07:37:47,213 INFO  [app] 	at io.quarkus.vertx.http.runtime.devmode.VertxHttpHotReplacementSetup$1.run(VertxHttpHotReplacementSetup.java:52)
2025-08-18T07:37:47.2424314Z 07:37:47,213 INFO  [app] 	at io.quarkus.deployment.dev.RuntimeUpdatesProcessor.doScan(RuntimeUpdatesProcessor.java:469)
2025-08-18T07:37:47.2425150Z 07:37:47,213 INFO  [app] 	at io.quarkus.deployment.dev.RuntimeUpdatesProcessor.doScan(RuntimeUpdatesProcessor.java:455)
2025-08-18T07:37:47.2426264Z 07:37:47,213 INFO  [app] 	at io.quarkus.vertx.http.runtime.devmode.VertxHttpHotReplacementSetup$6.call(VertxHttpHotReplacementSetup.java:163)
2025-08-18T07:37:47.2427730Z 07:37:47,213 INFO  [app] 	at io.quarkus.vertx.http.runtime.devmode.VertxHttpHotReplacementSetup$6.call(VertxHttpHotReplacementSetup.java:150)
2025-08-18T07:37:47.2428590Z 07:37:47,213 INFO  [app] 	at io.vertx.core.impl.ContextImpl.lambda$executeBlocking$4(ContextImpl.java:192)
2025-08-18T07:37:47.2429230Z 07:37:47,213 INFO  [app] 	at io.vertx.core.impl.ContextInternal.dispatch(ContextInternal.java:270)
2025-08-18T07:37:47.2429807Z 07:37:47,213 INFO  [app] 	at io.vertx.core.impl.ContextImpl$1.execute(ContextImpl.java:221)
2025-08-18T07:37:47.2430318Z 07:37:47,213 INFO  [app] 	at io.vertx.core.impl.WorkerTask.run(WorkerTask.java:56)
2025-08-18T07:37:47.2430866Z 07:37:47,213 INFO  [app] 	at org.jboss.threads.ContextHandler$1.runWith(ContextHandler.java:18)
2025-08-18T07:37:47.2431543Z 07:37:47,213 INFO  [app] 	at org.jboss.threads.EnhancedQueueExecutor$Task.doRunWith(EnhancedQueueExecutor.java:2651)
2025-08-18T07:37:47.2432220Z 07:37:47,213 INFO  [app] 	at org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2630)
2025-08-18T07:37:47.2432886Z 07:37:47,213 INFO  [app] 	at org.jboss.threads.EnhancedQueueExecutor.runThreadBody(EnhancedQueueExecutor.java:1622)
2025-08-18T07:37:47.2433791Z 07:37:47,213 INFO  [app] 	at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1589)
2025-08-18T07:37:47.2434419Z 07:37:47,213 INFO  [app] 	at org.jboss.threads.DelegatingRunnable.run(DelegatingRunnable.java:11)
2025-08-18T07:37:47.2435057Z 07:37:47,213 INFO  [app] 	at org.jboss.threads.ThreadLocalResettingRunnable.run(ThreadLocalResettingRunnable.java:11)
2025-08-18T07:37:47.2435771Z 07:37:47,214 INFO  [app] 	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
2025-08-18T07:37:47.2436545Z 07:37:47,214 INFO  [app] 	at java.base/java.lang.Thread.run(Thread.java:840)
2025-08-18T07:37:47.2437000Z 07:37:47,214 INFO  [app] 07:37:43,614 Restarting quarkus due to changes in GreetingResource.class.
2025-08-18T07:37:47.2437805Z 07:37:47,214 INFO  [app] 07:37:44,524 ERROR [io.qua.run.Quarkus] Error running Quarkus [Error Occurred After Shutdown]: java.lang.NoClassDefFoundError: io/quarkus/runtime/generated/Config
2025-08-18T07:37:47.2438570Z 07:37:47,214 INFO  [app] 	at io.quarkus.runner.ApplicationImpl.<clinit>(Unknown Source)
2025-08-18T07:37:47.2439180Z 07:37:47,214 INFO  [app] 	at java.base/java.lang.invoke.DirectMethodHandle.allocateInstance(DirectMethodHandle.java:520)
2025-08-18T07:37:47.2439753Z 07:37:47,214 INFO  [app] 	at io.quarkus.runtime.Quarkus.run(Quarkus.java:79)
2025-08-18T07:37:47.2440165Z 07:37:47,214 INFO  [app] 	at io.quarkus.runtime.Quarkus.run(Quarkus.java:51)
2025-08-18T07:37:47.2440689Z 07:37:47,214 INFO  [app] 	at io.quarkus.runtime.Quarkus.run(Quarkus.java:144)
2025-08-18T07:37:47.2441127Z 07:37:47,214 INFO  [app] 	at io.quarkus.runner.GeneratedMain.main(Unknown Source)
2025-08-18T07:37:47.2441674Z 07:37:47,214 INFO  [app] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
2025-08-18T07:37:47.2442374Z 07:37:47,214 INFO  [app] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
2025-08-18T07:37:47.2443173Z 07:37:47,214 INFO  [app] 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
2025-08-18T07:37:47.2443820Z 07:37:47,214 INFO  [app] 	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
2025-08-18T07:37:47.2444365Z 07:37:47,214 INFO  [app] 	at io.quarkus.runner.bootstrap.StartupActionImpl$1.run(StartupActionImpl.java:135)
2025-08-18T07:37:47.2444873Z 07:37:47,214 INFO  [app] 	at java.base/java.lang.Thread.run(Thread.java:840)
2025-08-18T07:37:47.2445365Z 07:37:47,214 INFO  [app] Caused by: java.lang.ClassNotFoundException: io.quarkus.runtime.generated.Config
2025-08-18T07:37:47.2445930Z 07:37:47,214 INFO  [app] 	at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:445)
2025-08-18T07:37:47.2446615Z 07:37:47,214 INFO  [app] 	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:592)
2025-08-18T07:37:47.2447103Z 07:37:47,214 INFO  [app] 	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:525)
2025-08-18T07:37:47.2447717Z 07:37:47,214 INFO  [app] 	at io.quarkus.bootstrap.classloading.QuarkusClassLoader.loadClass(QuarkusClassLoader.java:577)
2025-08-18T07:37:47.2448448Z 07:37:47,214 INFO  [app] 	at io.quarkus.bootstrap.classloading.QuarkusClassLoader.loadClass(QuarkusClassLoader.java:524)
2025-08-18T07:37:47.2449177Z 07:37:47,214 INFO  [app] 	at io.quarkus.bootstrap.classloading.QuarkusClassLoader.loadClass(QuarkusClassLoader.java:577)
2025-08-18T07:37:47.2449911Z 07:37:47,214 INFO  [app] 	at io.quarkus.bootstrap.classloading.QuarkusClassLoader.loadClass(QuarkusClassLoader.java:524)
2025-08-18T07:37:47.2450392Z 07:37:47,214 INFO  [app] 	... 12 more
```

I think this looks like a bug in Quarkus - unless - unless we started querying Quarkus before it was ready and then the config class generation wasn't finished. Doesn't make a sense because the runtime config must be ready before any runtime code is recorder, but I'd like to make sure that our "isRunningCheck" is fine and see this happening again before I report it. The issue is, I can't reproduce it locally so I don't see anyone fixing it.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)