### PR TITLE
Allow to attach IDE to tested Quarkus application process

### DIFF
--- a/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/QuarkusScenarioBootstrap.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/QuarkusScenarioBootstrap.java
@@ -1,5 +1,6 @@
 package io.quarkus.test.bootstrap;
 
+import static io.quarkus.test.configuration.Configuration.Property.ATTACH_TO_PROCESS;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.reflect.Field;
@@ -337,6 +338,13 @@ public class QuarkusScenarioBootstrap
 
     private static TestContextImpl toTestContext(ExtensionContext ctx) {
         var testNamespace = ExtensionContext.Namespace.create(ScenarioContext.class);
-        return new TestContextImpl(ctx.getRequiredTestClass(), ctx.getTags(), ctx.getStore(testNamespace));
+        boolean attachToProcess = new PropertyLookup(ATTACH_TO_PROCESS.getName()).getAsBoolean();
+        final TestContext.DebugOptions debugOptions;
+        if (attachToProcess) {
+            debugOptions = new TestContext.DebugOptions(true, true);
+        } else {
+            debugOptions = null;
+        }
+        return new TestContextImpl(ctx.getRequiredTestClass(), ctx.getTags(), ctx.getStore(testNamespace), debugOptions);
     }
 }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/TestContext.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/TestContext.java
@@ -46,7 +46,7 @@ public interface TestContext {
             this.debugOptions = debugOptions;
         }
 
-        TestContextImpl(Class<?> requiredTestClass, Set<String> tags, ExtensionContext.Store store) {
+        TestContextImpl(Class<?> requiredTestClass, Set<String> tags, ExtensionContext.Store store, DebugOptions debugOptions) {
             this.testStore = new TestStore() {
                 @Override
                 public Object get(Object key) {
@@ -61,7 +61,7 @@ public interface TestContext {
             this.requiredTestClass = requiredTestClass;
             this.tags = tags;
             this.runningTestMethodName = null;
-            this.debugOptions = null;
+            this.debugOptions = debugOptions;
         }
 
         TestContextImpl(TestContext testContext, String runningTestMethodName) {

--- a/quarkus-test-core/src/main/java/io/quarkus/test/configuration/Configuration.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/configuration/Configuration.java
@@ -196,6 +196,7 @@ public final class Configuration {
         SKIP_BEFORE_AND_AFTER("debug.skip-before-and-after-methods"),
         RUN_TESTS("debug.run-tests"),
         SUSPEND("debug.suspend"),
+        ATTACH_TO_PROCESS("debug.attach-to-process"),
         DOCKER_DETECTION("docker-detection-enabled"),
         JAVA_ENABLE_PREVIEW("enable-java-preview"),
         IGNORE_KNOWN_ISSUE("global.ignore-known-issue"),


### PR DESCRIPTION
### Summary

Previously I have implemented this https://github.com/quarkus-qe/quarkus-test-framework/wiki/1.-Getting-Started#debugging, which is still useful at least for me (I use it, hence it is :grinning: ). But there are few downsides:

- it uses it's own SureFire provider, so there could be slight differences to the one you use without the `-Dts.debug` option like test order, missing execution of package-friendly test methods etc.
- it starts application and other resources (like databases) in environment you like (like OCP) and waits until you don't need it anymore (press enter), but if you just want to debug one test method and don't need application to hold etc. it is too much
- it doesn't cover every single scenario because it only implements what I needed (e.g. if test class has multiple Quarkus app then behavior is undefined)
- to execute tests and suspend you need many arguments (`-Dts.debug -Dts.global.debug.run-tests -Dts.global.debug.suspend`)

I'd like to add option to cover situations I am most often, which is that I need to execute one test method and just see what is happening from POV of Quarkus core project or tested app on localhost. Hence I am proposing to add new option. Documentation that I'd add to our Wiki would say this:

```
If the only thing you need is to debug localhost application in JVM when your test method is executed, you can use:
`mvn clean test -Dit.test=ReactiveGreetingResourceIT#shouldSayDefaultGreeting -Dts.global.debug.attach-to-process`. The `ts.global.debug.attach-to-process` system property will tell the Quarkus QE Test Framework to add the attach option to the `java` command.
```

I have been debugging Quarkus application that fails to start this morning and I missed this option. I don't really mind if I will be the only one using it :-)


Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)