### PR TITLE
Pin Windows Native job to windows-2022 runner

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -192,7 +192,7 @@ jobs:
           path: artifacts-latest-windows-jvm${{ matrix.java }}.tar
   windows-build-native-latest:
     name: Windows Native
-    runs-on: windows-latest
+    runs-on: windows-2022
     strategy:
       matrix:
         java: [ 21 ]


### PR DESCRIPTION
## Summary

- Pin the Windows Native job runner from `windows-latest` to `windows-2022` in `daily.yaml`

## Why

The `windows-latest` GitHub Actions runner [now resolves to `windows-2025-vs2026`](https://github.com/actions/runner-images/issues/14017) (rolled out June 8–15, 2026), which ships with **Visual Studio 2026**. The `graalvm/setup-graalvm@v1` action only knows about VS 2017, 2019, and 2022 installation paths when searching for `vcvarsall.bat`, so it fails immediately with:

```
##[error]Failed to find vcvarsall.bat
```

Reported upstream as [graalvm/setup-graalvm#218](https://github.com/graalvm/setup-graalvm/issues/218), fix submitted in [graalvm/setup-graalvm#219](https://github.com/graalvm/setup-graalvm/pull/219).

## Why only `daily.yaml` Windows Native

- **`daily.yaml` Windows Native** — uses `graalvm/setup-graalvm@v1` which needs `vcvarsall.bat` → **pinned to `windows-2022`**
- **`daily.yaml` Windows JVM** (line 163) — does not use GraalVM/native-image, so `windows-latest` is fine
- **`pr.yaml` Windows JVM** (line 129) — same, no GraalVM involved

Once `graalvm/setup-graalvm` adds VS2026 support, this can be reverted back to `windows-latest`.

## Test plan

- [ ] Verify the Windows Native daily build passes with the `windows-2022` runner