### PR TITLE
Remove the ubi8 compatibility runs from daily Kubernetes CI

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -79,12 +79,6 @@ jobs:
           - quarkus-version: "999-SNAPSHOT"
             java: 21
             extra-maven-args: ''
-          - quarkus-version: "999-SNAPSHOT"
-            java: 17 # test 'quarkus-container-image-jib' with images based on UBI8 and Java 17
-            extra-maven-args: '-pl examples/pingpong/ -Dtest-ubi8-compatibility -Dquarkus.jib.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-17-runtime:latest'
-          - quarkus-version: "999-SNAPSHOT"
-            java: 21 # test 'quarkus-container-image-jib' with images based on UBI8 and Java 21
-            extra-maven-args: '-pl examples/pingpong/ -Dtest-ubi8-compatibility -Dquarkus.jib.base-jvm-image=registry.access.redhat.com/ubi8/openjdk-21-runtime:latest'
     steps:
       - uses: actions/checkout@v6
       - name: Reclaim Disk Space


### PR DESCRIPTION
### Summary

Removing the ubi8 compatibility from Kubernetes CI. There are 2 reasons
* In next LTS the UBI8/RHEL8 won't be supported
* The daily CI fail as it can't find `io.quarkus.qe:quarkus-test-preparer` as we executing only one module and we removed the sonatype repository setting from pom.xml in https://github.com/quarkus-qe/quarkus-test-framework/pull/1911

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against Kubernetes (use `run kubernetes` phrase in comment)
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)