### PR TITLE
Revert "Release 1.8.0.Beta1"

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 name: Quarkus QE Test Framework
 release:
-  current-version: 1.8.0.Beta1
-  next-version: 1.8.0.Beta2
+  current-version: 1.7.0.Beta1
+  next-version: 1.7.0.Beta2


### PR DESCRIPTION
Reverts quarkus-qe/quarkus-test-framework#1680

Sonatype Central doesn't allow artifacts depending on -SNAPSHOT versions into release repository anymore, so the release was unsuccessful.