### PR TITLE
Change name for repository check when the java certs should be replaced

### DIFF
--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftS2iGitRepositoryQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftS2iGitRepositoryQuarkusApplicationManagedResource.java
@@ -153,7 +153,8 @@ public class OpenShiftS2iGitRepositoryQuarkusApplicationManagedResource
         String replaceJavaCaCertsAsString = REPLACE_JAVA_CA_CERTS.get(model.getContext());
         if (replaceJavaCaCertsAsString == null || replaceJavaCaCertsAsString.isEmpty()) {
             // property not set; by default recognize own repository so that we don't need to set it everywhere
-            return remoteRepo.contains("eng.redhat.com") || remoteRepo.contains("engineering.redhat.com");
+            return remoteRepo.contains("eng.redhat.com") || remoteRepo.contains("engineering.redhat.com")
+                    || remoteRepo.contains("corp.redhat.com");
         }
         return Boolean.parseBoolean(replaceJavaCaCertsAsString);
     }


### PR DESCRIPTION
### Summary

Since we switch internal repository, the jobs which using `ts.global.s2i.maven.remote.repository` start throwing 
```
Could not transfer artifact io.quarkus:quarkus-bom:pom:999-SNAPSHOT from/to internal.s2i.maven.remote.repository.mirror (https://redacted):
 (certificate_unknown) PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target
```

Back in the day there there were same problems and the https://github.com/quarkus-qe/quarkus-test-framework/pull/1453 was created to fix it. As we changed the repository we need to update the string check.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against Kubernetes (use `run kubernetes` phrase in comment)
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)