### PR TITLE
Kafka amq streams

### DIFF
--- a/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/operator/model/KafkaInstanceCustomResource.java
+++ b/quarkus-test-service-kafka/src/main/java/io/quarkus/test/services/operator/model/KafkaInstanceCustomResource.java
@@ -6,7 +6,7 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Kind;
 import io.fabric8.kubernetes.model.annotation.Version;
 
-@Version("v1")
+@Version("v1beta2")
 @Group("kafka.strimzi.io")
 @Kind("Kafka")
 public class KafkaInstanceCustomResource

--- a/quarkus-test-service-kafka/src/main/resources/strimzi-operator-kafka-instance.yaml
+++ b/quarkus-test-service-kafka/src/main/resources/strimzi-operator-kafka-instance.yaml
@@ -1,5 +1,5 @@
 # Based on https://github.com/strimzi/strimzi-kafka-operator/blob/release-0.46.x/examples/kafka/kafka-single-node.yaml
-apiVersion: kafka.strimzi.io/v1
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaNodePool
 metadata:
   name: dual-role
@@ -20,7 +20,7 @@ spec:
         kraftMetadata: shared
 ---
 
-apiVersion: kafka.strimzi.io/v1
+apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
   name: kafka-instance

--- a/quarkus-test-service-kafka/src/main/resources/strimzi-operator-kafka-instance.yaml
+++ b/quarkus-test-service-kafka/src/main/resources/strimzi-operator-kafka-instance.yaml
@@ -29,7 +29,9 @@ metadata:
     strimzi.io/kraft: enabled
 spec:
   kafka:
-    version: 4.1.1
+    # When updating this version please run the OperatorOpenShiftAmqStreamsKafkaStreamIT in TS
+    # as the amq-streams are different from the latest operator
+    version: 4.1.0
     replicas: 1
     listeners:
       - name: plain


### PR DESCRIPTION
### Summary

Reverting the https://github.com/quarkus-qe/quarkus-test-framework/pull/1774 as in TS we testing with `amq-streams`

The latest `amq-streams` operator is base on 0.48.X (https://docs.redhat.com/en/documentation/red_hat_streams_for_apache_kafka/3.1/html/release_notes_for_streams_for_apache_kafka_3.1_on_openshift/features-str) and this change happen in 0.49.x

Note after the merge I'll create draft for update to `v1` but merge it when the `amq-streams` 3.2 is released.


Also downgrading the kafka version for ocp to 4.1.0 as the 4.1.1 is not supported on `amq-streams` + adding the note to try the TS tests when bumping it. 

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against Kubernetes (use `run kubernetes` phrase in comment)
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)