### PR TITLE
Trigger daily deploy snapshot on push to main

### DIFF
--- a/.github/workflows/daily-deploy.yml
+++ b/.github/workflows/daily-deploy.yml
@@ -1,5 +1,8 @@
 name: "Daily deploy snapshot"
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
   schedule:
     - cron: '0 23 * * *'


### PR DESCRIPTION
## Summary
- Add `push` trigger on `main` branch to the daily deploy workflow so snapshots are deployed on every push, not just on the nightly schedule.

## Test plan
- [ ] Verify the workflow triggers on push to `main`
- [ ] Verify the scheduled and manual dispatch triggers still work