### PR TITLE
Support running Keycloak in production mode on Kubernetes

### DIFF
--- a/quarkus-test-kubernetes/src/main/java/io/quarkus/test/services/containers/KubernetesContainerManagedResource.java
+++ b/quarkus-test-kubernetes/src/main/java/io/quarkus/test/services/containers/KubernetesContainerManagedResource.java
@@ -88,10 +88,14 @@ public class KubernetesContainerManagedResource implements ManagedResource {
         return loggingHandler.logs();
     }
 
-    private void applyDeployment() {
-        String deploymentFile = getConfiguration()
+    protected String getTemplate() {
+        return getConfiguration()
                 .getOrDefault(Configuration.Property.KUBERNETES_DEPLOYMENT_TEMPLATE_PROPERTY,
                         DEPLOYMENT_TEMPLATE_PROPERTY_DEFAULT);
+    }
+
+    private void applyDeployment() {
+        String deploymentFile = getTemplate();
         client.applyServiceProperties(model.getContext().getOwner(), deploymentFile, this::replaceDeploymentContent,
                 model.getContext().getServiceFolder().resolve(DEPLOYMENT));
     }
@@ -109,7 +113,7 @@ public class KubernetesContainerManagedResource implements ManagedResource {
                 .replaceAll(quote("${ARGS}"), args);
     }
 
-    private boolean useInternalServiceAsUrl() {
+    protected boolean useInternalServiceAsUrl() {
         return Boolean.TRUE.toString()
                 .equals(getConfiguration()
                         .get(Configuration.Property.KUBERNETES_USE_INTERNAL_SERVICE_AS_URL_PROPERTY));
@@ -117,5 +121,13 @@ public class KubernetesContainerManagedResource implements ManagedResource {
 
     private Configuration getConfiguration() {
         return model.getContext().getOwner().getConfiguration();
+    }
+
+    protected KubectlClient getClient() {
+        return client;
+    }
+
+    protected ContainerManagedResourceBuilder getModel() {
+        return model;
     }
 }

--- a/quarkus-test-service-keycloak/src/main/java/io/quarkus/test/bootstrap/KeycloakService.java
+++ b/quarkus-test-service-keycloak/src/main/java/io/quarkus/test/bootstrap/KeycloakService.java
@@ -31,6 +31,7 @@ import org.apache.http.ssl.SSLContexts;
 import org.keycloak.authorization.client.AuthzClient;
 import org.keycloak.authorization.client.Configuration;
 
+import io.quarkus.test.logging.Log;
 import io.quarkus.test.security.certificate.Certificate;
 
 public class KeycloakService extends BaseService<KeycloakService> {
@@ -96,12 +97,18 @@ public class KeycloakService extends BaseService<KeycloakService> {
     }
 
     public AuthzClient createAuthzClient(String clientId, String clientSecret) {
-        return AuthzClient.create(new Configuration(
-                StringUtils.substringBefore(getRealmUrl(), "/realms"),
-                realm,
-                clientId,
-                Collections.singletonMap("secret", clientSecret),
-                prepareHttpClientForAuthzClient()));
+        try {
+            return AuthzClient.create(new Configuration(
+                    StringUtils.substringBefore(getRealmUrl(), "/realms"),
+                    realm,
+                    clientId,
+                    Collections.singletonMap("secret", clientSecret),
+                    prepareHttpClientForAuthzClient()));
+        } catch (Exception exception) {
+            // this exception can silently occur in the JUnit callback method, and we need to know about it
+            Log.error("Failed to create AuthzClient: %s", exception);
+            throw exception;
+        }
     }
 
     private HttpClient prepareHttpClientForAuthzClient() {

--- a/quarkus-test-service-keycloak/src/main/java/io/quarkus/test/services/containers/KubernetesKeycloakContainerManagedResource.java
+++ b/quarkus-test-service-keycloak/src/main/java/io/quarkus/test/services/containers/KubernetesKeycloakContainerManagedResource.java
@@ -5,9 +5,115 @@
 
 package io.quarkus.test.services.containers;
 
+import java.lang.annotation.Annotation;
+import java.util.List;
+
+import io.quarkus.test.bootstrap.ManagedResource;
+import io.quarkus.test.bootstrap.Protocol;
+import io.quarkus.test.bootstrap.ServiceContext;
+import io.quarkus.test.services.URILike;
+
 public class KubernetesKeycloakContainerManagedResource extends KubernetesContainerManagedResource {
 
+    protected static final String DEPLOYMENT_TEMPLATE_PROPERTY_HTTPS_DEFAULT = "/kubernetes-deployment-https-template.yml";
+
     protected KubernetesKeycloakContainerManagedResource(KeycloakContainerManagedResourceBuilder model) {
-        super(model);
+        super(adaptModel(model));
+    }
+
+    @Override
+    public URILike getURI(Protocol protocol) {
+        if (protocol == Protocol.HTTPS && !useInternalServiceAsUrl()) {
+            return createURI(Protocol.HTTPS.getValue(), getClient().host(),
+                    getClient().port(getModel().getContext().getOwner()));
+        }
+        return super.getURI(protocol);
+    }
+
+    @Override
+    protected String getTemplate() {
+        if (getModel() instanceof KeycloakContainerManagedResourceBuilder keycloakModel
+                && !keycloakModel.runKeycloakInProdMode()) {
+            return super.getTemplate();
+        }
+        return DEPLOYMENT_TEMPLATE_PROPERTY_HTTPS_DEFAULT;
+    }
+
+    private static ContainerManagedResourceBuilder adaptModel(KeycloakContainerManagedResourceBuilder model) {
+        if (!model.runKeycloakInProdMode()) {
+            return model;
+        }
+        return new HttpsContainerManagedResourceBuilder(model);
+    }
+
+    private static final class HttpsContainerManagedResourceBuilder extends ContainerManagedResourceBuilder {
+
+        private final KeycloakContainerManagedResourceBuilder delegate;
+
+        private HttpsContainerManagedResourceBuilder(KeycloakContainerManagedResourceBuilder delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        protected Integer getPort() {
+            // we only support one port, because Keycloak only listen on one port
+            return delegate.getTlsPort();
+        }
+
+        @Override
+        protected String getImage() {
+            return delegate.getImage();
+        }
+
+        @Override
+        protected String getExpectedLog() {
+            return delegate.getExpectedLog();
+        }
+
+        @Override
+        protected String[] getCommand() {
+            return delegate.getCommand();
+        }
+
+        @Override
+        protected Integer getTlsPort() {
+            return delegate.getTlsPort();
+        }
+
+        @Override
+        protected boolean isSslEnabled() {
+            return delegate.isSslEnabled();
+        }
+
+        @Override
+        protected ServiceContext getContext() {
+            return delegate.getContext();
+        }
+
+        @Override
+        public void init(Annotation annotation) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        protected void init(String image, String[] command, String expectedLog, int port, boolean portDockerHostToLocalhost) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        protected void init(String image, String[] command, String expectedLog, int port, int tlsPort, boolean sslEnabled,
+                boolean portDockerHostToLocalhost) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ManagedResource build(ServiceContext context) {
+            return delegate.build(context);
+        }
+
+        @Override
+        public List<MountConfig> getMounts() {
+            return delegate.getMounts();
+        }
     }
 }

--- a/quarkus-test-service-keycloak/src/main/resources/kubernetes-deployment-https-template.yml
+++ b/quarkus-test-service-keycloak/src/main/resources/kubernetes-deployment-https-template.yml
@@ -1,0 +1,26 @@
+---
+apiVersion: "v1"
+kind: "List"
+items:
+- apiVersion: "apps/v1"
+  kind: "Deployment"
+  metadata:
+    name: "${SERVICE_NAME}"
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        deployment: "${SERVICE_NAME}"
+    template:
+      metadata:
+        labels:
+          deployment: "${SERVICE_NAME}"
+      spec:
+        containers:
+        - image: "${IMAGE}"
+          args: [${ARGS}]
+          name: "${SERVICE_NAME}"
+          ports:
+          - containerPort: ${INTERNAL_PORT}
+            name: "https"
+            protocol: "TCP"


### PR DESCRIPTION
### Summary

Keycloak in production mode uses HTTPS protocol, however our framework only exposes HTTP port, so there is NPE when creating Keycloak `AuthZClient`.

I verified locally this PR fixed ^^^, but my env differs from our daily CI as I am using Minikube with rootless podman and had to do some port forwarding. I do not guarantee that this fixes the test completely in our GH CI.

I have added some logging because when certain exceptions are thrown in JUnit callbacks, it seems to be silent and I didn't know what is happening in there.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)