### PR TITLE
[1.7.z] Pin TODO app to specific commit

### DIFF
--- a/examples/external-applications/src/test/java/io/quarkus/qe/TodoDemoIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/TodoDemoIT.java
@@ -24,6 +24,7 @@ import io.restassured.response.Response;
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class TodoDemoIT {
     private static final String REPO = "https://github.com/quarkusio/todo-demo-app.git";
+    private static final String COMMIT = "464aa60a65d0a991be8e663720247861c9427c93";
     private static final String DEFAULT_ARGS = "-DskipTests=true -Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus.platform.version=${QUARKUS_PLATFORM_VERSION} ";
     private static final String UBER = "-Dquarkus.package.jar.type=uber-jar ";
     private static final String NO_SUFFIX = "-Dquarkus.package.jar.add-runner-suffix=false";
@@ -33,21 +34,21 @@ public class TodoDemoIT {
             // store data in /tmp/psql as in OpenShift we don't have permissions to /var/lib/postgresql/data
             .withProperty("PGDATA", "/tmp/psql");
 
-    @GitRepositoryQuarkusApplication(repo = REPO, mavenArgs = DEFAULT_ARGS + UBER)
+    @GitRepositoryQuarkusApplication(repo = REPO, branch = COMMIT, mavenArgs = DEFAULT_ARGS + UBER)
     static final RestService todoApp = new RestService()
             .withProperty("quarkus.datasource.username", database.getUser())
             .withProperty("quarkus.datasource.password", database.getPassword())
             .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl);
 
-    @GitRepositoryQuarkusApplication(repo = REPO, artifact = "todo-backend-1.0-SNAPSHOT-runner.jar", mavenArgs = DEFAULT_ARGS
+    @GitRepositoryQuarkusApplication(repo = REPO, branch = COMMIT, artifact = "todo-backend-1.0-SNAPSHOT-runner.jar", mavenArgs = DEFAULT_ARGS
             + UBER)
     static final RestService todoExplicitApp = new RestService()
             .withProperty("quarkus.datasource.username", database.getUser())
             .withProperty("quarkus.datasource.password", database.getPassword())
             .withProperty("quarkus.datasource.jdbc.url", database::getJdbcUrl);
 
-    @GitRepositoryQuarkusApplication(repo = REPO, artifact = "todo-backend-1.0-SNAPSHOT.jar", mavenArgs = DEFAULT_ARGS + UBER
-            + NO_SUFFIX)
+    @GitRepositoryQuarkusApplication(repo = REPO, branch = COMMIT, artifact = "todo-backend-1.0-SNAPSHOT.jar", mavenArgs = DEFAULT_ARGS
+            + UBER + NO_SUFFIX)
     static final RestService todoUnsuffixedApp = new RestService()
             .withProperty("quarkus.datasource.username", database.getUser())
             .withProperty("quarkus.datasource.password", database.getPassword())


### PR DESCRIPTION
### Summary

Similar to https://github.com/quarkus-qe/quarkus-test-framework/pull/1890. I don't know valid commit in the time of 3.27 release so I'm setting the latest working one (before the 5th of May merges). 

The TODO app move baseline from Java 17 to 25 (e.g. `maven.compiler.release` from 17 to 25)

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against Kubernetes (use `run kubernetes` phrase in comment)
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)