### PR TITLE
Fix scaleTo() to prevent duplicate pods from DeploymentConfig

### DIFF
--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/bootstrap/inject/OpenShiftClient.java
@@ -443,7 +443,9 @@ public final class OpenShiftClient {
     }
 
     /**
-     * Scale the service to the replicas.
+     * Scale the service to the given number of replicas.
+     * Also scales down any existing DeploymentConfig to 0, since on some OCP clusters a DC may
+     * coexist with the Deployment created by the Quarkus OpenShift extension, causing duplicate pods.
      *
      * @param service
      * @param replicas
@@ -461,6 +463,28 @@ public final class OpenShiftClient {
                     .runAndWait();
         } catch (Exception e) {
             fail("Service failed to be scaled. Caused by " + e.getMessage());
+        }
+
+        scaleDownDeploymentConfigIfExists(service.getName());
+    }
+
+    /**
+     * On some OCP clusters, a DeploymentConfig may coexist with the Deployment created by the
+     * Quarkus OpenShift extension. Scale it to 0 so only the Deployment pods are active,
+     * avoiding duplicate pods.
+     */
+    private void scaleDownDeploymentConfigIfExists(String name) {
+        if (client.deploymentConfigs().withName(name).get() == null) {
+            return;
+        }
+        try {
+            new Command(OC, "scale",
+                    "dc/" + name,
+                    "--replicas=0",
+                    "-n", currentNamespace)
+                    .runAndWait();
+        } catch (Exception e) {
+            LOG.debug("Failed to scale down DeploymentConfig " + name + ": " + e.getMessage());
         }
     }
 


### PR DESCRIPTION
### Summary

Detected in our Jenkins job: `quarkus-main-rhel8-jdk17-openshift-ts-jvm-ocp-4-stable-weekly/SCENARIO=misc`.
On ocp, a DeploymentConfig may coexist with Deployment created (by OpenShift extension). The current `scaleTo()` only targets the Deployment, leaving DC pods active. So this results in duplicate pods per service with inconsistent app state , for instance, in the failed job, split atomicInteger counters across JVMs : 
```
[ERROR] io.quarkus.ts.infinispan.client.OperatorOpenShiftInfinispanCountersIT.testMultipleClientIncrement -- Time elapsed: 1.814 s <<< FAILURE!
03:47:04 org.opentest4j.AssertionFailedError: expected: <10> but was: <4>
```

With this fix scales down the DC to 0 if one exists, if not DC is present then nothing happens.


Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against Kubernetes (use `run kubernetes` phrase in comment)
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)