### PR TITLE
Use temp directory by default and init git repo in gitignored dirs

### DIFF
--- a/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/QuarkusCliClient.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/QuarkusCliClient.java
@@ -5,7 +5,6 @@ import static io.quarkus.test.services.quarkus.model.QuarkusProperties.createDis
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -46,7 +45,6 @@ public class QuarkusCliClient {
             + " to be unavailable";
     private static final PropertyLookup COMMAND = new PropertyLookup(CLI_CMD.getName(), "quarkus");
     private static final Path TARGET = Paths.get("target");
-    private volatile boolean useTemporaryDirectory = false;
 
     private final ScenarioContext context;
 
@@ -106,17 +104,16 @@ public class QuarkusCliClient {
     }
 
     public QuarkusCliRestService createApplication(String name, CreateApplicationRequest request, String targetFolderName) {
+        String dirName = extractDirectoryName(name);
         final Path serviceFolder;
         if (isNotEmpty(targetFolderName)) {
-            serviceFolder = TARGET.resolve(targetFolderName).resolve(name);
-        } else if (useTemporaryDirectory) {
+            serviceFolder = TARGET.resolve(targetFolderName).resolve(dirName);
+        } else {
             try {
-                serviceFolder = Files.createTempDirectory(name).resolve(name);
+                serviceFolder = Files.createTempDirectory(dirName).resolve(dirName);
             } catch (IOException e) {
                 throw new RuntimeException("Failed to create temporary directory", e);
             }
-        } else {
-            serviceFolder = null;
         }
         QuarkusCliRestService service = new QuarkusCliRestService(this, serviceFolder);
         ServiceContext serviceContext = service.register(name, context);
@@ -149,6 +146,8 @@ public class QuarkusCliClient {
         abortIfRegistryUnavailable(result, "application");
         assertTrue(result.isSuccessful(), "The application was not created. Output: " + result.getOutput());
 
+        initGitRepoIfInsideGitIgnoredDir(serviceContext.getServiceFolder());
+
         return service;
     }
 
@@ -161,7 +160,17 @@ public class QuarkusCliClient {
 
     public QuarkusCliRestService createApplicationFromExistingSources(String name, String targetFolderName, Path sourcesDir,
             ManagedResourceCreator managedResourceCreator) {
-        Path serviceFolder = isNotEmpty(targetFolderName) ? TARGET.resolve(targetFolderName).resolve(name) : null;
+        String dirName = extractDirectoryName(name);
+        final Path serviceFolder;
+        if (isNotEmpty(targetFolderName)) {
+            serviceFolder = TARGET.resolve(targetFolderName).resolve(dirName);
+        } else {
+            try {
+                serviceFolder = Files.createTempDirectory(dirName).resolve(dirName);
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to create temporary directory", e);
+            }
+        }
         QuarkusCliRestService service = new QuarkusCliRestService(this, serviceFolder);
         ServiceContext serviceContext = service.register(name, context);
 
@@ -171,6 +180,8 @@ public class QuarkusCliClient {
         FileUtils.deletePath(serviceContext.getServiceFolder());
 
         FileUtils.copyDirectoryTo(sourcesDir, serviceContext.getServiceFolder());
+
+        initGitRepoIfInsideGitIgnoredDir(serviceContext.getServiceFolder());
 
         return service;
     }
@@ -200,6 +211,39 @@ public class QuarkusCliClient {
         Result result = runCliAndWait(serviceFolder, args.toArray(new String[0]));
         assertTrue(result.isSuccessful(), "The application was not updated. Output: " + result.getOutput());
         return result;
+    }
+
+    // OpenRewrite's rewrite-maven-plugin (6.40.0+) excludes files that are gitignored and untracked.
+    // If the app is inside a gitignored directory (e.g. target/), OpenRewrite skips its pom.xml.
+    // Initializing a git repo scopes OpenRewrite to the app's own directory.
+    // See https://redhat.atlassian.net/browse/QQE-2579
+    private static void initGitRepoIfInsideGitIgnoredDir(Path directory) {
+        try {
+            Process checkIgnore = ProcessBuilderProvider.command(List.of("git", "check-ignore", "-q", directory.toString()))
+                    .redirectErrorStream(true)
+                    .start();
+            if (checkIgnore.waitFor() == 0) {
+                ProcessBuilderProvider.command(List.of("git", "init"))
+                        .directory(directory.toFile())
+                        .redirectErrorStream(true)
+                        .start()
+                        .waitFor();
+            }
+        } catch (Exception e) {
+            Log.warn("Failed to initialize git repo in " + directory + ": " + e.getMessage());
+        }
+    }
+
+    private static String extractDirectoryName(String name) {
+        int colonPos = name.indexOf(':');
+        if (colonPos > 0) {
+            int lastColon = name.lastIndexOf(':');
+            if (lastColon == colonPos) {
+                return name.substring(colonPos + 1);
+            }
+            return name.substring(colonPos + 1, lastColon);
+        }
+        return name;
     }
 
     private static boolean isNotEmpty(String str) {
@@ -519,15 +563,4 @@ public class QuarkusCliClient {
         return CreateExtensionRequest.defaults();
     }
 
-    /**
-     * This client will only create new applications inside temporary directory (unless user explicitly specified path).
-     * It can be useful if you need to create new Quarkus applications in the temporary directory only within one
-     * test method.
-     *
-     * @return {@link Closeable} which disables using temporary directory
-     */
-    public Closeable useTemporaryDirectory() {
-        useTemporaryDirectory = true;
-        return () -> useTemporaryDirectory = false;
-    }
 }


### PR DESCRIPTION
## Summary
- The `rewrite-maven-plugin` 6.40.0 (shipped in `quarkus-updates` 1.11.0) fixed its gitignore handling so files in gitignored+untracked directories are correctly excluded from OpenRewrite processing
- Since test apps were created inside `target/` (which is gitignored by the project), OpenRewrite skipped their `pom.xml` and no dependency renames were applied, causing `QuarkusCliUtilsExampleIT.exampleDependencyUpdateTest` to fail
- Two complementary fixes:
  - **Default to temp directory** when no explicit `targetFolderName` is specified in `createApplication()` and `createApplicationFromExistingSources()`, so apps are created outside the git tree
  - **Initialize a git repo** after app creation when the app directory is inside a gitignored path (e.g. via `createApplicationAt()`), scoping OpenRewrite to the app's own directory

Fixes: [QQE-2579](https://redhat.atlassian.net/browse/QQE-2579)

## Test plan
- [x] Verified `QuarkusCliUtilsExampleIT.exampleDependencyUpdateTest` fails without the fix
- [x] Verified the test passes with the fix applied