### PR TITLE
[1.8.z] Backport 22.05.2026 + 3.33 platform build workaround

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -44,7 +44,8 @@ jobs:
           git clone -b 3.33 https://github.com/quarkusio/quarkus.git && cd quarkus && ./mvnw -B --no-transfer-progress -s .github/mvn-settings.xml clean install -Dquickly -Dno-test-modules -Prelocations
       - name: Build Quarkus Platform 3.33.999-SNAPSHOT
         run: |
-          git clone -b 3.33 https://github.com/quarkusio/quarkus-platform.git && cd quarkus-platform && ./mvnw versions:set -DnewVersion=3.33.999-SNAPSHOT -DgenerateBackupPoms=false && ./mvnw install -Dquarkus.version=3.33.999-SNAPSHOT -DskipTests -DskipITs
+          # TODO revert commit for excluding the camel-quarkus-integration-test-cxf-soap-grouped
+          git clone -b 3.33 https://github.com/quarkusio/quarkus-platform.git && cd quarkus-platform && ./mvnw versions:set -DnewVersion=3.33.999-SNAPSHOT -DgenerateBackupPoms=false && ./mvnw process-resources -Dquarkus.invoke-platform-project.skip=true && cd generated-platform-project && ../mvnw install -Dquarkus.version=3.33.999-SNAPSHOT -DskipTests -DskipITs -pl "-io.quarkus.platform:camel-quarkus-integration-test-cxf-soap-grouped"
       - name: Tar Maven Repo
         shell: bash
         run: tar -I 'pigz -9' -cf maven-repo.tgz -C ~ .m2/repository

--- a/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/annotations/DisabledOnFips.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/annotations/DisabledOnFips.java
@@ -1,0 +1,20 @@
+package io.quarkus.test.scenarios.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Inherited
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(DisabledOnFipsCondition.class)
+public @interface DisabledOnFips {
+    /**
+     * Why is the annotated test class or test method disabled.
+     */
+    String reason() default "";
+}

--- a/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/annotations/DisabledOnFipsAndNativeCondition.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/annotations/DisabledOnFipsAndNativeCondition.java
@@ -1,17 +1,13 @@
 package io.quarkus.test.scenarios.annotations;
 
 import static io.quarkus.test.services.quarkus.model.QuarkusProperties.isNativeEnabled;
+import static io.quarkus.test.utils.FipsUtils.isFipsEnabledEnvironment;
 
 import org.junit.jupiter.api.extension.ConditionEvaluationResult;
 import org.junit.jupiter.api.extension.ExecutionCondition;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 public class DisabledOnFipsAndNativeCondition implements ExecutionCondition {
-
-    /**
-     * We set environment variable "FIPS" to "fips" in our Jenkins jobs when FIPS are enabled.
-     */
-    private static final String FIPS_ENABLED = "fips";
 
     @Override
     public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
@@ -20,10 +16,6 @@ public class DisabledOnFipsAndNativeCondition implements ExecutionCondition {
         }
 
         return ConditionEvaluationResult.enabled("The test is not running in FIPS enabled environment in native mode");
-    }
-
-    private static boolean isFipsEnabledEnvironment() {
-        return FIPS_ENABLED.equalsIgnoreCase(System.getenv().get("FIPS"));
     }
 
 }

--- a/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/annotations/DisabledOnFipsCondition.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/annotations/DisabledOnFipsCondition.java
@@ -1,0 +1,20 @@
+package io.quarkus.test.scenarios.annotations;
+
+import static io.quarkus.test.utils.FipsUtils.isFipsEnabledEnvironment;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class DisabledOnFipsCondition implements ExecutionCondition {
+
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+        if (isFipsEnabledEnvironment()) {
+            return ConditionEvaluationResult.disabled("The test is running in FIPS enabled environment");
+        }
+
+        return ConditionEvaluationResult.enabled("The test is not running in FIPS enabled environment");
+    }
+
+}

--- a/quarkus-test-core/src/main/java/io/quarkus/test/utils/FipsUtils.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/utils/FipsUtils.java
@@ -1,0 +1,17 @@
+package io.quarkus.test.utils;
+
+public final class FipsUtils {
+
+    /**
+     * We set environment variable "FIPS" to "fips" in our Jenkins jobs when FIPS are enabled.
+     */
+    private static final String FIPS_ENABLED = "fips";
+
+    private FipsUtils() {
+
+    }
+
+    public static boolean isFipsEnabledEnvironment() {
+        return FIPS_ENABLED.equalsIgnoreCase(System.getenv().get("FIPS"));
+    }
+}


### PR DESCRIPTION
### Summary

Backport of:
* https://github.com/quarkus-qe/quarkus-test-framework/pull/1897


Add workaround for unable to build 3.33 platform. For more info see https://github.com/quarkusio/quarkus-platform/pull/1981

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against Kubernetes (use `run kubernetes` phrase in comment)
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)