### PR TITLE
Add quoting of GIT_REF and GIT_URI on Openshift

### DIFF
--- a/examples/external-applications/src/test/resources/uber-jar-quarkus-s2i-source-build-template.yml
+++ b/examples/external-applications/src/test/resources/uber-jar-quarkus-s2i-source-build-template.yml
@@ -20,8 +20,8 @@ items:
           name: ${APP_NAME}:latest
       source:
         git:
-          uri: ${GIT_URI}
-          ref: ${GIT_REF}
+          uri: "${GIT_URI}"
+          ref: "${GIT_REF}"
         type: Git
         contextDir: ${CONTEXT_DIR}
         configMaps:

--- a/quarkus-test-openshift/src/main/resources/quarkus-s2i-source-build-template.yml
+++ b/quarkus-test-openshift/src/main/resources/quarkus-s2i-source-build-template.yml
@@ -20,8 +20,8 @@ items:
           name: ${APP_NAME}:latest
       source:
         git:
-          uri: ${GIT_URI}
-          ref: ${GIT_REF}
+          uri: "${GIT_URI}"
+          ref: "${GIT_REF}"
         type: Git
         contextDir: ${CONTEXT_DIR}
         configMaps:


### PR DESCRIPTION
### Summary

Fixes #1817 

In some cases the GIT_REF was passed correctly but snakeyaml convert it to differnt value. Examle is 3.20 was converted as 3.2. Probably it was converted as number instead of string.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against Kubernetes (use `run kubernetes` phrase in comment)
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)