### PR TITLE
Adding DisabledOnFips annotation

### DIFF
--- a/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/annotations/DisabledOnFips.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/annotations/DisabledOnFips.java
@@ -1,0 +1,20 @@
+package io.quarkus.test.scenarios.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Inherited
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(DisabledOnFipsCondition.class)
+public @interface DisabledOnFips {
+    /**
+     * Why is the annotated test class or test method disabled.
+     */
+    String reason() default "";
+}

--- a/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/annotations/DisabledOnFipsAndNativeCondition.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/annotations/DisabledOnFipsAndNativeCondition.java
@@ -1,17 +1,13 @@
 package io.quarkus.test.scenarios.annotations;
 
 import static io.quarkus.test.services.quarkus.model.QuarkusProperties.isNativeEnabled;
+import static io.quarkus.test.utils.FipsUtils.isFipsEnabledEnvironment;
 
 import org.junit.jupiter.api.extension.ConditionEvaluationResult;
 import org.junit.jupiter.api.extension.ExecutionCondition;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 public class DisabledOnFipsAndNativeCondition implements ExecutionCondition {
-
-    /**
-     * We set environment variable "FIPS" to "fips" in our Jenkins jobs when FIPS are enabled.
-     */
-    private static final String FIPS_ENABLED = "fips";
 
     @Override
     public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
@@ -20,10 +16,6 @@ public class DisabledOnFipsAndNativeCondition implements ExecutionCondition {
         }
 
         return ConditionEvaluationResult.enabled("The test is not running in FIPS enabled environment in native mode");
-    }
-
-    private static boolean isFipsEnabledEnvironment() {
-        return FIPS_ENABLED.equalsIgnoreCase(System.getenv().get("FIPS"));
     }
 
 }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/annotations/DisabledOnFipsCondition.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/annotations/DisabledOnFipsCondition.java
@@ -1,15 +1,12 @@
 package io.quarkus.test.scenarios.annotations;
 
+import static io.quarkus.test.utils.FipsUtils.isFipsEnabledEnvironment;
+
 import org.junit.jupiter.api.extension.ConditionEvaluationResult;
 import org.junit.jupiter.api.extension.ExecutionCondition;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 public class DisabledOnFipsCondition implements ExecutionCondition {
-
-    /**
-     * We set environment variable "FIPS" to "fips" in our Jenkins jobs when FIPS are enabled.
-     */
-    private static final String FIPS_ENABLED = "fips";
 
     @Override
     public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
@@ -18,10 +15,6 @@ public class DisabledOnFipsCondition implements ExecutionCondition {
         }
 
         return ConditionEvaluationResult.enabled("The test is not running in FIPS enabled environment");
-    }
-
-    private static boolean isFipsEnabledEnvironment() {
-        return FIPS_ENABLED.equalsIgnoreCase(System.getenv().get("FIPS"));
     }
 
 }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/annotations/DisabledOnFipsCondition.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/annotations/DisabledOnFipsCondition.java
@@ -1,0 +1,27 @@
+package io.quarkus.test.scenarios.annotations;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class DisabledOnFipsCondition implements ExecutionCondition {
+
+    /**
+     * We set environment variable "FIPS" to "fips" in our Jenkins jobs when FIPS are enabled.
+     */
+    private static final String FIPS_ENABLED = "fips";
+
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+        if (isFipsEnabledEnvironment()) {
+            return ConditionEvaluationResult.disabled("The test is running in FIPS enabled environment");
+        }
+
+        return ConditionEvaluationResult.enabled("The test is not running in FIPS enabled environment");
+    }
+
+    private static boolean isFipsEnabledEnvironment() {
+        return FIPS_ENABLED.equalsIgnoreCase(System.getenv().get("FIPS"));
+    }
+
+}

--- a/quarkus-test-core/src/main/java/io/quarkus/test/utils/FipsUtils.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/utils/FipsUtils.java
@@ -1,0 +1,17 @@
+package io.quarkus.test.utils;
+
+public final class FipsUtils {
+
+    /**
+     * We set environment variable "FIPS" to "fips" in our Jenkins jobs when FIPS are enabled.
+     */
+    private static final String FIPS_ENABLED = "fips";
+
+    private FipsUtils() {
+
+    }
+
+    public static boolean isFipsEnabledEnvironment() {
+        return FIPS_ENABLED.equalsIgnoreCase(System.getenv().get("FIPS"));
+    }
+}


### PR DESCRIPTION
### Summary

This PR adding the `DisabledOnFips` annotation. We currently have only `DisabledOnFipsAndNative`.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against Kubernetes (use `run kubernetes` phrase in comment)
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)