### PR TITLE
[1.7.z] Bump Quarkus to 3.27.4, backports

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,8 @@ jobs:
     if: ${{github.event.pull_request.merged == true}}
 
     steps:
-      - uses: actions/checkout@v5
-      - uses: radcortez/project-metadata-action@main
+      - uses: actions/checkout@v6
+      - uses: smallrye/project-metadata-action@main
         name: Retrieve project metadata
         id: metadata
         with:

--- a/examples/infinispan/pom.xml
+++ b/examples/infinispan/pom.xml
@@ -53,6 +53,20 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${compiler-plugin.version}</version>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <!-- needed for quarkus-infinispan-client with Java 24+ -->
+                            <groupId>org.infinispan.protostream</groupId>
+                            <artifactId>protostream-processor</artifactId>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <profiles>

--- a/plugins/test-preparer/src/main/java/io/quarkus/test/plugin/preparer/PreparePomMojo.java
+++ b/plugins/test-preparer/src/main/java/io/quarkus/test/plugin/preparer/PreparePomMojo.java
@@ -36,7 +36,7 @@ public class PreparePomMojo extends AbstractMojo {
     private static final boolean SKIP_INTEGRATION_TESTS = Boolean.getBoolean("skipITs");
     // this needs to be system property, it is too early for FW configuration
     private static final Set<String> PROPAGATED_ANNOTATION_PROCESSOR_ARTIFACTS = Set.of("hibernate-processor",
-            "hibernate-search-processor");
+            "hibernate-search-processor", "protostream-processor");
     private static final String TARGET_POM = "quarkus-app-pom.xml";
     private static final String MAVEN_COMPILER_RELEASE = "maven.compiler.release";
     private static final String PROPERTY_START = "\\${";

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>3.27.3</quarkus.platform.version>
+        <quarkus.platform.version>3.27.4</quarkus.platform.version>
         <exclude.tests.with.tags>quarkus-cli</exclude.tests.with.tags>
         <include.tests>**/*IT.java</include.tests>
         <exclude.openshift.tests>**/OpenShift*IT.java</exclude.openshift.tests>

--- a/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/QuarkusCliClient.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/QuarkusCliClient.java
@@ -172,6 +172,9 @@ public class QuarkusCliClient {
     public Result updateApplication(UpdateApplicationRequest request, Path serviceFolder) {
         List<String> args = new ArrayList<>(List.of("update"));
 
+        // TODO remove when https://redhat.atlassian.net/browse/QQE-2579 is investigated and fixed
+        args.add("--quarkus-update-recipes=1.10.1");
+
         // apply updates
         if (request.applyUpdates) {
             args.add("-y");

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftS2iGitRepositoryQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftS2iGitRepositoryQuarkusApplicationManagedResource.java
@@ -34,6 +34,7 @@ public class OpenShiftS2iGitRepositoryQuarkusApplicationManagedResource
     private static final PropertyLookup QUARKUS_NATIVE_S2I_FROM_SRC = new PropertyLookup(
             S2I_BASE_NATIVE_IMAGE.getName(),
             "quay.io/quarkus/ubi9-quarkus-graalvmce-s2i:jdk-21");
+    private static final String QUARKUS_SOURCE_S2I_NATIVE_BUILD_PROPERTIES = "-Dquarkus.native.native-image-xmx=5g";
 
     private final GitRepositoryQuarkusApplicationManagedResourceBuilder model;
 
@@ -89,6 +90,7 @@ public class OpenShiftS2iGitRepositoryQuarkusApplicationManagedResource
     protected String replaceDeploymentContent(String content) {
         String quarkusPlatformVersion = QuarkusProperties.getVersion();
         String quarkusS2iBaseImage = getQuarkusS2iBaseImage();
+        String quarkusSourceS2iBuildNativeProperties = isNativeTest() ? QUARKUS_SOURCE_S2I_NATIVE_BUILD_PROPERTIES : "";
         String mavenArgs = model.getMavenArgsWithVersion();
 
         return content.replaceAll(quote("${APP_NAME}"), model.getContext().getOwner().getName())
@@ -98,6 +100,7 @@ public class OpenShiftS2iGitRepositoryQuarkusApplicationManagedResource
                 .replaceAll(quote("${CONTEXT_DIR}"), model.getContextDir())
                 .replaceAll(quote("${GIT_MAVEN_ARGS}"), mavenArgs)
                 .replaceAll(quote("${CURRENT_NAMESPACE}"), client.project())
+                .replaceAll(quote("${QUARKUS_SOURCE_S2I_NATIVE_BUILD_PROPERTIES}"), quarkusSourceS2iBuildNativeProperties)
                 .replaceAll(quote(QUARKUS_PLATFORM_GROUP_ID_PROPERTY), PLATFORM_GROUP_ID.get())
                 .replaceAll(quote(QUARKUS_PLATFORM_VERSION_PROPERTY), quarkusPlatformVersion);
     }

--- a/quarkus-test-openshift/src/main/resources/quarkus-s2i-source-build-template.yml
+++ b/quarkus-test-openshift/src/main/resources/quarkus-s2i-source-build-template.yml
@@ -36,7 +36,7 @@ items:
         sourceStrategy:
           env:
             - name: MAVEN_ARGS
-              value: -s /configuration/settings.xml ${GIT_MAVEN_ARGS} -Dquarkus.platform.version=${QUARKUS_PLATFORM_VERSION} -Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus-plugin.version=${QUARKUS_PLATFORM_VERSION} -Djavax.net.ssl.trustStore=/etc/pki/java/cacerts
+              value: -s /configuration/settings.xml ${GIT_MAVEN_ARGS} -Dquarkus.platform.version=${QUARKUS_PLATFORM_VERSION} -Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus-plugin.version=${QUARKUS_PLATFORM_VERSION} -Djavax.net.ssl.trustStore=/etc/pki/java/cacerts ${QUARKUS_SOURCE_S2I_NATIVE_BUILD_PROPERTIES}
           from:
             kind: DockerImage
             name: ${QUARKUS_S2I_BUILDER_IMAGE}


### PR DESCRIPTION
### Summary

Bump Quarkus to 3.27.4

Backports:
 * https://github.com/quarkus-qe/quarkus-test-framework/pull/1874
 * https://github.com/quarkus-qe/quarkus-test-framework/pull/1894

Changes for Java 25 on Jenkins part:
 * https://github.com/quarkus-qe/quarkus-test-framework/pull/1814/ - https://github.com/quarkus-qe/quarkus-test-framework/pull/1814/changes/57a23456794e73355d44c1db22b1e26c8db47e30
 * https://github.com/quarkus-qe/quarkus-test-framework/pull/1876

Changes for CLI update scenario:
 * https://github.com/quarkus-qe/quarkus-test-framework/pull/1905/changes/54e6a617f6dfd841855733ffbe724f1c98cd273d

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against Kubernetes (use `run kubernetes` phrase in comment)
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)