### PR TITLE
Fix Windows native build, bump Mandrel from JDK 21 to JDK 25

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -204,7 +204,7 @@ jobs:
         java: [ 21 ]
         quarkus-version: ["999-SNAPSHOT"]
         graalvm-version: ["mandrel-latest"]
-        graalvm-java: ["21"]
+        graalvm-java: ["25"]
     steps:
       - uses: actions/checkout@v6
       - name: Install JDK ${{ matrix.java }}


### PR DESCRIPTION
### Summary

Bump Mandrel from JDK 21 to JDK 25
The Linux native job already uses JDK 25, but the Windows native job was still using graalvm-java 21


Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against Kubernetes (use `run kubernetes` phrase in comment)
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)