### PR TITLE
Use quarkus as default packaging

### DIFF
--- a/checkstyle-suppressions.xml
+++ b/checkstyle-suppressions.xml
@@ -7,5 +7,5 @@
 <suppressions>
     <suppress checks="LineLength"
               files="PreparePomMojo.java"
-              lines="32"/>
+              lines="34"/>
 </suppressions>

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,0 +1,9 @@
+# Quarkus test preparer
+
+Prepares source directory for applications build in quarkus testing.
+In particular it prepares custom `pom.xml` based on template from this module.
+
+## Packaging
+By default, test preparer creates apps with packaging `quarkus`.
+It will ignore `packaging` attribute set in the tested project. 
+To override this behaviour in your project, set property `ts.packaging` to the packaging you want.

--- a/plugins/test-preparer/src/main/java/io/quarkus/test/plugin/preparer/PreparePomMojo.java
+++ b/plugins/test-preparer/src/main/java/io/quarkus/test/plugin/preparer/PreparePomMojo.java
@@ -11,6 +11,8 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
@@ -54,6 +56,7 @@ public class PreparePomMojo extends AbstractMojo {
     private static final String IO_QUARKUS_QE = "io.quarkus.qe";
     private static final String FAILSAFE_PLUGIN_VERSION = "failsafe-plugin.version";
     private static final String SUREFIRE_PLUGIN_VERSION = "surefire-plugin.version";
+    private static final String PACKAGING_OVERRIDING_PROPERTY = "ts.packaging";
     /**
      * Properties to propagate to the target POM file.
      */
@@ -80,6 +83,7 @@ public class PreparePomMojo extends AbstractMojo {
         var newPomModel = getNewPomMavenModel();
         newPomModel.setArtifactId(project.getArtifactId());
         newPomModel.setVersion(project.getVersion());
+        overridePackaging(newPomModel, project);
         addCurrentProjectDependencies(newPomModel, rawCurrentProjectModel, project);
         addCurrentProjectPlugins(newPomModel, rawCurrentProjectModel, project);
         addCurrentProjectRepositories(newPomModel, rawCurrentProjectModel);
@@ -187,6 +191,27 @@ public class PreparePomMojo extends AbstractMojo {
             }
 
             newPomModel.addDependency(dependency);
+        }
+    }
+
+    /**
+     * We're using packaging "quarkus" by default, set in the pom template.
+     * We want to use "quarkus" packaging unless explicitly stated otherwise.
+     * We cannot ask for "project.getPackaging()" because that will always have "jar" by default,
+     * and we want "quarkus" as default.
+     * Also remove quarkus-maven-plugin "executions" goals, as those are not required for quarkus packaging
+     */
+    private static void overridePackaging(Model newPomModel, MavenProject project) {
+        String overridingPackagingProperty = project.getProperties().getProperty(PACKAGING_OVERRIDING_PROPERTY);
+        if (overridingPackagingProperty != null) {
+            newPomModel.setPackaging(overridingPackagingProperty);
+        }
+        // packaging other that "quarkus" should also have execution goals for quarkus-maven-plugin
+        if (overridingPackagingProperty != null && !overridingPackagingProperty.equals("quarkus")) {
+            PluginExecution pluginExecution = new PluginExecution();
+            pluginExecution.setGoals(Arrays.asList("build", "generate-code", "generate-code-tests", "native-image-agent"));
+            newPomModel.getBuild().getPlugins().stream().filter(p -> p.getArtifactId().equals("quarkus-maven-plugin"))
+                    .findFirst().get().setExecutions(List.of(pluginExecution));
         }
     }
 

--- a/plugins/test-preparer/src/main/resources/quarkus-app-pom.xml
+++ b/plugins/test-preparer/src/main/resources/quarkus-app-pom.xml
@@ -5,6 +5,7 @@
 	<groupId>io.quarkus.qe.test.app</groupId>
 	<artifactId>{{must-be-replaced}}</artifactId>
 	<version>1.0.0-SNAPSHOT</version>
+    <packaging>quarkus</packaging>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -43,16 +44,6 @@
 				<artifactId>quarkus-maven-plugin</artifactId>
 				<version>$REPLACE{quarkus.platform.version}</version>
 				<extensions>true</extensions>
-				<executions>
-					<execution>
-						<goals>
-							<goal>build</goal>
-							<goal>generate-code</goal>
-							<goal>generate-code-tests</goal>
-							<goal>native-image-agent</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
### Summary

Use "quarkus" packaging as default. All apps that doesn't override the packaging, will use "quarkus" packaging as default.

I've introduced a new property `ts.packaging`, for cases when we want to manually override this packaging. We cannot rely on `packaging` attribute from the project as that will always have "jar" by default (even if not set) and we only want to override packaging, if explicitly meant to.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against Kubernetes (use `run kubernetes` phrase in comment)
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)