### PR TITLE
Disable OpenShiftMCPIT

### DIFF
--- a/examples/platforms/src/test/java/io/quarkus/qe/mcp/OpenShiftMCPIT.java
+++ b/examples/platforms/src/test/java/io/quarkus/qe/mcp/OpenShiftMCPIT.java
@@ -1,5 +1,7 @@
 package io.quarkus.qe.mcp;
 
+import org.junit.jupiter.api.Disabled;
+
 import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
@@ -8,6 +10,7 @@ import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.test.services.quarkus.model.QuarkusProperties;
 
 @OpenShiftScenario
+@Disabled("https://github.com/quarkiverse/quarkus-langchain4j/issues/2340")
 public class OpenShiftMCPIT extends BasicMCPIT {
 
     private static String workingFolder = QuarkusProperties.isNativeEnabled() ? "/home/quarkus" : "/deployments";


### PR DESCRIPTION
### Summary

Follow up of https://github.com/quarkus-qe/quarkus-test-framework/pull/1879 as there is same failure on OCP

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against Kubernetes (use `run kubernetes` phrase in comment)
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)