### PR TITLE
[1.8.z] Bump Quarkus to 3.33.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>3.33.1</quarkus.platform.version>
+        <quarkus.platform.version>3.33.2</quarkus.platform.version>
         <exclude.tests.with.tags>quarkus-cli</exclude.tests.with.tags>
         <include.tests>**/*IT.java</include.tests>
         <exclude.openshift.tests>**/OpenShift*IT.java</exclude.openshift.tests>

--- a/quarkus-test-core/src/test/resources/quarkus-app-pom.xml
+++ b/quarkus-test-core/src/test/resources/quarkus-app-pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <maven.compiler.release>17</maven.compiler.release>
     <surefire-plugin.version>3.5.4</surefire-plugin.version>
-    <quarkus.platform.version>3.33.1</quarkus.platform.version>
+    <quarkus.platform.version>3.33.2</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <failsafe-plugin.version>3.5.4</failsafe-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>


### PR DESCRIPTION
### Summary

Bump Quarkus to 3.33.2

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against Kubernetes (use `run kubernetes` phrase in comment)
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)