### PR TITLE
[1.8] Add custom certificates to custom location during s2i builds

### DIFF
--- a/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftSSLRequestIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftSSLRequestIT.java
@@ -1,0 +1,8 @@
+package io.quarkus.qe;
+
+import io.quarkus.test.scenarios.OpenShiftDeploymentStrategy;
+import io.quarkus.test.scenarios.OpenShiftScenario;
+
+@OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.Build)
+public class OpenShiftSSLRequestIT extends SSLRequestIT {
+}

--- a/examples/external-applications/src/test/java/io/quarkus/qe/SSLRequestIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/SSLRequestIT.java
@@ -1,0 +1,24 @@
+package io.quarkus.qe;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.GitRepositoryQuarkusApplication;
+import io.restassured.response.Response;
+
+@QuarkusScenario
+public class SSLRequestIT {
+
+    @GitRepositoryQuarkusApplication(repo = "https://github.com/fedinskiy/reproducer.git", branch = "framework-ssl-anchor")
+    static final RestService app = new RestService();
+
+    @Test
+    public void shouldSendExternalRequests() {
+        Response response = app.given().get("/external-https");
+        Assertions.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        Assertions.assertEquals("200", response.body().asString());
+    }
+}

--- a/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftS2iGitRepositoryQuarkusApplicationManagedResource.java
+++ b/quarkus-test-openshift/src/main/java/io/quarkus/test/services/quarkus/OpenShiftS2iGitRepositoryQuarkusApplicationManagedResource.java
@@ -51,9 +51,7 @@ public class OpenShiftS2iGitRepositoryQuarkusApplicationManagedResource
         if (model.isDevMode()) {
             Assertions.fail("DEV mode is not supported when using GIT repositories on OpenShift deployments");
         }
-        System.out.println("name: " + S2I_MAVEN_REMOTE_REPOSITORY.getName());
         String repo = MAVEN_REMOTE_REPOSITORY.get(model.getContext());
-        System.out.println("Repo: " + repo);
         if (DisabledOnQuarkusSnapshotCondition.isQuarkusSnapshotVersion()
                 && StringUtils.isEmpty(repo)) {
             Assertions.fail("s2i can't use the Quarkus 999-SNAPSHOT version if not Maven repository has been provided");

--- a/quarkus-test-openshift/src/main/resources/quarkus-s2i-source-build-template.yml
+++ b/quarkus-test-openshift/src/main/resources/quarkus-s2i-source-build-template.yml
@@ -30,13 +30,13 @@ items:
             destinationDir: "/configuration"
           - configMap:
               name: etc-pki-java
-            destinationDir: "/etc/pki/java/"
+            destinationDir: "/custom-java-certs"
       strategy:
         type: Source
         sourceStrategy:
           env:
             - name: MAVEN_ARGS
-              value: -s /configuration/settings.xml ${GIT_MAVEN_ARGS} -Dquarkus.platform.version=${QUARKUS_PLATFORM_VERSION} -Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus-plugin.version=${QUARKUS_PLATFORM_VERSION} -Djavax.net.ssl.trustStore=/etc/pki/java/cacerts ${QUARKUS_SOURCE_S2I_NATIVE_BUILD_PROPERTIES}
+              value: -s /configuration/settings.xml ${GIT_MAVEN_ARGS} -Dquarkus.platform.version=${QUARKUS_PLATFORM_VERSION} -Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus-plugin.version=${QUARKUS_PLATFORM_VERSION} -Djavax.net.ssl.trustStore=/custom-java-certs/cacerts ${QUARKUS_SOURCE_S2I_NATIVE_BUILD_PROPERTIES}
           from:
             kind: DockerImage
             name: ${QUARKUS_S2I_BUILDER_IMAGE}


### PR DESCRIPTION
### Summary
Fixes https://github.com/quarkus-qe/quarkus-test-framework/issues/1778

(cherry picked from commit e6585a0cb920e1cf6948c88da244be4883f93066)


Backport of https://github.com/quarkus-qe/quarkus-test-framework/pull/1928


Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] This change requires execution against Kubernetes (use `run kubernetes` phrase in comment)
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)