### PR TITLE
Switch daily builds to Quarkus 3.x branch

### DIFF
--- a/.github/workflows/build-quarkus.yml
+++ b/.github/workflows/build-quarkus.yml
@@ -26,13 +26,13 @@ jobs:
           # Save local repo to GH ENV to ensure that it's the same in all steps
           mkdir -p maven-repository
           echo "LOCAL_REPO=$(pwd)/maven-repository" >> $GITHUB_ENV
-      - name: Build Quarkus 999-SNAPSHOT
+      - name: Build Quarkus 3.999-SNAPSHOT
         run: |
-          git clone https://github.com/quarkusio/quarkus.git && cd quarkus && ./mvnw -B --no-transfer-progress -s .github/mvn-settings.xml clean install -Dquickly -Dno-test-modules -Prelocations -Dmaven.repo.local=${{ env.LOCAL_REPO }}
-      - name: Build Quarkus Platform 999-SNAPSHOT
+          git clone -b 3.x https://github.com/quarkusio/quarkus.git && cd quarkus && ./mvnw -B --no-transfer-progress -s .github/mvn-settings.xml clean install -Dquickly -Dno-test-modules -Prelocations -Dmaven.repo.local=${{ env.LOCAL_REPO }}
+      - name: Build Quarkus Platform 3.999-SNAPSHOT
         run: |
           LOCAL_REPO="$(pwd)/maven-repository"
-          git clone https://github.com/quarkusio/quarkus-platform.git && cd quarkus-platform && ./mvnw install -Dquarkus.version=999-SNAPSHOT -DskipTests -DskipITs -Dmaven.repo.local=${{ env.LOCAL_REPO }}
+          git clone https://github.com/quarkusio/quarkus-platform.git && cd quarkus-platform && ./mvnw install -Dquarkus.version=3.999-SNAPSHOT -DskipTests -DskipITs -Dmaven.repo.local=${{ env.LOCAL_REPO }}
       - name: Cache Build Outputs
         uses: actions/cache/save@v6
         with:

--- a/.github/workflows/daily-deploy.yml
+++ b/.github/workflows/daily-deploy.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/deploy
         with:
-          release-version: '999-SNAPSHOT'
+          release-version: '3.999-SNAPSHOT'
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           ossrh-token: ${{ secrets.OSSRH_TOKEN }}
           gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        quarkus-version: ["999-SNAPSHOT"]
+        quarkus-version: ["3.999-SNAPSHOT"]
         java: [ 21, 25 ]
     steps:
       - uses: actions/checkout@v7
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        quarkus-version: ["999-SNAPSHOT"]
+        quarkus-version: ["3.999-SNAPSHOT"]
         java: [ 25 ]
     steps:
       - uses: actions/checkout@v7
@@ -76,7 +76,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - quarkus-version: "999-SNAPSHOT"
+          - quarkus-version: "3.999-SNAPSHOT"
             java: 21
             extra-maven-args: ''
     steps:
@@ -120,7 +120,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        quarkus-version: ["999-SNAPSHOT"]
+        quarkus-version: ["3.999-SNAPSHOT"]
         java: [21]
     steps:
       - uses: actions/checkout@v7
@@ -164,7 +164,7 @@ jobs:
     strategy:
       matrix:
         java: [ 21, 25 ]
-        quarkus-version: ["999-SNAPSHOT"]
+        quarkus-version: ["3.999-SNAPSHOT"]
     steps:
       - uses: actions/checkout@v7
       - name: Install JDK ${{ matrix.java }}
@@ -196,7 +196,7 @@ jobs:
     strategy:
       matrix:
         java: [ 21 ]
-        quarkus-version: ["999-SNAPSHOT"]
+        quarkus-version: ["3.999-SNAPSHOT"]
         graalvm-version: ["mandrel-latest"]
         graalvm-java: ["25"]
     steps:


### PR DESCRIPTION
## Summary
- Build Quarkus from the `3.x` branch instead of `main` (version changes from `999-SNAPSHOT` to `3.999-SNAPSHOT`)
- Update `build-quarkus.yml` to clone `quarkusio/quarkus` with `-b 3.x`
- Update `daily.yaml` and `daily-deploy.yml` to use `3.999-SNAPSHOT` version

## Test plan
- [ ] Trigger `build-quarkus.yml` manually and verify it clones and builds from the `3.x` branch
- [ ] Verify the daily build jobs pick up `3.999-SNAPSHOT` artifacts correctly