### PR TITLE
Drop ubi-quarkus-mandrel-builder-image:jdk-21 usage

### DIFF
--- a/.github/workflows/kube-pr.yml
+++ b/.github/workflows/kube-pr.yml
@@ -96,9 +96,6 @@ jobs:
         include:
           - quarkus-version: "999-SNAPSHOT"
             java: 21
-          - quarkus-version: "999-SNAPSHOT"
-            java: 21 # test 'quarkus-container-image-jib' with images based on UBI8 and Java 21
-            extra-maven-args: '-pl examples/pingpong/ -Dtest-ubi8-compatibility -Dquarkus.jib.base-native-image=quay.io/quarkus/quarkus-micro-image:2.0 -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-21'
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
### Summary

Drop ubi-quarkus-mandrel-builder-image:jdk-21 usage

ubi-quarkus-mandrel-builder-image:jdk-25 is the way to go, one supported Mandrel version

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against Kubernetes (use `run kubernetes` phrase in comment)
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)