### PR TITLE
Don't use file path in ConfigMap and Secret name as it causes issues when tests are run from macOS

### DIFF
--- a/quarkus-test-core/src/main/java/io/quarkus/test/utils/StringUtils.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/utils/StringUtils.java
@@ -1,0 +1,23 @@
+package io.quarkus.test.utils;
+
+import static io.quarkus.runtime.util.StringUtil.hyphenate;
+
+public final class StringUtils {
+
+    public static final String HYPHEN = "-";
+
+    private StringUtils() {
+    }
+
+    /**
+     * Kubernetes API objects like ConfigMap and Secret require that metadata name comply
+     * the '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*' regex.
+     *
+     * @param metadataName API object name as specified in 'metadata.name'
+     * @return sanitized object name
+     */
+    public static String sanitizeKubernetesObjectName(String metadataName) {
+        return hyphenate(metadataName);
+    }
+
+}

--- a/quarkus-test-knative-events/root/src/main/java/io/quarkus/test/services/knative/eventing/FunqyKnativeEventsService.java
+++ b/quarkus-test-knative-events/root/src/main/java/io/quarkus/test/services/knative/eventing/FunqyKnativeEventsService.java
@@ -229,7 +229,9 @@ public class FunqyKnativeEventsService extends BaseService<FunqyKnativeEventsSer
         private FuncInvoker(String baseUrl) {
             request = RestAssured
                     .given()
-                    .baseUri(requireNonNull(baseUrl));
+                    .baseUri(requireNonNull(baseUrl))
+                    // TODO: support TLS communication with Knative service
+                    .relaxedHTTPSValidation();
         }
 
         public FuncInvoker<T> appJsonContentType() {

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/ExtensionOpenShiftQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/ExtensionOpenShiftQuarkusApplicationManagedResource.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.regex.Pattern;
 
+import io.quarkus.test.bootstrap.Service;
 import io.quarkus.test.bootstrap.inject.OpenShiftClient;
 import io.quarkus.test.configuration.PropertyLookup;
 import io.quarkus.test.utils.Command;
@@ -221,14 +222,15 @@ public class ExtensionOpenShiftQuarkusApplicationManagedResource
     }
 
     private void withEnvVars(List<String> args) {
-        Map<String, String> envVars = model.getContext().getOwner().getProperties();
+        Service service = model.getContext().getOwner();
+        Map<String, String> envVars = service.getProperties();
         String property = QUARKUS_OPENSHIFT_ENV_VARS;
         if (isKnativeDeployment()) {
             property = QUARKUS_KNATIVE_ENV_VARS;
         }
         for (Entry<String, String> envVar : envVars.entrySet()) {
             if (envVar.getValue().startsWith(SECRET_WITH_DESTINATION_PREFIX)) {
-                var result = client.createSecretForSecretWithDestinationPropertyInternal(envVar.getValue());
+                var result = client.createSecretForSecretWithDestinationProperty(service, envVar.getValue());
                 args.add(withProperty("quarkus.openshift.secret-volumes." + result.secretName() + ".secret-name",
                         result.secretName()));
                 args.add(withProperty(

--- a/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/Db2Service.java
+++ b/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/Db2Service.java
@@ -7,20 +7,19 @@ public class Db2Service extends DatabaseService<Db2Service> {
     static final String DATABASE_PROPERTY = "DBNAME";
     static final String JDBC_NAME = "db2";
 
+    public Db2Service() {
+        withProperty("AUTOCONFIG", "false");
+        withProperty("ARCHIVE_LOGS", "false");
+        withProperty("LICENSE", "accept");
+        onPreStart(service -> service
+                .withProperty(USER_PROPERTY, getUser())
+                .withProperty(PASSWORD_PROPERTY, getPassword())
+                .withProperty(DATABASE_PROPERTY, getDatabase()));
+    }
+
     @Override
     protected String getJdbcName() {
         return JDBC_NAME;
     }
 
-    @Override
-    public Db2Service onPreStart(Action action) {
-        withProperty(USER_PROPERTY, getUser());
-        withProperty(PASSWORD_PROPERTY, getPassword());
-        withProperty(DATABASE_PROPERTY, getDatabase());
-        withProperty("AUTOCONFIG", "false");
-        withProperty("ARCHIVE_LOGS", "false");
-        withProperty("LICENSE", "accept");
-
-        return super.onPreStart(action);
-    }
 }

--- a/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/MariaDbService.java
+++ b/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/MariaDbService.java
@@ -8,25 +8,24 @@ public class MariaDbService extends DatabaseService<MariaDbService> {
     static final String DATABASE_PROPERTY = "MARIADB_DATABASE";
     static final String JDBC_NAME = "mariadb";
 
+    public MariaDbService() {
+        onPreStart(service -> service
+                // Some MariaDB images need MariaDB, some others MySql ones... So, we provide both:
+                // - MySQL properties
+                .withProperty(MySqlService.USER_PROPERTY, getUser())
+                .withProperty(MySqlService.PASSWORD_PROPERTY, getPassword())
+                .withProperty(MySqlService.PASSWORD_ROOT_PROPERTY, getPassword())
+                .withProperty(MySqlService.DATABASE_PROPERTY, getDatabase())
+                // - MariaDB properties
+                .withProperty(USER_PROPERTY, getUser())
+                .withProperty(PASSWORD_PROPERTY, getPassword())
+                .withProperty(PASSWORD_ROOT_PROPERTY, getPassword())
+                .withProperty(DATABASE_PROPERTY, getDatabase()));
+    }
+
     @Override
     protected String getJdbcName() {
         return JDBC_NAME;
     }
 
-    @Override
-    public MariaDbService onPreStart(Action action) {
-        // Some MariaDB images need MariaDB, some others MySql ones... So, we provide both:
-        // - MySQL properties
-        withProperty(MySqlService.USER_PROPERTY, getUser());
-        withProperty(MySqlService.PASSWORD_PROPERTY, getPassword());
-        withProperty(MySqlService.PASSWORD_ROOT_PROPERTY, getPassword());
-        withProperty(MySqlService.DATABASE_PROPERTY, getDatabase());
-        // - MariaDB properties
-        withProperty(USER_PROPERTY, getUser());
-        withProperty(PASSWORD_PROPERTY, getPassword());
-        withProperty(PASSWORD_ROOT_PROPERTY, getPassword());
-        withProperty(DATABASE_PROPERTY, getDatabase());
-
-        return super.onPreStart(action);
-    }
 }

--- a/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/MySqlService.java
+++ b/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/MySqlService.java
@@ -8,18 +8,17 @@ public class MySqlService extends DatabaseService<MySqlService> {
     static final String DATABASE_PROPERTY = "MYSQL_DATABASE";
     static final String JDBC_NAME = "mysql";
 
+    public MySqlService() {
+        onPreStart(service -> service
+                .withProperty(USER_PROPERTY, getUser())
+                .withProperty(PASSWORD_PROPERTY, getPassword())
+                .withProperty(PASSWORD_ROOT_PROPERTY, getPassword())
+                .withProperty(DATABASE_PROPERTY, getDatabase()));
+    }
+
     @Override
     protected String getJdbcName() {
         return JDBC_NAME;
     }
 
-    @Override
-    public MySqlService onPreStart(Action action) {
-        withProperty(USER_PROPERTY, getUser());
-        withProperty(PASSWORD_PROPERTY, getPassword());
-        withProperty(PASSWORD_ROOT_PROPERTY, getPassword());
-        withProperty(DATABASE_PROPERTY, getDatabase());
-
-        return super.onPreStart(action);
-    }
 }

--- a/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/OracleService.java
+++ b/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/OracleService.java
@@ -12,6 +12,11 @@ public class OracleService extends DatabaseService<OracleService> {
     public OracleService() {
         // Oracle disallows to use "user", so we use "myuser" as default user name.
         withUser(USER_DEFAULT_VALUE);
+        onPreStart(service -> service
+                .withProperty(USER_PROPERTY, getUser())
+                .withProperty(PASSWORD_PROPERTY, getPassword())
+                .withProperty(USER_PASSWORD_PROPERTY, getPassword())
+                .withProperty(DATABASE_PROPERTY, getDatabase()));
     }
 
     @Override
@@ -39,15 +44,5 @@ public class OracleService extends DatabaseService<OracleService> {
     public String getReactiveUrl() {
         var host = getURI();
         return getJdbcName() + ":thin:@" + host.getHost() + ":" + host.getPort() + "/" + getDatabase();
-    }
-
-    @Override
-    public OracleService onPreStart(Action action) {
-        withProperty(USER_PROPERTY, getUser());
-        withProperty(PASSWORD_PROPERTY, getPassword());
-        withProperty(USER_PASSWORD_PROPERTY, getPassword());
-        withProperty(DATABASE_PROPERTY, getDatabase());
-
-        return super.onPreStart(action);
     }
 }

--- a/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/PostgresqlService.java
+++ b/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/PostgresqlService.java
@@ -19,24 +19,23 @@ public class PostgresqlService extends DatabaseService<PostgresqlService> {
     static final String DH_PASSWORD_PROPERTY = "POSTGRES_PASSWORD";
     static final String DH_DATABASE_PROPERTY = "POSTGRES_DB";
 
+    public PostgresqlService() {
+        onPreStart(service -> service
+                // RedHat registry environment variables
+                .withProperty(USER_PROPERTY, getUser())
+                .withProperty(PASSWORD_PROPERTY, getPassword())
+                .withProperty(DATABASE_PROPERTY, getDatabase())
+                .withProperty(LOG_DESTINATION, "/dev/stdout")
+
+                // DockerHub environment variables
+                .withProperty(DH_USER_PROPERTY, getUser())
+                .withProperty(DH_PASSWORD_PROPERTY, getPassword())
+                .withProperty(DH_DATABASE_PROPERTY, getDatabase()));
+    }
+
     @Override
     protected String getJdbcName() {
         return JDBC_NAME;
     }
 
-    @Override
-    public PostgresqlService onPreStart(Action action) {
-        // RedHat registry environment variables
-        withProperty(USER_PROPERTY, getUser());
-        withProperty(PASSWORD_PROPERTY, getPassword());
-        withProperty(DATABASE_PROPERTY, getDatabase());
-        withProperty(LOG_DESTINATION, "/dev/stdout");
-
-        // DockerHub environment variables
-        withProperty(DH_USER_PROPERTY, getUser());
-        withProperty(DH_PASSWORD_PROPERTY, getPassword());
-        withProperty(DH_DATABASE_PROPERTY, getDatabase());
-
-        return super.onPreStart(action);
-    }
 }

--- a/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/SqlServerService.java
+++ b/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/SqlServerService.java
@@ -17,6 +17,8 @@ public class SqlServerService extends DatabaseService<SqlServerService> {
     public SqlServerService() {
         super();
         withPassword(DEFAULT_PASSWORD);
+        withProperty("ACCEPT_EULA", "Y");
+        onPreStart(service -> service.withProperty("MSSQL_SA_PASSWORD", getPassword()));
     }
 
     @Override
@@ -85,10 +87,4 @@ public class SqlServerService extends DatabaseService<SqlServerService> {
         return JDBC_NAME;
     }
 
-    @Override
-    public SqlServerService onPreStart(Action action) {
-        withProperty("MSSQL_SA_PASSWORD", getPassword());
-        withProperty("ACCEPT_EULA", "Y");
-        return super.onPreStart(action);
-    }
 }

--- a/quarkus-test-service-infinispan/src/main/java/io/quarkus/test/bootstrap/InfinispanService.java
+++ b/quarkus-test-service-infinispan/src/main/java/io/quarkus/test/bootstrap/InfinispanService.java
@@ -17,6 +17,33 @@ public class InfinispanService extends BaseService<InfinispanService> {
     private String username = USERNAME_DEFAULT;
     private String password = PASSWORD_DEFAULT;
 
+    public InfinispanService() {
+        onPreStart(service -> {
+            service.withProperty("USER", getUsername());
+            service.withProperty("PASS", getPassword());
+
+            if (configFile != null && !configFile.isEmpty()) {
+                // legacy -> Infinispan previous to version 14
+                service.withProperty("CONFIG_PATH", RESOURCE_PREFIX + configFile);
+                // Infinispan 14+ configuration setup
+                service.withProperty("INFINISPAN_CONFIG_PATH",
+                        "resource_with_destination::/opt/infinispan/server/conf|" + configFile);
+            }
+
+            if (userConfigFiles != null) {
+                for (int index = 0; index < userConfigFiles.size(); index++) {
+                    service.withProperty("USER_CONFIG_" + index, RESOURCE_PREFIX + userConfigFiles.get(index));
+                }
+            }
+
+            if (secretFiles != null) {
+                for (int index = 0; index < secretFiles.size(); index++) {
+                    service.withProperty("SECRET_" + index, SECRET_PREFIX + secretFiles.get(index));
+                }
+            }
+        });
+    }
+
     public String getUsername() {
         return username;
     }
@@ -53,32 +80,5 @@ public class InfinispanService extends BaseService<InfinispanService> {
     public InfinispanService withPassword(String password) {
         this.password = password;
         return this;
-    }
-
-    @Override
-    public InfinispanService onPreStart(Action action) {
-        withProperty("USER", getUsername());
-        withProperty("PASS", getPassword());
-
-        if (configFile != null && !configFile.isEmpty()) {
-            // legacy -> Infinispan previous to version 14
-            withProperty("CONFIG_PATH", RESOURCE_PREFIX + configFile);
-            // Infinispan 14+ configuration setup
-            withProperty("INFINISPAN_CONFIG_PATH", "resource_with_destination::/opt/infinispan/server/conf|" + configFile);
-        }
-
-        if (userConfigFiles != null) {
-            for (int index = 0; index < userConfigFiles.size(); index++) {
-                withProperty("USER_CONFIG_" + index, RESOURCE_PREFIX + userConfigFiles.get(index));
-            }
-        }
-
-        if (secretFiles != null) {
-            for (int index = 0; index < secretFiles.size(); index++) {
-                withProperty("SECRET_" + index, SECRET_PREFIX + secretFiles.get(index));
-            }
-        }
-
-        return super.onPreStart(action);
     }
 }


### PR DESCRIPTION
### Summary

Intention for this PR is to stop using the file path in the Kubernetes ConfigMap and Secret API objects. The reason for this is that Rostislav experienced issues due to how the file path is on macOS. For that reason, this PR:

1. Generates a new secret name from the owner (service) name, file name and random (because filenames may not be unique for the service). Before this PR, ConfigMap and Secrete name could look like `ttx6w0000gn-T-vertx-jwt-certs13580627245463743513-vertx-jwt-key` which doesn't fit Kubernetes regular expression `[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*` (e.g in `OpenShiftBladeRunnerHandlerIT`) for API object names. New name consist of the service name, random (assures name uniqueness) and the filename. That is, the new name for the previously mentioned example looks like `app-259487800-vertx-jwt-key`.
2. Separate static properties and "future" properties in order to have properties with a test scope. That is now, we have certainty that config properties are not shared between test classes unintentionally. This is required for the 1. bulletpoint, because when secret name is unique and more than one test classes share same field (abstract parent), it would create multiple secrets due to the fact that supplier-based properties were added to the static properties again and again on every service registration.
3. The `onPreStart` now only adds the pre-start action. That isn't really a change, it was done before, but some database services relied on the implementation detail that the BaseService always call it and disused it. Now, the BaseService do not need to call this method, therefore I refactored the db services to add the pre-start action explicitly. This change is a consequence of separating static properties and "future" properties (supplier-based properties).


Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)