### PR TITLE
Fix Kube PR workflow

### DIFF
--- a/.github/workflows/kube-pr.yml
+++ b/.github/workflows/kube-pr.yml
@@ -1,4 +1,4 @@
-name: "PR"
+name: "PR Kubernetes"
 on:
   issue_comment:
     types: [ created ]
@@ -15,8 +15,20 @@ jobs:
       contains(github.event.comment.body, 'run kubernetes')
     outputs:
       comment_id: ${{ steps.create_comment.outputs.result }}
+      head_sha: ${{ steps.get_pr_sha.outputs.pr_sha }}
     steps:
-      - name: Comment PR with Link
+      - name: Get PR SHA
+        id: get_pr_sha
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+            core.setOutput('pr_sha', pr.data.head.sha);
+      - name: Add comment to PR with link
         id: create_comment
         uses: actions/github-script@v8
         with:
@@ -45,7 +57,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          ref: ${{ github.event.issue.pull_request.head.sha }}
+          ref: ${{ needs.write-comment.outputs.head_sha }}
       - name: Reclaim Disk Space
         run: .github/ci-prerequisites.sh
       - name: Install JDK ${{ matrix.java }}
@@ -95,7 +107,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          ref: ${{ github.event.issue.pull_request.head.sha }}
+          ref: ${{ needs.write-comment.outputs.head_sha }}
       - name: Reclaim Disk Space
         run: .github/ci-prerequisites.sh
       - name: Install JDK ${{ matrix.java }}
@@ -134,7 +146,7 @@ jobs:
     name: Update comment
     runs-on: ubuntu-latest
     needs: [ write-comment, kubernetes-build-jvm-latest, kubernetes-build-native-latest ]
-    if: always()
+    if: success() || failure()
     steps:
       - name: Update PR comment with status
         uses: actions/github-script@v8


### PR DESCRIPTION
### Summary

Fix the Kubernetes workflow for PR which was introduced in https://github.com/quarkus-qe/quarkus-test-framework/pull/1713

The workflow used the main branch instead of PR HEAD.
The update comment job was sometimes executed even when `run kubernetes` was not commented. This should be fixed by setting the `success() || failure()` instead of `always()` which is executed even when the needed jobs are skipped.

I tested with temporary created organization to be more like our workflow and the enabled test was executed so I believe this should work. Unfortunately it's not possible to run this workflow as it use the one which is on main.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against Kubernetes (use `run kubernetes` phrase in comment)
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)