### PR TITLE
Add `quarkus.openshift.secret-volumes."secret-volumes".items."items".mode` when building OpenShift using extension

### DIFF
--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/ExtensionOpenShiftQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/ExtensionOpenShiftQuarkusApplicationManagedResource.java
@@ -237,6 +237,10 @@ public class ExtensionOpenShiftQuarkusApplicationManagedResource
                 args.add(withProperty(
                         "quarkus.openshift.secret-volumes." + result.secretName() + ".items.\"" + result.fileName() + "\".path",
                         result.fileName()));
+                // TODO remove set of mode or this `TODO` base on outcome of https://github.com/quarkusio/quarkus/issues/54784
+                args.add(withProperty(
+                        "quarkus.openshift.secret-volumes." + result.secretName() + ".items.\"" + result.fileName() + "\".mode",
+                        "0644"));
                 args.add(withProperty("quarkus.openshift.mounts." + result.secretName() + ".name",
                         result.secretName()));
                 args.add(withProperty("quarkus.openshift.mounts." + result.secretName() + ".path",


### PR DESCRIPTION
### Summary

Adding `quarkus.openshift.secret-volumes."secret-volumes".items."items".mode` as now the mode is also set, by default it's -1 and it failing to deploy the app. We add these properties when adding the TLS for Keycloak and mode wasn't needed. I created the https://github.com/quarkusio/quarkus/issues/54784 as even when this is not bug it should be added to migration guide.

I'll keep this as draft till Friday to possibly remove the TODO which I added.

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against Kubernetes (use `run kubernetes` phrase in comment)
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)