### PR TITLE
Bump strimzi-test-container to 0.115.0 and adjust the code

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <oracle.image>docker.io/gvenzl/oracle-free:23-slim-faststart</oracle.image>
         <postgresql.image>docker.io/library/postgres:18</postgresql.image>
         <mysql.image>docker.io/library/mysql:9.5</mysql.image>
-        <strimzi.testcontainers.version>0.113.0</strimzi.testcontainers.version>
+        <strimzi.testcontainers.version>0.115.0</strimzi.testcontainers.version>
         <infinispan.image>quay.io/infinispan/server:16.0</infinispan.image>
         <!-- TODO use official image if this fixed https://github.com/hashicorp/docker-consul/issues/184 -->
         <!-- We're not allowed to use newer consul version than 1.16.4 due to changed license -->

--- a/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/StrimziKafkaContainerManagedResource.java
+++ b/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/StrimziKafkaContainerManagedResource.java
@@ -18,8 +18,8 @@ import io.quarkus.test.security.certificate.Certificate;
 import io.quarkus.test.services.URILike;
 import io.quarkus.test.services.containers.model.KafkaProtocol;
 import io.quarkus.test.services.containers.model.KafkaVendor;
-import io.quarkus.test.services.containers.strimzi.ExtendedStrimziKafkaContainer;
 import io.quarkus.test.utils.DockerUtils;
+import io.strimzi.test.container.ExtendedStrimziKafkaContainer;
 
 public class StrimziKafkaContainerManagedResource extends BaseKafkaContainerManagedResource {
 

--- a/quarkus-test-service-kafka/src/main/java/io/strimzi/test/container/ExtendedStrimziKafkaContainer.java
+++ b/quarkus-test-service-kafka/src/main/java/io/strimzi/test/container/ExtendedStrimziKafkaContainer.java
@@ -1,4 +1,4 @@
-package io.quarkus.test.services.containers.strimzi;
+package io.strimzi.test.container;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -11,7 +11,6 @@ import com.github.dockerjava.api.command.InspectContainerResponse;
 import io.quarkus.test.logging.Log;
 import io.quarkus.test.services.containers.model.KafkaVendor;
 import io.smallrye.mutiny.tuples.Tuple2;
-import io.strimzi.test.container.StrimziKafkaContainer;
 
 /**
  * Extend the functionality of io.strimzi.StrimziKafkaContainer with:
@@ -74,7 +73,7 @@ public class ExtendedStrimziKafkaContainer extends StrimziKafkaContainer {
      * since config/kraft/server.properties contains node.id=1, we have to use this value
      */
     public ExtendedStrimziKafkaContainer enableKraftMode() {
-        return (ExtendedStrimziKafkaContainer) super.withNodeId(1).withBrokerId(1);
+        return (ExtendedStrimziKafkaContainer) super.withNodeId(1);
     }
 
     public void configureScram(String name, String password) {


### PR DESCRIPTION
### Summary

Bump strimzi-test-container to 0.115.0 and adjust the code

Breaking changes:
 * https://github.com/strimzi/test-container/pull/176
 * https://github.com/strimzi/test-container/pull/170

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against Kubernetes (use `run kubernetes` phrase in comment)
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)