### PR TITLE
Fix passing JVM system properties to RestService

### DIFF
--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/LocalhostQuarkusApplicationManagedResource.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/LocalhostQuarkusApplicationManagedResource.java
@@ -177,12 +177,12 @@ public abstract class LocalhostQuarkusApplicationManagedResource extends Quarkus
             runtimeProperties.putIfAbsent(QUARKUS_GRPC_SERVER_PORT_PROPERTY, "" + assignedGrpcPort);
         }
 
-        // Collect all properties and if some are JVM option properties (start with -X: or -XX:) the initial -D is not added
+        // Collect all properties and if some are JVM option properties (start with -X or -XX) the initial -D is not added
         // as they already contain the prefix for JVM. These properties should be fully in hand of user as some of them
         // can contain multiple `=`. Other properties are transformed to follow the format of `-D<key>=<value>`
         return runtimeProperties.entrySet().stream()
                 .map(e -> {
-                    if (e.getKey().startsWith("-X:") || e.getKey().startsWith("-XX:")) {
+                    if (e.getKey().startsWith("-X") || e.getKey().startsWith("-XX")) {
                         return PropertiesUtils.toJvmSystemProperty(e.getKey(), getComputedValue(e.getValue()));
                     }
                     return PropertiesUtils.toMvnSystemProperty(e.getKey(), getComputedValue(e.getValue()));

--- a/quarkus-test-core/src/main/java/io/quarkus/test/utils/PropertiesUtils.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/utils/PropertiesUtils.java
@@ -108,9 +108,20 @@ public final class PropertiesUtils {
                 + "=" + propertyValue;
     }
 
+    /**
+     * The JVM properties start with either `-X` or `-XX:`. The one which start with `-X` can have format like `-X<name>`
+     * or `-X<name>:<param>`. The name and param are separated by `:`, if the param is not set the `:` is not used.
+     *
+     * @param propertyKey
+     * @param propertyValue
+     * @return The formated value of JVM property
+     */
     public static String toJvmSystemProperty(String propertyKey, String propertyValue) {
+        if (propertyValue.isEmpty()) {
+            return (OS.WINDOWS.isCurrentOs() ? propertyKey.replace("\"", "\\\"") : propertyKey);
+        }
         return (OS.WINDOWS.isCurrentOs() ? propertyKey.replace("\"", "\\\"") : propertyKey)
-                + "=" + propertyValue;
+                + ":" + propertyValue;
     }
 
 }


### PR DESCRIPTION
### Summary

In https://github.com/quarkus-qe/quarkus-test-framework/pull/1789 I introduced the option to pass `-X/-XX` argument with FW RestService. After working on AoT coverage in TS I figure out that the logic introduce in https://github.com/quarkus-qe/quarkus-test-framework/pull/1789 is wrong.

The `-X` can be defined as `-X<name>` (`-Xdebug` and similar) or `-X<name>:<params>` (`-Xlog:aot`). Both variants don't pass the previous logic.
The `-XX` should look like as `-XX:<name>` or `-XX:<name>=<params>`. The 2nd option was coverage by the previous logic.

Now all option should be passed correctly. There can be some option about I don't know and have different format but we probably won't need them. But as I wrote previously in javadoc, these properties should be fully in hand of user as they can be complicated compared to maven properties.


Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against Kubernetes (use `run kubernetes` phrase in comment)
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)