### PR TITLE
Bump Kafka version to aling with client in Quarkus

### DIFF
--- a/examples/kafka/pom.xml
+++ b/examples/kafka/pom.xml
@@ -52,7 +52,7 @@
                         <configuration>
                             <systemPropertyVariables>
                                 <custom.kafka.image>quay.io/strimzi/kafka</custom.kafka.image>
-                                <custom.kafka.version>0.47.0-kafka-4.0.0</custom.kafka.version>
+                                <custom.kafka.version>0.51.0-kafka-4.1.1 </custom.kafka.version>
                             </systemPropertyVariables>
                         </configuration>
                     </execution>

--- a/examples/kafka/src/test/java/io/quarkus/qe/OpenShiftStrimziOperatorKafkaWithoutRegistryMessagingIT.java
+++ b/examples/kafka/src/test/java/io/quarkus/qe/OpenShiftStrimziOperatorKafkaWithoutRegistryMessagingIT.java
@@ -15,7 +15,8 @@ import io.quarkus.test.services.operator.KafkaInstance;
 @OpenShiftScenario
 public class OpenShiftStrimziOperatorKafkaWithoutRegistryMessagingIT {
 
-    @Operator(name = "strimzi-kafka-operator")
+    // TODO: Update when OCP 4.14 is unsupported; this is the last version that works on OCP 4.14
+    @Operator(name = "strimzi-kafka-operator", channel = "strimzi-0.50.x")
     static final KafkaInstance kafka = new KafkaInstance();
 
     @QuarkusApplication

--- a/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/model/KafkaVendor.java
+++ b/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/model/KafkaVendor.java
@@ -3,7 +3,7 @@ package io.quarkus.test.services.containers.model;
 public enum KafkaVendor {
     CONFLUENT("confluentinc/cp-kafka", "7.7.7", 9092, KafkaRegistry.CONFLUENT),
     // When updating strimzi kafka also update version in examples-kafka pom
-    STRIMZI("quay.io/strimzi/kafka", "0.47.0-kafka-4.0.0", 9092, KafkaRegistry.APICURIO);
+    STRIMZI("quay.io/strimzi/kafka", "0.51.0-kafka-4.1.1", 9092, KafkaRegistry.APICURIO);
 
     private final String image;
     private final String defaultVersion;

--- a/quarkus-test-service-kafka/src/main/resources/strimzi-operator-kafka-instance.yaml
+++ b/quarkus-test-service-kafka/src/main/resources/strimzi-operator-kafka-instance.yaml
@@ -29,7 +29,7 @@ metadata:
     strimzi.io/kraft: enabled
 spec:
   kafka:
-    version: 4.0.0
+    version: 4.1.1
     replicas: 1
     listeners:
       - name: plain


### PR DESCRIPTION
### Summary

* Bumping used containers and operators to use the same Kafka version as the current Quarkus main Kafka client, which is 4.1.1.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against Kubernetes (use `run kubernetes` phrase in comment)
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)