### PR TITLE
Add management tls

### DIFF
--- a/examples/management/src/test/java/io/quarkus/qe/LocalTLSIT.java
+++ b/examples/management/src/test/java/io/quarkus/qe/LocalTLSIT.java
@@ -14,7 +14,7 @@ import io.restassured.response.Response;
 // todo Merge with LocalIT when framework support SSL/TLS on openshift https://github.com/quarkus-qe/quarkus-test-framework/issues/1052
 public class LocalTLSIT {
 
-    @QuarkusApplication(certificates = @Certificate(configureManagementInterface = true, configureKeystore = true, useTlsRegistry = false))
+    @QuarkusApplication(certificates = @Certificate(configureManagementInterface = true, configureKeystore = true, useTlsRegistry = false), ssl = true)
     static final RestService service = new RestService()
             .withProperty("quarkus.management.port", "9003");
 

--- a/examples/management/src/test/java/io/quarkus/qe/OpenShiftTLSIT.java
+++ b/examples/management/src/test/java/io/quarkus/qe/OpenShiftTLSIT.java
@@ -1,11 +1,8 @@
 package io.quarkus.qe;
 
-import org.junit.jupiter.api.Disabled;
-
 import io.quarkus.test.scenarios.OpenShiftScenario;
 
 @OpenShiftScenario
-@Disabled("https://github.com/quarkus-qe/quarkus-test-framework/issues/1052")
 // todo delete when framework support SSL/TLS on openshift
 public class OpenShiftTLSIT extends LocalTLSIT {
 }

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
@@ -113,6 +113,7 @@ public final class OpenShiftClient {
     public static final PropertyLookup ENABLED_EPHEMERAL_NAMESPACES = new PropertyLookup(
             OPENSHIFT_EPHEMERAL_NAMESPACES.getName(), Boolean.TRUE.toString());
     public static final String TLS_ROUTE_SUFFIX = "-tls";
+    public static final String TLS_MANAGEMENT_ROUTE_SUFFIX = "-tls-management";
     private static final String DOT = ".";
     private static final Logger LOG = Logger.getLogger(OpenShiftClient.class);
 

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/BuildOpenShiftQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/BuildOpenShiftQuarkusApplicationManagedResource.java
@@ -1,5 +1,6 @@
 package io.quarkus.test.services.quarkus;
 
+import static io.quarkus.test.bootstrap.inject.OpenShiftClient.TLS_MANAGEMENT_ROUTE_SUFFIX;
 import static io.quarkus.test.services.quarkus.QuarkusApplicationManagedResourceBuilder.HTTP_PORT_DEFAULT;
 import static io.quarkus.test.services.quarkus.model.QuarkusProperties.QUARKUS_JVM_S2I;
 import static io.quarkus.test.services.quarkus.model.QuarkusProperties.QUARKUS_NATIVE_S2I;
@@ -119,6 +120,13 @@ public class BuildOpenShiftQuarkusApplicationManagedResource
     private void exposeServices() {
         client.expose(model.getContext().getOwner(), HTTP_PORT_DEFAULT);
         client.expose(model.getContext().getOwner().getName() + "-management", model.getManagementPort());
+        if (model.isSslEnabled() && model.useSeparateManagementInterface()) {
+            client.exposeDeploymentPort(model.getContext().getName(), "mgmt-https", model.getManagementPort());
+            client.createService(model.getContext().getName(),
+                    model.getContext().getName() + TLS_MANAGEMENT_ROUTE_SUFFIX, model.getManagementPort());
+            client.createTlsPassthroughRoute(model.getContext().getOwner().getName() + TLS_MANAGEMENT_ROUTE_SUFFIX,
+                    model.getContext().getOwner().getName() + TLS_MANAGEMENT_ROUTE_SUFFIX, model.getManagementPort());
+        }
     }
 
     private void startBuild() {

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftQuarkusApplicationCertificateConfigurator.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftQuarkusApplicationCertificateConfigurator.java
@@ -1,5 +1,6 @@
 package io.quarkus.test.services.quarkus;
 
+import static io.quarkus.test.bootstrap.inject.OpenShiftClient.TLS_MANAGEMENT_ROUTE_SUFFIX;
 import static io.quarkus.test.bootstrap.inject.OpenShiftClient.TLS_ROUTE_SUFFIX;
 import static io.quarkus.test.security.certificate.ServingCertificateConfig.SERVING_CERTIFICATE_KEY;
 
@@ -104,7 +105,9 @@ public abstract class OpenShiftQuarkusApplicationCertificateConfigurator {
         return Arrays.asList(
                 // add SAN for service
                 appName + TLS_ROUTE_SUFFIX,
+                appName + TLS_MANAGEMENT_ROUTE_SUFFIX,
                 // add SAN for route
-                client.predictRouteHost(appName + TLS_ROUTE_SUFFIX));
+                client.predictRouteHost(appName + TLS_ROUTE_SUFFIX),
+                client.predictRouteHost(appName + TLS_MANAGEMENT_ROUTE_SUFFIX));
     }
 }

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftQuarkusApplicationManagedResource.java
@@ -1,5 +1,6 @@
 package io.quarkus.test.services.quarkus;
 
+import static io.quarkus.test.bootstrap.inject.OpenShiftClient.TLS_MANAGEMENT_ROUTE_SUFFIX;
 import static io.quarkus.test.bootstrap.inject.OpenShiftClient.TLS_ROUTE_SUFFIX;
 import static io.quarkus.test.openshift.utils.OpenShiftPropertiesUtils.CA_BUNDLE_CONFIGMAP_NAME;
 import static io.quarkus.test.openshift.utils.OpenShiftPropertiesUtils.EXTERNAL_SSL_PORT;
@@ -109,7 +110,8 @@ public abstract class OpenShiftQuarkusApplicationManagedResource<T extends Quark
             fail("gRPC is not supported for OpenShift tests yet");
         } else if (protocol == Protocol.MANAGEMENT && model.useSeparateManagementInterface()) {
             if (model.useManagementSsl()) {
-                fail("SSL is not supported for management on OpenShift tests yet");
+                return client.url(context.getOwner().getName() + TLS_MANAGEMENT_ROUTE_SUFFIX)
+                        .withPort(EXTERNAL_SSL_PORT).withScheme(Protocol.HTTPS.getValue());
             }
             return client.url(context.getOwner().getName() + "-management").withPort(EXTERNAL_PORT);
         }


### PR DESCRIPTION
### Summary

Fixes https://github.com/quarkus-qe/quarkus-test-framework/issues/1638

atm it's draft as I think this should implement the `SslEnabledManagement` as the could be need to just have tls app port but non tls management port

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against Kubernetes (use `run kubernetes` phrase in comment)
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)