### PR TITLE
Add Google Maven Central mirror to S2I build settings

### DIFF
--- a/quarkus-test-openshift/src/main/resources/settings-mvn.yml
+++ b/quarkus-test-openshift/src/main/resources/settings-mvn.yml
@@ -16,6 +16,13 @@ data:
                 <url>${internal.s2i.maven.remote.repository}</url>
                 <blocked>false</blocked>
             </mirror>
+            <mirror>
+                <id>google-maven-central</id>
+                <mirrorOf>central</mirrorOf>
+                <name>Google Maven Central mirror</name>
+                <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
+                <blocked>false</blocked>
+            </mirror>
         </mirrors>
         <profiles>
             <profile>


### PR DESCRIPTION
## Summary

- Add a Google Maven Central mirror (`https://maven-central.storage-download.googleapis.com/maven2/`) to the S2I source build Maven settings template

S2I build pods may not have direct access to Maven Central (`repo.maven.apache.org`). In [build #171](https://jenkins-csb-quarkusqe-main.dno.corp.redhat.com/job/quarkus-main-rhel8-jdk17-openshift-ts-jvm-ocp-4-stable-weekly/SCENARIO=root-modules,jdk=openjdk-17,label=RHEL8%20&&%20large/171/console), every Maven Central download hung for ~166 seconds before timing out, causing all S2I-based tests to fail. Routing Central requests through Google's public mirror avoids this issue.

## Test plan

- [ ] Run an OpenShift S2I-based test (e.g. `OpenShiftQuickstartIT`) and confirm Central dependencies are resolved through the Google mirror in the build pod logs