### PR TITLE
Split quarkus core and quarkus platfrom versions

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        quarkus-version: ["3.999-SNAPSHOT"]
+        quarkus-version: ["999-core-3.x-SNAPSHOT"]
         java: [ 21, 25 ]
     steps:
       - uses: actions/checkout@v7
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        quarkus-version: ["3.999-SNAPSHOT"]
+        quarkus-version: ["999-core-3.x-SNAPSHOT"]
         java: [ 25 ]
     steps:
       - uses: actions/checkout@v7
@@ -76,7 +76,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - quarkus-version: "3.999-SNAPSHOT"
+          - quarkus-version: "999-core-3.x-SNAPSHOT"
             java: 21
             extra-maven-args: ''
     steps:
@@ -120,7 +120,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        quarkus-version: ["3.999-SNAPSHOT"]
+        quarkus-version: ["999-core-3.x-SNAPSHOT"]
         java: [21]
     steps:
       - uses: actions/checkout@v7
@@ -164,7 +164,7 @@ jobs:
     strategy:
       matrix:
         java: [ 21, 25 ]
-        quarkus-version: ["3.999-SNAPSHOT"]
+        quarkus-version: ["999-core-3.x-SNAPSHOT"]
     steps:
       - uses: actions/checkout@v7
       - name: Install JDK ${{ matrix.java }}
@@ -196,7 +196,7 @@ jobs:
     strategy:
       matrix:
         java: [ 21 ]
-        quarkus-version: ["3.999-SNAPSHOT"]
+        quarkus-version: ["999-core-3.x-SNAPSHOT"]
         graalvm-version: ["mandrel-latest"]
         graalvm-java: ["25"]
     steps:

--- a/.github/workflows/kube-pr.yml
+++ b/.github/workflows/kube-pr.yml
@@ -47,7 +47,7 @@ jobs:
     needs: write-comment
     strategy:
       matrix:
-        quarkus-version: ["3.999-SNAPSHOT"]
+        quarkus-version: ["999-core-3.x-SNAPSHOT"]
         java: [21]
     steps:
       - uses: actions/checkout@v7
@@ -94,7 +94,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - quarkus-version: "3.999-SNAPSHOT"
+          - quarkus-version: "999-core-3.x-SNAPSHOT"
             java: 21
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -28,7 +28,7 @@ jobs:
     needs: validate-format
     strategy:
       matrix:
-        quarkus-version: ["3.999-SNAPSHOT"]
+        quarkus-version: ["999-core-3.x-SNAPSHOT"]
         java: [ 21 ]
     outputs:
       has-flaky-tests: ${{steps.flaky-test-detector.outputs.has-flaky-tests}}
@@ -79,7 +79,7 @@ jobs:
     needs: validate-format
     strategy:
       matrix:
-        quarkus-version: [ "3.999-SNAPSHOT" ]
+        quarkus-version: [ "999-core-3.x-SNAPSHOT" ]
         java: [ 21 ]
     outputs:
       has-flaky-tests: ${{steps.flaky-test-detector.outputs.has-flaky-tests}}
@@ -131,7 +131,7 @@ jobs:
     strategy:
       matrix:
         java: [ 21 ]
-        quarkus-version: ["3.999-SNAPSHOT"]
+        quarkus-version: ["999-core-3.x-SNAPSHOT"]
     outputs:
       has-flaky-tests: ${{steps.flaky-test-detector.outputs.has-flaky-tests}}
     steps:

--- a/.github/workflows/weekly-jacoco.yml
+++ b/.github/workflows/weekly-jacoco.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        quarkus-version: ["3.999-SNAPSHOT"]
+        quarkus-version: ["999-core-3.x-SNAPSHOT"]
         java: [ 17 ]
     steps:
       - uses: actions/checkout@v7

--- a/examples/platforms/pom.xml
+++ b/examples/platforms/pom.xml
@@ -10,9 +10,6 @@
     </parent>
     <artifactId>examples-platforms</artifactId>
     <name>Quarkus - Test Framework - Examples - Additional platforms</name>
-    <properties>
-        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    </properties>
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -58,16 +55,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <configuration>
-                    <systemPropertyVariables>
-                        <quarkus.platform.group-id>${quarkus.platform.group-id}</quarkus.platform.group-id>
-                    </systemPropertyVariables>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -54,6 +54,15 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <quarkus.platform.group-id>${quarkus.platform.group-id}</quarkus.platform.group-id>
+                        <quarkus.platform.version>${quarkus.platform.version}</quarkus.platform.version>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
@@ -83,6 +92,10 @@
                             <forkedProcessTimeoutInSeconds>0</forkedProcessTimeoutInSeconds>
                             <!--our ForkNode factory helps us to propagate termination signal down to JUnit provider -->
                             <forkNode implementation="io.quarkus.test.debug.SureFireDebugForkNodeFactory" />
+                            <systemPropertyVariables>
+                                <quarkus.platform.group-id>${quarkus.platform.group-id}</quarkus.platform.group-id>
+                                <quarkus.platform.version>${quarkus.platform.version}</quarkus.platform.version>
+                            </systemPropertyVariables>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/examples/quarkus-cli/src/test/java/io/quarkus/qe/QuarkusCliClientIT.java
+++ b/examples/quarkus-cli/src/test/java/io/quarkus/qe/QuarkusCliClientIT.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.builder.Version;
 import io.quarkus.test.bootstrap.QuarkusCliClient;
 import io.quarkus.test.bootstrap.QuarkusCliDefaultService;
 import io.quarkus.test.bootstrap.QuarkusCliRestService;
@@ -33,7 +34,6 @@ import io.quarkus.test.scenarios.QuarkusScenario;
 import io.quarkus.test.scenarios.TestQuarkusCli;
 import io.quarkus.test.scenarios.annotations.EnabledOnNative;
 import io.quarkus.test.services.quarkus.CliDevModeVersionLessQuarkusApplicationManagedResource;
-import io.quarkus.test.services.quarkus.model.QuarkusProperties;
 
 @Tag("quarkus-cli")
 @QuarkusScenario
@@ -52,11 +52,12 @@ public class QuarkusCliClientIT {
 
     @Test
     public void shouldVersionMatchQuarkusVersion() {
+        String version = Version.getVersion(); // version of cli should be the same as Quarkus core version
         // Using option
-        assertEquals(QuarkusProperties.getVersion(), cliClient.run("--version").getOutput());
+        assertEquals(version, cliClient.run("--version").getOutput());
 
         // Using shortcut
-        assertEquals(QuarkusProperties.getVersion(), cliClient.run("-v").getOutput());
+        assertEquals(version, cliClient.run("-v").getOutput());
     }
 
     @TestQuarkusCli

--- a/pom.xml
+++ b/pom.xml
@@ -51,9 +51,9 @@
         <quarkus.group-id>io.quarkus</quarkus.group-id>
         <quarkus.artifact-id>quarkus-bom</quarkus.artifact-id>
         <quarkus.version>3.999-SNAPSHOT</quarkus.version>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>${quarkus.artifact-id}</quarkus.platform.artifact-id>
-        <quarkus.platform.version>3.999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>999-core-3.x-SNAPSHOT</quarkus.platform.version>
         <exclude.tests.with.tags>quarkus-cli</exclude.tests.with.tags>
         <include.tests>**/*IT.java</include.tests>
         <exclude.openshift.tests>**/OpenShift*IT.java</exclude.openshift.tests>

--- a/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/QuarkusCliClient.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/QuarkusCliClient.java
@@ -359,13 +359,14 @@ public class QuarkusCliClient {
     }
 
     private static boolean isUpstream(String version) {
-        return version.contains(QUARKUS_UPSTREAM_VERSION);
+        return version.contains("-SNAPSHOT");
     }
 
     protected static String getFixedStreamVersion() {
         var rawVersion = QuarkusProperties.getVersion();
         if (isUpstream(rawVersion)) {
-            throw new IllegalStateException("Cannot set fixed stream version for '%s' as it doesn't exist" + rawVersion);
+            throw new IllegalStateException(
+                    "Cannot set fixed stream version for '%s' as it doesn't exist".formatted(rawVersion));
         }
 
         String[] version = rawVersion.split(Pattern.quote("."));

--- a/quarkus-test-cli/src/main/java/io/quarkus/test/extensions/TestQuarkusCliExtension.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/extensions/TestQuarkusCliExtension.java
@@ -25,7 +25,7 @@ import io.quarkus.test.services.quarkus.model.QuarkusProperties;
  */
 public class TestQuarkusCliExtension implements TestTemplateInvocationContextProvider {
 
-    private static final String QUARKUS_UPSTREAM_VERSION = "3.999-SNAPSHOT";
+    private static final String QUARKUS_UPSTREAM_VERSION = "-SNAPSHOT";
     private static final PropertyLookup RUN_WITH_LATEST_RELEASED = new PropertyLookup("cli.snapshot.test-released-quarkus",
             "true");
 

--- a/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/annotations/DisabledOnQuarkusSnapshotCondition.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/annotations/DisabledOnQuarkusSnapshotCondition.java
@@ -11,7 +11,7 @@ import org.junit.platform.commons.util.AnnotationUtils;
 import io.quarkus.test.services.quarkus.model.QuarkusProperties;
 
 public class DisabledOnQuarkusSnapshotCondition implements ExecutionCondition {
-    private static final String QUARKUS_SNAPSHOT_VERSION = "3.999-SNAPSHOT";
+    private static final String QUARKUS_SNAPSHOT_VERSION = "-SNAPSHOT";
     private static final ConditionEvaluationResult ENABLED_BY_DEFAULT = ConditionEvaluationResult.enabled(
             "@DisabledOnQuarkusSnapshot is not present");
 


### PR DESCRIPTION
### Summary

Without that change, when we run test suite with explicit platform version, framework tries to use core components with the same version

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against Kubernetes (use `run kubernetes` phrase in comment)
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)