### PR TITLE
Pin xmx to 4g for native source s2i builds

### DIFF
--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftS2iGitRepositoryQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftS2iGitRepositoryQuarkusApplicationManagedResource.java
@@ -34,6 +34,7 @@ public class OpenShiftS2iGitRepositoryQuarkusApplicationManagedResource
     private static final PropertyLookup QUARKUS_NATIVE_S2I_FROM_SRC = new PropertyLookup(
             S2I_BASE_NATIVE_IMAGE.getName(),
             "quay.io/quarkus/ubi9-quarkus-graalvmce-s2i:jdk-25");
+    private static final String QUARKUS_SOURCE_S2I_NATIVE_BUILD_PROPERTIES = "-Dquarkus.native.native-image-xmx=5g";
 
     private final GitRepositoryQuarkusApplicationManagedResourceBuilder model;
 
@@ -89,6 +90,7 @@ public class OpenShiftS2iGitRepositoryQuarkusApplicationManagedResource
     protected String replaceDeploymentContent(String content) {
         String quarkusPlatformVersion = QuarkusProperties.getVersion();
         String quarkusS2iBaseImage = getQuarkusS2iBaseImage();
+        String quarkusSourceS2iBuildNativeProperties = isNativeTest() ? QUARKUS_SOURCE_S2I_NATIVE_BUILD_PROPERTIES : "";
         String mavenArgs = model.getMavenArgsWithVersion();
 
         return content.replaceAll(quote("${APP_NAME}"), model.getContext().getOwner().getName())
@@ -98,6 +100,7 @@ public class OpenShiftS2iGitRepositoryQuarkusApplicationManagedResource
                 .replaceAll(quote("${CONTEXT_DIR}"), model.getContextDir())
                 .replaceAll(quote("${GIT_MAVEN_ARGS}"), mavenArgs)
                 .replaceAll(quote("${CURRENT_NAMESPACE}"), client.project())
+                .replaceAll(quote("${QUARKUS_SOURCE_S2I_NATIVE_BUILD_PROPERTIES}"), quarkusSourceS2iBuildNativeProperties)
                 .replaceAll(quote(QUARKUS_PLATFORM_GROUP_ID_PROPERTY), PLATFORM_GROUP_ID.get())
                 .replaceAll(quote(QUARKUS_PLATFORM_VERSION_PROPERTY), quarkusPlatformVersion);
     }

--- a/quarkus-test-openshift/src/main/resources/quarkus-s2i-source-build-template.yml
+++ b/quarkus-test-openshift/src/main/resources/quarkus-s2i-source-build-template.yml
@@ -36,7 +36,7 @@ items:
         sourceStrategy:
           env:
             - name: MAVEN_ARGS
-              value: -s /configuration/settings.xml ${GIT_MAVEN_ARGS} -Dquarkus.platform.version=${QUARKUS_PLATFORM_VERSION} -Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus-plugin.version=${QUARKUS_PLATFORM_VERSION} -Djavax.net.ssl.trustStore=/etc/pki/java/cacerts
+              value: -s /configuration/settings.xml ${GIT_MAVEN_ARGS} -Dquarkus.platform.version=${QUARKUS_PLATFORM_VERSION} -Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus-plugin.version=${QUARKUS_PLATFORM_VERSION} -Djavax.net.ssl.trustStore=/etc/pki/java/cacerts ${QUARKUS_SOURCE_S2I_NATIVE_BUILD_PROPERTIES}
           from:
             kind: DockerImage
             name: ${QUARKUS_S2I_BUILDER_IMAGE}


### PR DESCRIPTION
### Summary

* Otherwise the pod allocates all the memory on the node in OCP/Kube and kills the cluster.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against Kubernetes (use `run kubernetes` phrase in comment)
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)