### PR TITLE
Quarkus bumping the Keycloak to 26.6.1 so this it to sync with it

### DIFF
--- a/examples/keycloak/src/test/resources/keycloak-custom-template.yaml
+++ b/examples/keycloak/src/test/resources/keycloak-custom-template.yaml
@@ -13,7 +13,7 @@ items:
         from:
           kind: DockerImage
           # Hardcoded image is used only here, tests use one from KeycloakContainer
-          name: quay.io/keycloak/keycloak:26.5
+          name: quay.io/keycloak/keycloak:26.6
 - apiVersion: apps/v1
   kind: Deployment
   metadata:

--- a/quarkus-test-service-keycloak/src/main/java/io/quarkus/test/services/KeycloakContainer.java
+++ b/quarkus-test-service-keycloak/src/main/java/io/quarkus/test/services/KeycloakContainer.java
@@ -14,7 +14,7 @@ import io.quarkus.test.services.containers.KeycloakContainerManagedResourceBuild
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface KeycloakContainer {
-    String image() default "quay.io/keycloak/keycloak:26.5";
+    String image() default "quay.io/keycloak/keycloak:26.6";
 
     int port() default 8080;
 


### PR DESCRIPTION
### Summary

Bumping Keycloak to 26.6 as Quarkus bumped it also in https://github.com/quarkusio/quarkus/pull/53735

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against Kubernetes (use `run kubernetes` phrase in comment)
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)