### PR TITLE
Fix mounting error on windows when SELinux is set

### DIFF
--- a/quarkus-test-containers/src/main/java/io/quarkus/test/services/containers/GenericDockerContainerManagedResource.java
+++ b/quarkus-test-containers/src/main/java/io/quarkus/test/services/containers/GenericDockerContainerManagedResource.java
@@ -1,10 +1,5 @@
 package io.quarkus.test.services.containers;
 
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-
 import org.apache.commons.lang3.StringUtils;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
@@ -62,14 +57,8 @@ public class GenericDockerContainerManagedResource extends DockerContainerManage
         }
 
         for (ContainerManagedResourceBuilder.MountConfig mount : model.getMounts()) {
-            try {
-                URL resource = this.getClass().getClassLoader().getResource(mount.from);
-                Path source = Paths.get(resource.toURI());
-                Log.info(model.getContext().getOwner(), "Mounting " + source + " to " + mount.to);
-                container.addFileSystemBind(source.toString(), mount.to, BindMode.READ_ONLY, SelinuxContext.SHARED);
-            } catch (URISyntaxException e) {
-                throw new RuntimeException(e);
-            }
+            Log.info(model.getContext().getOwner(), "Mounting " + mount.from + " to " + mount.to);
+            container.withClasspathResourceMapping(mount.from, mount.to, BindMode.READ_ONLY, SelinuxContext.SHARED);
         }
 
         container.withExposedPorts(model.getPort());


### PR DESCRIPTION
### Summary

When using `@Mount` and running it on windows I get 
```
2025-08-29 07:30:14,259 WARN  [org.tes.con.ContainerDef] (main) Unable to mount a file from test host into a running container. This may be a misconfiguration or limitation of your Docker environment. Some features might not work.
2025-08-29 07:30:14,290 ERROR [tc.doc.io/.0] (main) Could not start container: com.github.dockerjava.api.exception.InternalServerErrorException: Status 500: {"message":"invalid volume specification: 'C:\\Users\\hudson\\quarkus-test-suite\\nosql-db\\mongodb\\target\\test-classes\\mongod.conf:/etc/mongod.conf:ro,z'"}
```

There was some problem when mounting it (the propagating the SELinux on Windows wasn't problem).  Probably wrongly resolving path or something, didn't debug it that much.

The `withClasspathResourceMapping` resolving the resource by it self instead of our FW and binding them.

Tested it on windows and linux and it work.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)