### PR TITLE
Use generic setKeyCertOptions/setTrustOptions for Vert.x 5 compatibility

### DIFF
--- a/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/RestService.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/bootstrap/RestService.java
@@ -144,8 +144,8 @@ public class RestService extends BaseService<RestService> {
             } else {
                 pemKeyCertOptions.addKeyPath(clientCert.keyPath());
             }
-            options.setPemKeyCertOptions(pemKeyCertOptions);
-            options.setPemTrustOptions(new PemTrustOptions().addCertPath(clientCert.truststorePath()));
+            options.setKeyCertOptions(pemKeyCertOptions);
+            options.setTrustOptions(new PemTrustOptions().addCertPath(clientCert.truststorePath()));
         } else {
             final String keystorePath;
             final String truststorePath;


### PR DESCRIPTION
## Summary
- Quarkus `main` bumped to Vert.x 5.1.3, which removed the type-specific `setPemKeyCertOptions()` and `setPemTrustOptions()` methods from `WebClientOptions`
- Replace with the generic `setKeyCertOptions()` and `setTrustOptions()` methods, which accept the `KeyCertOptions`/`TrustOptions` interfaces that `PemKeyCertOptions`/`PemTrustOptions` implement
- Fixes the [Daily Build failure](https://github.com/quarkus-qe/quarkus-test-framework/actions/runs/28312915274) affecting all platforms (Linux, Windows, Kubernetes) in both JVM and Native modes

## Test plan
- [ ] CI Daily Build passes with this change