### PR TITLE
Disabled MCPIT because of issue #2340

### DIFF
--- a/examples/platforms/src/test/java/io/quarkus/qe/mcp/DevModeMCPIT.java
+++ b/examples/platforms/src/test/java/io/quarkus/qe/mcp/DevModeMCPIT.java
@@ -5,6 +5,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 
 import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
@@ -13,6 +14,7 @@ import io.quarkus.test.services.Dependency;
 import io.quarkus.test.services.DevModeQuarkusApplication;
 
 @QuarkusScenario
+@Disabled("https://github.com/quarkiverse/quarkus-langchain4j/issues/2340")
 public class DevModeMCPIT extends BasicMCPIT {
 
     @DevModeQuarkusApplication(boms = { @Dependency(artifactId = "quarkus-mcp-server-bom") }, dependencies = {

--- a/examples/platforms/src/test/java/io/quarkus/qe/mcp/MCPIT.java
+++ b/examples/platforms/src/test/java/io/quarkus/qe/mcp/MCPIT.java
@@ -2,6 +2,8 @@ package io.quarkus.qe.mcp;
 
 import java.nio.file.Path;
 
+import org.junit.jupiter.api.Disabled;
+
 import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.QuarkusScenario;
@@ -9,6 +11,7 @@ import io.quarkus.test.services.Dependency;
 import io.quarkus.test.services.QuarkusApplication;
 
 @QuarkusScenario
+@Disabled("https://github.com/quarkiverse/quarkus-langchain4j/issues/2340")
 public class MCPIT extends BasicMCPIT {
 
     @QuarkusApplication(boms = { @Dependency(artifactId = "quarkus-mcp-server-bom") }, dependencies = {


### PR DESCRIPTION
### Summary

Disabled MCPIT because of issue #2340

https://github.com/quarkiverse/quarkus-langchain4j/issues/2340


Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against Kubernetes (use `run kubernetes` phrase in comment)
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)