### PR TITLE
Add protostream-processor to list of annotations processors which should be added to generated pom

### DIFF
--- a/plugins/test-preparer/src/main/java/io/quarkus/test/plugin/preparer/PreparePomMojo.java
+++ b/plugins/test-preparer/src/main/java/io/quarkus/test/plugin/preparer/PreparePomMojo.java
@@ -38,7 +38,7 @@ public class PreparePomMojo extends AbstractMojo {
     private static final boolean SKIP_INTEGRATION_TESTS = Boolean.getBoolean("skipITs");
     // this needs to be system property, it is too early for FW configuration
     private static final Set<String> PROPAGATED_ANNOTATION_PROCESSOR_ARTIFACTS = Set.of("hibernate-processor",
-            "hibernate-search-processor");
+            "hibernate-search-processor", "protostream-processor");
     private static final String TARGET_POM = "quarkus-app-pom.xml";
     private static final String MAVEN_COMPILER_RELEASE = "maven.compiler.release";
     private static final String PROPERTY_START = "\\${";


### PR DESCRIPTION
### Summary

This should fix Infinispan examples on PR OCP workflow.

This is problem only with java 24+.

The previous PRs which fixed it for baremetal https://github.com/quarkus-qe/quarkus-test-framework/pull/1814

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against Kubernetes (use `run kubernetes` phrase in comment)
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)