### PR TITLE
[1.8.z] Backport + bump of Quarkus 

### DIFF
--- a/checkstyle-suppressions.xml
+++ b/checkstyle-suppressions.xml
@@ -7,5 +7,5 @@
 <suppressions>
     <suppress checks="LineLength"
               files="PreparePomMojo.java"
-              lines="32"/>
+              lines="34"/>
 </suppressions>

--- a/examples/amq-tcp/pom.xml
+++ b/examples/amq-tcp/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>io.quarkiverse.artemis</groupId>
             <artifactId>quarkus-artemis-jms</artifactId>
-            <version>3.12.2</version>
+            <version>3.14.0</version>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/examples/kafka/pom.xml
+++ b/examples/kafka/pom.xml
@@ -52,7 +52,7 @@
                         <configuration>
                             <systemPropertyVariables>
                                 <custom.kafka.image>quay.io/strimzi/kafka</custom.kafka.image>
-                                <custom.kafka.version>0.47.0-kafka-4.0.0</custom.kafka.version>
+                                <custom.kafka.version>0.51.0-kafka-4.1.1 </custom.kafka.version>
                             </systemPropertyVariables>
                         </configuration>
                     </execution>

--- a/examples/kafka/src/test/java/io/quarkus/qe/OpenShiftStrimziOperatorKafkaWithoutRegistryMessagingIT.java
+++ b/examples/kafka/src/test/java/io/quarkus/qe/OpenShiftStrimziOperatorKafkaWithoutRegistryMessagingIT.java
@@ -15,7 +15,8 @@ import io.quarkus.test.services.operator.KafkaInstance;
 @OpenShiftScenario
 public class OpenShiftStrimziOperatorKafkaWithoutRegistryMessagingIT {
 
-    @Operator(name = "strimzi-kafka-operator")
+    // TODO: Update when OCP 4.14 is unsupported; this is the last version that works on OCP 4.14
+    @Operator(name = "strimzi-kafka-operator", channel = "strimzi-0.50.x")
     static final KafkaInstance kafka = new KafkaInstance();
 
     @QuarkusApplication

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,0 +1,9 @@
+# Quarkus test preparer
+
+Prepares source directory for applications build in quarkus testing.
+In particular it prepares custom `pom.xml` based on template from this module.
+
+## Packaging
+By default, test preparer creates apps with packaging `quarkus`.
+It will ignore `packaging` attribute set in the tested project. 
+To override this behaviour in your project, set property `ts.packaging` to the packaging you want.

--- a/plugins/test-preparer/src/main/java/io/quarkus/test/plugin/preparer/PreparePomMojo.java
+++ b/plugins/test-preparer/src/main/java/io/quarkus/test/plugin/preparer/PreparePomMojo.java
@@ -38,7 +38,7 @@ public class PreparePomMojo extends AbstractMojo {
     private static final boolean SKIP_INTEGRATION_TESTS = Boolean.getBoolean("skipITs");
     // this needs to be system property, it is too early for FW configuration
     private static final Set<String> PROPAGATED_ANNOTATION_PROCESSOR_ARTIFACTS = Set.of("hibernate-processor",
-            "hibernate-search-processor");
+            "hibernate-search-processor", "protostream-processor");
     private static final String TARGET_POM = "quarkus-app-pom.xml";
     private static final String MAVEN_COMPILER_RELEASE = "maven.compiler.release";
     private static final String PROPERTY_START = "\\${";

--- a/plugins/test-preparer/src/main/java/io/quarkus/test/plugin/preparer/PreparePomMojo.java
+++ b/plugins/test-preparer/src/main/java/io/quarkus/test/plugin/preparer/PreparePomMojo.java
@@ -11,6 +11,8 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
@@ -54,6 +56,7 @@ public class PreparePomMojo extends AbstractMojo {
     private static final String IO_QUARKUS_QE = "io.quarkus.qe";
     private static final String FAILSAFE_PLUGIN_VERSION = "failsafe-plugin.version";
     private static final String SUREFIRE_PLUGIN_VERSION = "surefire-plugin.version";
+    private static final String PACKAGING_OVERRIDING_PROPERTY = "ts.packaging";
     /**
      * Properties to propagate to the target POM file.
      */
@@ -80,6 +83,7 @@ public class PreparePomMojo extends AbstractMojo {
         var newPomModel = getNewPomMavenModel();
         newPomModel.setArtifactId(project.getArtifactId());
         newPomModel.setVersion(project.getVersion());
+        overridePackaging(newPomModel, project);
         addCurrentProjectDependencies(newPomModel, rawCurrentProjectModel, project);
         addCurrentProjectPlugins(newPomModel, rawCurrentProjectModel, project);
         addCurrentProjectRepositories(newPomModel, rawCurrentProjectModel);
@@ -187,6 +191,27 @@ public class PreparePomMojo extends AbstractMojo {
             }
 
             newPomModel.addDependency(dependency);
+        }
+    }
+
+    /**
+     * We're using packaging "quarkus" by default, set in the pom template.
+     * We want to use "quarkus" packaging unless explicitly stated otherwise.
+     * We cannot ask for "project.getPackaging()" because that will always have "jar" by default,
+     * and we want "quarkus" as default.
+     * Also remove quarkus-maven-plugin "executions" goals, as those are not required for quarkus packaging
+     */
+    private static void overridePackaging(Model newPomModel, MavenProject project) {
+        String overridingPackagingProperty = project.getProperties().getProperty(PACKAGING_OVERRIDING_PROPERTY);
+        if (overridingPackagingProperty != null) {
+            newPomModel.setPackaging(overridingPackagingProperty);
+        }
+        // packaging other that "quarkus" should also have execution goals for quarkus-maven-plugin
+        if (overridingPackagingProperty != null && !overridingPackagingProperty.equals("quarkus")) {
+            PluginExecution pluginExecution = new PluginExecution();
+            pluginExecution.setGoals(Arrays.asList("build", "generate-code", "generate-code-tests", "native-image-agent"));
+            newPomModel.getBuild().getPlugins().stream().filter(p -> p.getArtifactId().equals("quarkus-maven-plugin"))
+                    .findFirst().get().setExecutions(List.of(pluginExecution));
         }
     }
 

--- a/plugins/test-preparer/src/main/resources/quarkus-app-pom.xml
+++ b/plugins/test-preparer/src/main/resources/quarkus-app-pom.xml
@@ -5,6 +5,7 @@
 	<groupId>io.quarkus.qe.test.app</groupId>
 	<artifactId>{{must-be-replaced}}</artifactId>
 	<version>1.0.0-SNAPSHOT</version>
+    <packaging>quarkus</packaging>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -43,16 +44,6 @@
 				<artifactId>quarkus-maven-plugin</artifactId>
 				<version>$REPLACE{quarkus.platform.version}</version>
 				<extensions>true</extensions>
-				<executions>
-					<execution>
-						<goals>
-							<goal>build</goal>
-							<goal>generate-code</goal>
-							<goal>generate-code-tests</goal>
-							<goal>native-image-agent</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>3.32.3</quarkus.platform.version>
+        <quarkus.platform.version>3.33.1</quarkus.platform.version>
         <exclude.tests.with.tags>quarkus-cli</exclude.tests.with.tags>
         <include.tests>**/*IT.java</include.tests>
         <exclude.openshift.tests>**/OpenShift*IT.java</exclude.openshift.tests>

--- a/quarkus-test-core/src/test/resources/quarkus-app-pom.xml
+++ b/quarkus-test-core/src/test/resources/quarkus-app-pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <maven.compiler.release>17</maven.compiler.release>
     <surefire-plugin.version>3.5.4</surefire-plugin.version>
-    <quarkus.platform.version>3.32.3</quarkus.platform.version>
+    <quarkus.platform.version>3.33.1</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <failsafe-plugin.version>3.5.4</failsafe-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftS2iGitRepositoryQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftS2iGitRepositoryQuarkusApplicationManagedResource.java
@@ -34,6 +34,7 @@ public class OpenShiftS2iGitRepositoryQuarkusApplicationManagedResource
     private static final PropertyLookup QUARKUS_NATIVE_S2I_FROM_SRC = new PropertyLookup(
             S2I_BASE_NATIVE_IMAGE.getName(),
             "quay.io/quarkus/ubi9-quarkus-graalvmce-s2i:jdk-25");
+    private static final String QUARKUS_SOURCE_S2I_NATIVE_BUILD_PROPERTIES = "-Dquarkus.native.native-image-xmx=5g";
 
     private final GitRepositoryQuarkusApplicationManagedResourceBuilder model;
 
@@ -89,6 +90,7 @@ public class OpenShiftS2iGitRepositoryQuarkusApplicationManagedResource
     protected String replaceDeploymentContent(String content) {
         String quarkusPlatformVersion = QuarkusProperties.getVersion();
         String quarkusS2iBaseImage = getQuarkusS2iBaseImage();
+        String quarkusSourceS2iBuildNativeProperties = isNativeTest() ? QUARKUS_SOURCE_S2I_NATIVE_BUILD_PROPERTIES : "";
         String mavenArgs = model.getMavenArgsWithVersion();
 
         return content.replaceAll(quote("${APP_NAME}"), model.getContext().getOwner().getName())
@@ -98,6 +100,7 @@ public class OpenShiftS2iGitRepositoryQuarkusApplicationManagedResource
                 .replaceAll(quote("${CONTEXT_DIR}"), model.getContextDir())
                 .replaceAll(quote("${GIT_MAVEN_ARGS}"), mavenArgs)
                 .replaceAll(quote("${CURRENT_NAMESPACE}"), client.project())
+                .replaceAll(quote("${QUARKUS_SOURCE_S2I_NATIVE_BUILD_PROPERTIES}"), quarkusSourceS2iBuildNativeProperties)
                 .replaceAll(quote(QUARKUS_PLATFORM_GROUP_ID_PROPERTY), PLATFORM_GROUP_ID.get())
                 .replaceAll(quote(QUARKUS_PLATFORM_VERSION_PROPERTY), quarkusPlatformVersion);
     }

--- a/quarkus-test-openshift/src/main/resources/quarkus-s2i-source-build-template.yml
+++ b/quarkus-test-openshift/src/main/resources/quarkus-s2i-source-build-template.yml
@@ -36,7 +36,7 @@ items:
         sourceStrategy:
           env:
             - name: MAVEN_ARGS
-              value: -s /configuration/settings.xml ${GIT_MAVEN_ARGS} -Dquarkus.platform.version=${QUARKUS_PLATFORM_VERSION} -Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus-plugin.version=${QUARKUS_PLATFORM_VERSION} -Djavax.net.ssl.trustStore=/etc/pki/java/cacerts
+              value: -s /configuration/settings.xml ${GIT_MAVEN_ARGS} -Dquarkus.platform.version=${QUARKUS_PLATFORM_VERSION} -Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus-plugin.version=${QUARKUS_PLATFORM_VERSION} -Djavax.net.ssl.trustStore=/etc/pki/java/cacerts ${QUARKUS_SOURCE_S2I_NATIVE_BUILD_PROPERTIES}
           from:
             kind: DockerImage
             name: ${QUARKUS_S2I_BUILDER_IMAGE}

--- a/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/model/KafkaVendor.java
+++ b/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/containers/model/KafkaVendor.java
@@ -3,7 +3,7 @@ package io.quarkus.test.services.containers.model;
 public enum KafkaVendor {
     CONFLUENT("confluentinc/cp-kafka", "7.7.7", 9092, KafkaRegistry.CONFLUENT),
     // When updating strimzi kafka also update version in examples-kafka pom
-    STRIMZI("quay.io/strimzi/kafka", "0.47.0-kafka-4.0.0", 9092, KafkaRegistry.APICURIO);
+    STRIMZI("quay.io/strimzi/kafka", "0.51.0-kafka-4.1.1", 9092, KafkaRegistry.APICURIO);
 
     private final String image;
     private final String defaultVersion;

--- a/quarkus-test-service-kafka/src/main/resources/strimzi-operator-kafka-instance.yaml
+++ b/quarkus-test-service-kafka/src/main/resources/strimzi-operator-kafka-instance.yaml
@@ -29,7 +29,7 @@ metadata:
     strimzi.io/kraft: enabled
 spec:
   kafka:
-    version: 4.0.0
+    version: 4.1.1
     replicas: 1
     listeners:
       - name: plain


### PR DESCRIPTION
### Summary

Bumping Quarkus to 3.33.1

Backport of:
* https://github.com/quarkus-qe/quarkus-test-framework/pull/1854
* https://github.com/quarkus-qe/quarkus-test-framework/pull/1856
* https://github.com/quarkus-qe/quarkus-test-framework/pull/1861
* https://github.com/quarkus-qe/quarkus-test-framework/pull/1874
* https://github.com/quarkus-qe/quarkus-test-framework/pull/1876

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Dependency update
- [x] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against Kubernetes (use `run kubernetes` phrase in comment)
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)