### PR TITLE
1.7.z backports

### DIFF
--- a/examples/kafka/pom.xml
+++ b/examples/kafka/pom.xml
@@ -52,7 +52,7 @@
                         <configuration>
                             <systemPropertyVariables>
                                 <custom.kafka.image>quay.io/strimzi/kafka</custom.kafka.image>
-                                <custom.kafka.version>0.45.0-kafka-3.9.0</custom.kafka.version>
+                                <custom.kafka.version>0.47.0-kafka-4.0.0</custom.kafka.version>
                             </systemPropertyVariables>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>3.26.0</quarkus.platform.version>
+        <quarkus.platform.version>3.26.4</quarkus.platform.version>
         <exclude.tests.with.tags>quarkus-cli</exclude.tests.with.tags>
         <include.tests>**/*IT.java</include.tests>
         <exclude.openshift.tests>**/OpenShift*IT.java</exclude.openshift.tests>

--- a/quarkus-test-core/src/main/java/io/quarkus/test/utils/StringUtils.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/utils/StringUtils.java
@@ -1,0 +1,23 @@
+package io.quarkus.test.utils;
+
+import static io.quarkus.runtime.util.StringUtil.hyphenate;
+
+public final class StringUtils {
+
+    public static final String HYPHEN = "-";
+
+    private StringUtils() {
+    }
+
+    /**
+     * Kubernetes API objects like ConfigMap and Secret require that metadata name comply
+     * the '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*' regex.
+     *
+     * @param metadataName API object name as specified in 'metadata.name'
+     * @return sanitized object name
+     */
+    public static String sanitizeKubernetesObjectName(String metadataName) {
+        return hyphenate(metadataName);
+    }
+
+}

--- a/quarkus-test-knative-events/root/src/main/java/io/quarkus/test/services/knative/eventing/FunqyKnativeEventsService.java
+++ b/quarkus-test-knative-events/root/src/main/java/io/quarkus/test/services/knative/eventing/FunqyKnativeEventsService.java
@@ -229,7 +229,9 @@ public class FunqyKnativeEventsService extends BaseService<FunqyKnativeEventsSer
         private FuncInvoker(String baseUrl) {
             request = RestAssured
                     .given()
-                    .baseUri(requireNonNull(baseUrl));
+                    .baseUri(requireNonNull(baseUrl))
+                    // TODO: support TLS communication with Knative service
+                    .relaxedHTTPSValidation();
         }
 
         public FuncInvoker<T> appJsonContentType() {

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/ExtensionOpenShiftQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/ExtensionOpenShiftQuarkusApplicationManagedResource.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.regex.Pattern;
 
+import io.quarkus.test.bootstrap.Service;
 import io.quarkus.test.bootstrap.inject.OpenShiftClient;
 import io.quarkus.test.configuration.PropertyLookup;
 import io.quarkus.test.utils.Command;
@@ -221,14 +222,15 @@ public class ExtensionOpenShiftQuarkusApplicationManagedResource
     }
 
     private void withEnvVars(List<String> args) {
-        Map<String, String> envVars = model.getContext().getOwner().getProperties();
+        Service service = model.getContext().getOwner();
+        Map<String, String> envVars = service.getProperties();
         String property = QUARKUS_OPENSHIFT_ENV_VARS;
         if (isKnativeDeployment()) {
             property = QUARKUS_KNATIVE_ENV_VARS;
         }
         for (Entry<String, String> envVar : envVars.entrySet()) {
             if (envVar.getValue().startsWith(SECRET_WITH_DESTINATION_PREFIX)) {
-                var result = client.createSecretForSecretWithDestinationPropertyInternal(envVar.getValue());
+                var result = client.createSecretForSecretWithDestinationProperty(service, envVar.getValue());
                 args.add(withProperty("quarkus.openshift.secret-volumes." + result.secretName() + ".secret-name",
                         result.secretName()));
                 args.add(withProperty(

--- a/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/Db2Service.java
+++ b/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/Db2Service.java
@@ -7,20 +7,19 @@ public class Db2Service extends DatabaseService<Db2Service> {
     static final String DATABASE_PROPERTY = "DBNAME";
     static final String JDBC_NAME = "db2";
 
+    public Db2Service() {
+        withProperty("AUTOCONFIG", "false");
+        withProperty("ARCHIVE_LOGS", "false");
+        withProperty("LICENSE", "accept");
+        onPreStart(service -> service
+                .withProperty(USER_PROPERTY, getUser())
+                .withProperty(PASSWORD_PROPERTY, getPassword())
+                .withProperty(DATABASE_PROPERTY, getDatabase()));
+    }
+
     @Override
     protected String getJdbcName() {
         return JDBC_NAME;
     }
 
-    @Override
-    public Db2Service onPreStart(Action action) {
-        withProperty(USER_PROPERTY, getUser());
-        withProperty(PASSWORD_PROPERTY, getPassword());
-        withProperty(DATABASE_PROPERTY, getDatabase());
-        withProperty("AUTOCONFIG", "false");
-        withProperty("ARCHIVE_LOGS", "false");
-        withProperty("LICENSE", "accept");
-
-        return super.onPreStart(action);
-    }
 }

--- a/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/MariaDbService.java
+++ b/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/MariaDbService.java
@@ -8,25 +8,24 @@ public class MariaDbService extends DatabaseService<MariaDbService> {
     static final String DATABASE_PROPERTY = "MARIADB_DATABASE";
     static final String JDBC_NAME = "mariadb";
 
+    public MariaDbService() {
+        onPreStart(service -> service
+                // Some MariaDB images need MariaDB, some others MySql ones... So, we provide both:
+                // - MySQL properties
+                .withProperty(MySqlService.USER_PROPERTY, getUser())
+                .withProperty(MySqlService.PASSWORD_PROPERTY, getPassword())
+                .withProperty(MySqlService.PASSWORD_ROOT_PROPERTY, getPassword())
+                .withProperty(MySqlService.DATABASE_PROPERTY, getDatabase())
+                // - MariaDB properties
+                .withProperty(USER_PROPERTY, getUser())
+                .withProperty(PASSWORD_PROPERTY, getPassword())
+                .withProperty(PASSWORD_ROOT_PROPERTY, getPassword())
+                .withProperty(DATABASE_PROPERTY, getDatabase()));
+    }
+
     @Override
     protected String getJdbcName() {
         return JDBC_NAME;
     }
 
-    @Override
-    public MariaDbService onPreStart(Action action) {
-        // Some MariaDB images need MariaDB, some others MySql ones... So, we provide both:
-        // - MySQL properties
-        withProperty(MySqlService.USER_PROPERTY, getUser());
-        withProperty(MySqlService.PASSWORD_PROPERTY, getPassword());
-        withProperty(MySqlService.PASSWORD_ROOT_PROPERTY, getPassword());
-        withProperty(MySqlService.DATABASE_PROPERTY, getDatabase());
-        // - MariaDB properties
-        withProperty(USER_PROPERTY, getUser());
-        withProperty(PASSWORD_PROPERTY, getPassword());
-        withProperty(PASSWORD_ROOT_PROPERTY, getPassword());
-        withProperty(DATABASE_PROPERTY, getDatabase());
-
-        return super.onPreStart(action);
-    }
 }

--- a/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/MySqlService.java
+++ b/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/MySqlService.java
@@ -8,18 +8,17 @@ public class MySqlService extends DatabaseService<MySqlService> {
     static final String DATABASE_PROPERTY = "MYSQL_DATABASE";
     static final String JDBC_NAME = "mysql";
 
+    public MySqlService() {
+        onPreStart(service -> service
+                .withProperty(USER_PROPERTY, getUser())
+                .withProperty(PASSWORD_PROPERTY, getPassword())
+                .withProperty(PASSWORD_ROOT_PROPERTY, getPassword())
+                .withProperty(DATABASE_PROPERTY, getDatabase()));
+    }
+
     @Override
     protected String getJdbcName() {
         return JDBC_NAME;
     }
 
-    @Override
-    public MySqlService onPreStart(Action action) {
-        withProperty(USER_PROPERTY, getUser());
-        withProperty(PASSWORD_PROPERTY, getPassword());
-        withProperty(PASSWORD_ROOT_PROPERTY, getPassword());
-        withProperty(DATABASE_PROPERTY, getDatabase());
-
-        return super.onPreStart(action);
-    }
 }

--- a/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/OracleService.java
+++ b/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/OracleService.java
@@ -12,6 +12,11 @@ public class OracleService extends DatabaseService<OracleService> {
     public OracleService() {
         // Oracle disallows to use "user", so we use "myuser" as default user name.
         withUser(USER_DEFAULT_VALUE);
+        onPreStart(service -> service
+                .withProperty(USER_PROPERTY, getUser())
+                .withProperty(PASSWORD_PROPERTY, getPassword())
+                .withProperty(USER_PASSWORD_PROPERTY, getPassword())
+                .withProperty(DATABASE_PROPERTY, getDatabase()));
     }
 
     @Override
@@ -39,15 +44,5 @@ public class OracleService extends DatabaseService<OracleService> {
     public String getReactiveUrl() {
         var host = getURI();
         return getJdbcName() + ":thin:@" + host.getHost() + ":" + host.getPort() + "/" + getDatabase();
-    }
-
-    @Override
-    public OracleService onPreStart(Action action) {
-        withProperty(USER_PROPERTY, getUser());
-        withProperty(PASSWORD_PROPERTY, getPassword());
-        withProperty(USER_PASSWORD_PROPERTY, getPassword());
-        withProperty(DATABASE_PROPERTY, getDatabase());
-
-        return super.onPreStart(action);
     }
 }

--- a/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/PostgresqlService.java
+++ b/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/PostgresqlService.java
@@ -19,24 +19,23 @@ public class PostgresqlService extends DatabaseService<PostgresqlService> {
     static final String DH_PASSWORD_PROPERTY = "POSTGRES_PASSWORD";
     static final String DH_DATABASE_PROPERTY = "POSTGRES_DB";
 
+    public PostgresqlService() {
+        onPreStart(service -> service
+                // RedHat registry environment variables
+                .withProperty(USER_PROPERTY, getUser())
+                .withProperty(PASSWORD_PROPERTY, getPassword())
+                .withProperty(DATABASE_PROPERTY, getDatabase())
+                .withProperty(LOG_DESTINATION, "/dev/stdout")
+
+                // DockerHub environment variables
+                .withProperty(DH_USER_PROPERTY, getUser())
+                .withProperty(DH_PASSWORD_PROPERTY, getPassword())
+                .withProperty(DH_DATABASE_PROPERTY, getDatabase()));
+    }
+
     @Override
     protected String getJdbcName() {
         return JDBC_NAME;
     }
 
-    @Override
-    public PostgresqlService onPreStart(Action action) {
-        // RedHat registry environment variables
-        withProperty(USER_PROPERTY, getUser());
-        withProperty(PASSWORD_PROPERTY, getPassword());
-        withProperty(DATABASE_PROPERTY, getDatabase());
-        withProperty(LOG_DESTINATION, "/dev/stdout");
-
-        // DockerHub environment variables
-        withProperty(DH_USER_PROPERTY, getUser());
-        withProperty(DH_PASSWORD_PROPERTY, getPassword());
-        withProperty(DH_DATABASE_PROPERTY, getDatabase());
-
-        return super.onPreStart(action);
-    }
 }

--- a/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/SqlServerService.java
+++ b/quarkus-test-service-database/src/main/java/io/quarkus/test/bootstrap/SqlServerService.java
@@ -17,6 +17,8 @@ public class SqlServerService extends DatabaseService<SqlServerService> {
     public SqlServerService() {
         super();
         withPassword(DEFAULT_PASSWORD);
+        withProperty("ACCEPT_EULA", "Y");
+        onPreStart(service -> service.withProperty("MSSQL_SA_PASSWORD", getPassword()));
     }
 
     @Override
@@ -85,10 +87,4 @@ public class SqlServerService extends DatabaseService<SqlServerService> {
         return JDBC_NAME;
     }
 
-    @Override
-    public SqlServerService onPreStart(Action action) {
-        withProperty("MSSQL_SA_PASSWORD", getPassword());
-        withProperty("ACCEPT_EULA", "Y");
-        return super.onPreStart(action);
-    }
 }

--- a/quarkus-test-service-infinispan/src/main/java/io/quarkus/test/bootstrap/InfinispanService.java
+++ b/quarkus-test-service-infinispan/src/main/java/io/quarkus/test/bootstrap/InfinispanService.java
@@ -17,6 +17,33 @@ public class InfinispanService extends BaseService<InfinispanService> {
     private String username = USERNAME_DEFAULT;
     private String password = PASSWORD_DEFAULT;
 
+    public InfinispanService() {
+        onPreStart(service -> {
+            service.withProperty("USER", getUsername());
+            service.withProperty("PASS", getPassword());
+
+            if (configFile != null && !configFile.isEmpty()) {
+                // legacy -> Infinispan previous to version 14
+                service.withProperty("CONFIG_PATH", RESOURCE_PREFIX + configFile);
+                // Infinispan 14+ configuration setup
+                service.withProperty("INFINISPAN_CONFIG_PATH",
+                        "resource_with_destination::/opt/infinispan/server/conf|" + configFile);
+            }
+
+            if (userConfigFiles != null) {
+                for (int index = 0; index < userConfigFiles.size(); index++) {
+                    service.withProperty("USER_CONFIG_" + index, RESOURCE_PREFIX + userConfigFiles.get(index));
+                }
+            }
+
+            if (secretFiles != null) {
+                for (int index = 0; index < secretFiles.size(); index++) {
+                    service.withProperty("SECRET_" + index, SECRET_PREFIX + secretFiles.get(index));
+                }
+            }
+        });
+    }
+
     public String getUsername() {
         return username;
     }
@@ -53,32 +80,5 @@ public class InfinispanService extends BaseService<InfinispanService> {
     public InfinispanService withPassword(String password) {
         this.password = password;
         return this;
-    }
-
-    @Override
-    public InfinispanService onPreStart(Action action) {
-        withProperty("USER", getUsername());
-        withProperty("PASS", getPassword());
-
-        if (configFile != null && !configFile.isEmpty()) {
-            // legacy -> Infinispan previous to version 14
-            withProperty("CONFIG_PATH", RESOURCE_PREFIX + configFile);
-            // Infinispan 14+ configuration setup
-            withProperty("INFINISPAN_CONFIG_PATH", "resource_with_destination::/opt/infinispan/server/conf|" + configFile);
-        }
-
-        if (userConfigFiles != null) {
-            for (int index = 0; index < userConfigFiles.size(); index++) {
-                withProperty("USER_CONFIG_" + index, RESOURCE_PREFIX + userConfigFiles.get(index));
-            }
-        }
-
-        if (secretFiles != null) {
-            for (int index = 0; index < secretFiles.size(); index++) {
-                withProperty("SECRET_" + index, SECRET_PREFIX + secretFiles.get(index));
-            }
-        }
-
-        return super.onPreStart(action);
     }
 }

--- a/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/model/KafkaVendor.java
+++ b/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/model/KafkaVendor.java
@@ -3,7 +3,7 @@ package io.quarkus.test.services.containers.model;
 public enum KafkaVendor {
     CONFLUENT("confluentinc/cp-kafka", "7.6.1", 9092, KafkaRegistry.CONFLUENT),
     // When updating strimzi kafka also update version in examples-kafka pom
-    STRIMZI("quay.io/strimzi/kafka", "0.45.0-kafka-3.9.0", 9092, KafkaRegistry.APICURIO);
+    STRIMZI("quay.io/strimzi/kafka", "0.47.0-kafka-4.0.0", 9092, KafkaRegistry.APICURIO);
 
     private final String image;
     private final String defaultVersion;

--- a/quarkus-test-service-kafka/src/main/resources/strimzi-deployment-template.yml
+++ b/quarkus-test-service-kafka/src/main/resources/strimzi-deployment-template.yml
@@ -29,8 +29,8 @@ items:
         #!/bin/bash
         set -euv
         KAFKA_CLUSTER_ID="$(/opt/kafka/bin/kafka-storage.sh random-uuid)"
-        /opt/kafka/bin/kafka-storage.sh format -t=${KAFKA_CLUSTER_ID} -c config/kraft/server.properties
-        /opt/kafka/bin/kafka-server-start.sh config/kraft/server.properties --override listeners=PLAINTEXT://0.0.0.0:${KAFKA_PORT},CONTROLLER://localhost:9093 --override advertised.listeners=PLAINTEXT://${SERVICE_NAME}:${KAFKA_PORT}
+        /opt/kafka/bin/kafka-storage.sh format -t=${KAFKA_CLUSTER_ID} -c config/server.properties --standalone
+        /opt/kafka/bin/kafka-server-start.sh config/server.properties --override listeners=PLAINTEXT://0.0.0.0:${KAFKA_PORT},CONTROLLER://localhost:9093 --override advertised.listeners=PLAINTEXT://${SERVICE_NAME}:${KAFKA_PORT}
   - apiVersion: "apps/v1"
     kind: "Deployment"
     metadata:

--- a/quarkus-test-service-kafka/src/main/resources/strimzi-operator-kafka-instance.yaml
+++ b/quarkus-test-service-kafka/src/main/resources/strimzi-operator-kafka-instance.yaml
@@ -29,7 +29,7 @@ metadata:
     strimzi.io/kraft: enabled
 spec:
   kafka:
-    version: 3.9.0
+    version: 4.0.0
     replicas: 1
     listeners:
       - name: plain


### PR DESCRIPTION
### Summary

Backports:
* https://github.com/quarkus-qe/quarkus-test-framework/pull/1682
* https://github.com/quarkus-qe/quarkus-test-framework/pull/1684

Also bumps Quarkus version to 3.26.4

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)