### PR TITLE
Fix GitRepositoryQuarkusApplication double-build

### DIFF
--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/GitRepositoryLocalhostQuarkusApplicationManagedResource.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/GitRepositoryLocalhostQuarkusApplicationManagedResource.java
@@ -1,7 +1,6 @@
 package io.quarkus.test.services.quarkus;
 
 import static io.quarkus.test.services.quarkus.GitRepositoryResourceBuilderUtils.cloneRepository;
-import static io.quarkus.test.services.quarkus.GitRepositoryResourceBuilderUtils.mavenBuild;
 import static io.quarkus.test.services.quarkus.model.QuarkusProperties.PLATFORM_GROUP_ID;
 import static io.quarkus.test.utils.MavenUtils.withProperty;
 
@@ -30,7 +29,6 @@ public class GitRepositoryLocalhostQuarkusApplicationManagedResource
         super.onPreBuild();
 
         cloneRepository(model);
-        mavenBuild(model);
     }
 
     @Override

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/GitRepositoryQuarkusApplicationManagedResourceBuilder.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/GitRepositoryQuarkusApplicationManagedResourceBuilder.java
@@ -5,6 +5,8 @@ import static java.util.regex.Pattern.quote;
 import java.lang.annotation.Annotation;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
 
@@ -78,6 +80,14 @@ public class GitRepositoryQuarkusApplicationManagedResourceBuilder extends ProdQ
         }
 
         return new GitRepositoryLocalhostQuarkusApplicationManagedResource(this);
+    }
+
+    @Override
+    protected Path tryToReuseOrBuildArtifact() {
+        List<String> mvnArgs = Arrays.asList(StringUtils.split(getMavenArgsWithVersion(), " "));
+        return new QuarkusMavenPluginBuildHelper(this, getTargetFolderForLocalArtifacts(), getArtifactSuffix())
+                .buildOrReuseArtifact(mvnArgs)
+                .orElseThrow(() -> new RuntimeException("Failed to build artifact for git repository application"));
     }
 
     @Override

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/GitRepositoryResourceBuilderUtils.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/GitRepositoryResourceBuilderUtils.java
@@ -1,11 +1,8 @@
 package io.quarkus.test.services.quarkus;
 
-import java.util.Arrays;
-
 import org.apache.commons.lang3.StringUtils;
 
 import io.quarkus.test.utils.GitUtils;
-import io.quarkus.test.utils.MavenUtils;
 
 public final class GitRepositoryResourceBuilderUtils {
 
@@ -19,11 +16,6 @@ public final class GitRepositoryResourceBuilderUtils {
             GitUtils.checkoutBranch(model.getContext(), model.getGitBranch());
         }
         GitUtils.showRepositoryState(model.getContext());
-    }
-
-    public static void mavenBuild(final GitRepositoryQuarkusApplicationManagedResourceBuilder model) {
-        String[] mvnArgs = StringUtils.split(model.getMavenArgsWithVersion(), " ");
-        MavenUtils.build(model.getContext(), model.getApplicationFolder(), Arrays.asList(mvnArgs));
     }
 
 }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/ProdQuarkusApplicationManagedResourceBuilder.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/ProdQuarkusApplicationManagedResourceBuilder.java
@@ -85,7 +85,7 @@ public class ProdQuarkusApplicationManagedResourceBuilder extends ArtifactQuarku
         return Paths.get(TARGET);
     }
 
-    private Path tryToReuseOrBuildArtifact() {
+    protected Path tryToReuseOrBuildArtifact() {
         return new QuarkusMavenPluginBuildHelper(this, getTargetFolderForLocalArtifacts(), artifactSuffix)
                 .buildOrReuseArtifact();
     }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusMavenPluginBuildHelper.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/services/quarkus/QuarkusMavenPluginBuildHelper.java
@@ -315,18 +315,16 @@ public final class QuarkusMavenPluginBuildHelper {
             mavenBuildProjectRoot = prepareMavenProject(appFolder.resolve("mvn-build"));
         }
 
-        return getArtifact().or(() -> buildArtifactWithQuarkusMvnPlugin(mavenBuildProjectRoot, additionalArgs));
+        return getArtifact()
+                .or(() -> buildArtifactWithQuarkusMvnPlugin(mavenBuildProjectRoot, additionalArgs))
+                .or(this::getArtifact);
     }
 
     private Optional<Path> getArtifact() {
         Optional<String> artifactLocation = Optional.empty();
         final Path targetFolder = targetFolderForLocalArtifacts;
         if (artifactSuffix != null) {
-            var possiblyArtifact = findTargetFile(targetFolder, artifactSuffix).map(Path::of);
-            if (possiblyArtifact.isPresent()) {
-                return possiblyArtifact;
-            }
-            throw new IllegalStateException(String.format("Folder %s doesn't contain '%s'", targetFolder, artifactSuffix));
+            return findTargetFile(targetFolder, artifactSuffix).map(Path::of);
         }
         resourceBuilder.createSnapshotOfBuildPropertiesIfNotExists();
         if (!resourceBuilder.buildPropertiesChanged()) {

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/ContainerRegistryOpenShiftGitRepositoryQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/ContainerRegistryOpenShiftGitRepositoryQuarkusApplicationManagedResource.java
@@ -1,7 +1,6 @@
 package io.quarkus.test.services.quarkus;
 
 import static io.quarkus.test.services.quarkus.GitRepositoryResourceBuilderUtils.cloneRepository;
-import static io.quarkus.test.services.quarkus.GitRepositoryResourceBuilderUtils.mavenBuild;
 
 public class ContainerRegistryOpenShiftGitRepositoryQuarkusApplicationManagedResource
         extends ContainerRegistryOpenShiftQuarkusApplicationManagedResource {
@@ -16,7 +15,6 @@ public class ContainerRegistryOpenShiftGitRepositoryQuarkusApplicationManagedRes
         super.onPreBuild();
 
         cloneRepository(getModel());
-        mavenBuild(getModel());
     }
 
     private GitRepositoryQuarkusApplicationManagedResourceBuilder getModel() {


### PR DESCRIPTION
- Fixes #1884

### Summary

Remove the redundant `MavenUtils.build()` call from `GitRepositoryLocalhostQuarkusApplicationManagedResource.onPreBuild()` so that the application is built only once via `QuarkusMavenPluginBuildHelper`. The `mavenArgs` from the annotation are now passed as additional build arguments to the single build, ensuring properties like `quarkus.platform.version` are always applied.

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against Kubernetes (use `run kubernetes` phrase in comment)
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [ ] Methods and classes used in PR scenarios are meaningful
- [ ] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)