### PR TITLE
[1.5.z] Update Quarkus to 3.15.7 + Backports

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -66,12 +66,12 @@ jobs:
           path: maven-repo.tgz
           retention-days: 1
   linux-build-jvm-released:
-    name: Linux - JVM build - 3.15.6
+    name: Linux - JVM build - 3.15.7
     runs-on: ubuntu-latest
     needs: validate-format
     strategy:
       matrix:
-        quarkus-version: ["3.15.6"]
+        quarkus-version: ["3.15.7"]
         java: [ 17 ]
     outputs:
       has-flaky-tests: ${{steps.flaky-test-detector.outputs.has-flaky-tests}}
@@ -186,7 +186,7 @@ jobs:
     needs: validate-format
     strategy:
       matrix:
-        quarkus-version: [ "3.15.6" ]
+        quarkus-version: [ "3.15.7" ]
         java: [ 17 ]
         examples: [
           'examples/pingpong,examples/restclient,examples/greetings,examples/blocking-reactive-model,examples/https,examples/grpc,examples/consul,examples/infinispan,examples/microprofile,examples/keycloak,examples/kafka,examples/kafka-registry,examples/kafka-streams',

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <impsort-maven-plugin.version>1.11.0</impsort-maven-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>3.15.6</quarkus.platform.version>
+        <quarkus.platform.version>3.15.7</quarkus.platform.version>
         <exclude.tests.with.tags>quarkus-cli</exclude.tests.with.tags>
         <include.tests>**/*IT.java</include.tests>
         <exclude.openshift.tests>**/OpenShift*IT.java</exclude.openshift.tests>
@@ -301,7 +301,7 @@
                     <dependency>
                         <artifactId>quarkus-ide-config</artifactId>
                         <groupId>io.quarkus</groupId>
-                        <version>3.15.6</version>
+                        <version>3.15.7</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/quarkus-test-openshift/src/main/resources/quarkus-build-openshift-template.yml
+++ b/quarkus-test-openshift/src/main/resources/quarkus-build-openshift-template.yml
@@ -96,7 +96,7 @@ items:
                 - name: "JAVA_APP_JAR"
                   value: "/deployments/${ARTIFACT}"
               image: "${IMAGE_NAME}"
-              imagePullPolicy: "IfNotPresent"
+              imagePullPolicy: "Always"
               name: "${SERVICE_NAME}"
               ports:
                 - containerPort: ${INTERNAL_PORT}


### PR DESCRIPTION
### Summary

- Update Quarkus to 3.15.7
- Backports https://github.com/quarkus-qe/quarkus-test-framework/pull/1654

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)