### PR TITLE
Add Maven HTTP retry handler to S2I build MAVEN_ARGS

### DIFF
--- a/quarkus-test-openshift/src/main/resources/quarkus-s2i-source-build-template.yml
+++ b/quarkus-test-openshift/src/main/resources/quarkus-s2i-source-build-template.yml
@@ -36,7 +36,7 @@ items:
         sourceStrategy:
           env:
             - name: MAVEN_ARGS
-              value: -s /configuration/settings.xml ${GIT_MAVEN_ARGS} -Dquarkus.platform.version=${QUARKUS_PLATFORM_VERSION} -Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus-plugin.version=${QUARKUS_PLATFORM_VERSION} -Djavax.net.ssl.trustStore=/etc/pki/java/cacerts ${QUARKUS_SOURCE_S2I_NATIVE_BUILD_PROPERTIES}
+              value: -s /configuration/settings.xml ${GIT_MAVEN_ARGS} -Dquarkus.platform.version=${QUARKUS_PLATFORM_VERSION} -Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus-plugin.version=${QUARKUS_PLATFORM_VERSION} -Djavax.net.ssl.trustStore=/etc/pki/java/cacerts -Daether.connector.http.retryHandler.count=10 -Daether.connector.http.retryHandler.interval=3000 -Daether.connector.http.retryHandler.serviceUnavailable=429,502,503,504 ${QUARKUS_SOURCE_S2I_NATIVE_BUILD_PROPERTIES}
           from:
             kind: DockerImage
             name: ${QUARKUS_S2I_BUILDER_IMAGE}


### PR DESCRIPTION
## Summary

- Add Aether HTTP retry handler properties (`count=10`, `interval=3000`, `serviceUnavailable=429,502,503,504`) to the `MAVEN_ARGS` environment variable in the S2I source build template

The outer Jenkins Maven invocation already has these retry properties, but the S2I build pods run their own Maven process without them. A transient 502 Bad Gateway from the Nexus mirror causes the build to fail immediately — Maven caches the failed artifact lookup, making recovery impossible within that build attempt. This was the root cause of the `external-applications` module failure in [build #169](https://jenkins-csb-quarkusqe-main.dno.corp.redhat.com/view/periodic-builds/job/quarkus-main-rhel8-jdk17-openshift-ts-jvm-ocp-4-stable-weekly/SCENARIO=root-modules,jdk=openjdk-17,label=RHEL8%20&&%20large/169/console), where all three S2I-based tests (`OpenShiftQuickstartIT`, `OpenShiftTodoDemoIT`, `OpenShiftWorkshopHeroesIT`) failed consistently across retries.

Only Aether properties are needed since Maven 3.9.0+ defaults to the native HTTP transport (not Wagon), and the S2I builder image uses Maven 3.9.9.

## Test plan

- [ ] Verify the S2I template YAML is valid
- [ ] Run an OpenShift S2I-based test (e.g. `OpenShiftQuickstartIT`) and confirm the retry properties appear in the Maven command inside the build pod logs