### PR TITLE
Fix deployment to Kubernetes for Keycloak running in production mode

### DIFF
--- a/quarkus-test-kubernetes/src/main/java/io/quarkus/test/bootstrap/KubernetesExtensionBootstrap.java
+++ b/quarkus-test-kubernetes/src/main/java/io/quarkus/test/bootstrap/KubernetesExtensionBootstrap.java
@@ -66,6 +66,8 @@ public class KubernetesExtensionBootstrap implements ExtensionBootstrap {
     @Override
     public void onError(ScenarioContext context, Throwable throwable) {
         Map<String, String> logs = client.logs();
+        Path testLogsPath = logsTestFolder(context);
+        testLogsPath.toFile().mkdirs();
         for (Entry<String, String> podLog : logs.entrySet()) {
             FileUtils.copyContentTo(podLog.getValue(), logsTestFolder(context).resolve(podLog.getKey() + Log.LOG_SUFFIX));
         }


### PR DESCRIPTION
### Summary

This fixes the Keycloak deployment issue on Kubernetes when the Keycloak is running in a production mode and requires certificates mounted to certain path. We can see these failures in the framework daily build. It is basically c&p from OpenShift client plus fix for the writing of logs for thrown errors (like when the registry URL is missing).

The error log issue also happens for non-K8 deployments, e.g.:

```
2025-08-26T02:55:28.2677969Z [ERROR] io.quarkus.qe.KubernetesRemoteDevModeGreetingResourceIT -- Time elapsed: 57.78 s <<< FAILURE!
2025-08-26T02:55:28.2679879Z org.opentest4j.AssertionFailedError: Failed when writing file target/logs/KubernetesRemoteDevModeGreetingResourceIT/app-6b46cfd6bd-8mn4w.log
2025-08-26T02:55:28.2681662Z 	at io.quarkus.test.utils.FileUtils.copyContentTo(FileUtils.java:32)
2025-08-26T02:55:28.2705109Z 	at io.quarkus.test.bootstrap.KubernetesExtensionBootstrap.onError(KubernetesExtensionBootstrap.java:70)
2025-08-26T02:55:28.2708246Z 	at io.quarkus.test.bootstrap.QuarkusScenarioBootstrap.lambda$scenarioOnError$12(QuarkusScenarioBootstrap.java:206)
2025-08-26T02:55:28.2709369Z 	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
2025-08-26T02:55:28.2710423Z 	at io.quarkus.test.bootstrap.QuarkusScenarioBootstrap.scenarioOnError(QuarkusScenarioBootstrap.java:206)
2025-08-26T02:55:28.2711779Z 	at io.quarkus.test.bootstrap.QuarkusScenarioBootstrap.launchService(QuarkusScenarioBootstrap.java:197)
2025-08-26T02:55:28.2712796Z 	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
2025-08-26T02:55:28.2713961Z 	at io.quarkus.test.bootstrap.QuarkusScenarioBootstrap.beforeAll(QuarkusScenarioBootstrap.java:84)
2025-08-26T02:55:28.2715239Z 	at io.quarkus.test.bootstrap.QuarkusScenarioBootstrap.beforeAll(QuarkusScenarioBootstrap.java:54)
2025-08-26T02:55:28.2716732Z 	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
2025-08-26T02:55:28.2717455Z 	Suppressed: java.net.ConnectException: Connection refused
```



Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)