### PR TITLE
Add method that provides JDBC URL for specific Oracle database

### DIFF
--- a/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/OracleService.java
+++ b/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/OracleService.java
@@ -21,8 +21,18 @@ public class OracleService extends DatabaseService<OracleService> {
 
     @Override
     public String getJdbcUrl() {
+        return getJdbcUrl(getDatabase());
+    }
+
+    /**
+     * Creates JDBC URL pointing to the given database.
+     *
+     * @param databaseName database name
+     * @return JDBC URL
+     */
+    public String getJdbcUrl(String databaseName) {
         var host = getURI();
-        return "jdbc:" + getJdbcName() + ":thin:@" + host.getHost() + ":" + host.getPort() + "/" + getDatabase();
+        return "jdbc:" + getJdbcName() + ":thin:@" + host.getHost() + ":" + host.getPort() + "/" + databaseName;
     }
 
     @Override


### PR DESCRIPTION
### Summary

This method should come handy in Quarkus QE Test Suite, see https://github.com/quarkus-qe/quarkus-test-suite/pull/2584#discussion_r2300104947.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)