### PR TITLE
Move all FW to use Quarkus 3.999-SNAPSHOT instead of 999-SNAPSHOT

### DIFF
--- a/.github/actions/prepare-quarkus-cli/action.yml
+++ b/.github/actions/prepare-quarkus-cli/action.yml
@@ -1,5 +1,5 @@
-name: 'Create Quarkus CLI 999-SNAPSHOT'
-description: 'Creates Quarkus CLI based on the current Quarkus main (999-SNAPSHOT version)'
+name: 'Create Quarkus CLI 3.999-SNAPSHOT'
+description: 'Creates Quarkus CLI based on the current Quarkus main (3.999-SNAPSHOT version)'
 runs:
   using: "composite"
   steps:
@@ -8,7 +8,7 @@ runs:
       run: |
         cat <<EOF > ./quarkus-dev-cli
         #!/bin/bash
-        java -jar ~/.m2/repository/io/quarkus/quarkus-cli/999-SNAPSHOT/quarkus-cli-999-SNAPSHOT-runner.jar "\$@"
+        java -jar ~/.m2/repository/io/quarkus/quarkus-cli/3.999-SNAPSHOT/quarkus-cli-3.999-SNAPSHOT-runner.jar "\$@"
         EOF
         chmod +x ./quarkus-dev-cli
         ./quarkus-dev-cli version

--- a/.github/workflows/build-quarkus.yml
+++ b/.github/workflows/build-quarkus.yml
@@ -31,8 +31,10 @@ jobs:
           git clone -b 3.x https://github.com/quarkusio/quarkus.git && cd quarkus && ./mvnw -B --no-transfer-progress -s .github/mvn-settings.xml clean install -Dquickly -Dno-test-modules -Prelocations -Dmaven.repo.local=${{ env.LOCAL_REPO }}
       - name: Build Quarkus Platform 3.999-SNAPSHOT
         run: |
-          LOCAL_REPO="$(pwd)/maven-repository"
-          git clone https://github.com/quarkusio/quarkus-platform.git && cd quarkus-platform && ./mvnw install -Dquarkus.version=3.999-SNAPSHOT -DskipTests -DskipITs -Dmaven.repo.local=${{ env.LOCAL_REPO }}
+          git clone https://github.com/quarkusio/quarkus-platform.git && cd quarkus-platform
+          # TODO remove versions:set when moved to testing 999-SNAPSHOT (Quarkus 4)
+          ./mvnw versions:set -DnewVersion=3.999-SNAPSHOT -DgenerateBackupPoms=false
+          ./mvnw install -Dquarkus.version=3.999-SNAPSHOT -DskipTests -DskipITs -Dmaven.repo.local=${{ env.LOCAL_REPO }}
       - name: Cache Build Outputs
         uses: actions/cache/save@v6
         with:

--- a/.github/workflows/kube-pr.yml
+++ b/.github/workflows/kube-pr.yml
@@ -47,7 +47,7 @@ jobs:
     needs: write-comment
     strategy:
       matrix:
-        quarkus-version: ["999-SNAPSHOT"]
+        quarkus-version: ["3.999-SNAPSHOT"]
         java: [21]
     steps:
       - uses: actions/checkout@v7
@@ -94,7 +94,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - quarkus-version: "999-SNAPSHOT"
+          - quarkus-version: "3.999-SNAPSHOT"
             java: 21
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -28,7 +28,7 @@ jobs:
     needs: validate-format
     strategy:
       matrix:
-        quarkus-version: ["999-SNAPSHOT"]
+        quarkus-version: ["3.999-SNAPSHOT"]
         java: [ 21 ]
     outputs:
       has-flaky-tests: ${{steps.flaky-test-detector.outputs.has-flaky-tests}}
@@ -79,7 +79,7 @@ jobs:
     needs: validate-format
     strategy:
       matrix:
-        quarkus-version: [ "999-SNAPSHOT" ]
+        quarkus-version: [ "3.999-SNAPSHOT" ]
         java: [ 21 ]
     outputs:
       has-flaky-tests: ${{steps.flaky-test-detector.outputs.has-flaky-tests}}
@@ -131,7 +131,7 @@ jobs:
     strategy:
       matrix:
         java: [ 21 ]
-        quarkus-version: ["999-SNAPSHOT"]
+        quarkus-version: ["3.999-SNAPSHOT"]
     outputs:
       has-flaky-tests: ${{steps.flaky-test-detector.outputs.has-flaky-tests}}
     steps:

--- a/.github/workflows/weekly-jacoco.yml
+++ b/.github/workflows/weekly-jacoco.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        quarkus-version: ["999-SNAPSHOT"]
+        quarkus-version: ["3.999-SNAPSHOT"]
         java: [ 17 ]
     steps:
       - uses: actions/checkout@v7

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>3.999-SNAPSHOT</quarkus.platform.version>
         <exclude.tests.with.tags>quarkus-cli</exclude.tests.with.tags>
         <include.tests>**/*IT.java</include.tests>
         <exclude.openshift.tests>**/OpenShift*IT.java</exclude.openshift.tests>

--- a/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/QuarkusCliClient.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/QuarkusCliClient.java
@@ -36,7 +36,7 @@ public class QuarkusCliClient {
      * doesn't make sense to request a service context.
      */
     static final String CLI_SERVICE_CONTEXT_KEY = "io.quarkus.test.bootstrap#cli-service-context";
-    private static final String QUARKUS_UPSTREAM_VERSION = "999-SNAPSHOT";
+    private static final String QUARKUS_UPSTREAM_VERSION = "3.999-SNAPSHOT";
     private static final String BUILD = "build";
     private static final String DEV = "dev";
     private static final String QUARKUS_REGISTRY_UNAVAILABLE_ERROR = "Failed to resolve the Quarkus extension registry"

--- a/quarkus-test-cli/src/main/java/io/quarkus/test/extensions/TestQuarkusCliExtension.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/extensions/TestQuarkusCliExtension.java
@@ -25,7 +25,7 @@ import io.quarkus.test.services.quarkus.model.QuarkusProperties;
  */
 public class TestQuarkusCliExtension implements TestTemplateInvocationContextProvider {
 
-    private static final String QUARKUS_UPSTREAM_VERSION = "999-SNAPSHOT";
+    private static final String QUARKUS_UPSTREAM_VERSION = "3.999-SNAPSHOT";
     private static final PropertyLookup RUN_WITH_LATEST_RELEASED = new PropertyLookup("cli.snapshot.test-released-quarkus",
             "true");
 

--- a/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/annotations/DisabledOnQuarkusSnapshotCondition.java
+++ b/quarkus-test-core/src/main/java/io/quarkus/test/scenarios/annotations/DisabledOnQuarkusSnapshotCondition.java
@@ -11,7 +11,7 @@ import org.junit.platform.commons.util.AnnotationUtils;
 import io.quarkus.test.services.quarkus.model.QuarkusProperties;
 
 public class DisabledOnQuarkusSnapshotCondition implements ExecutionCondition {
-    private static final String QUARKUS_SNAPSHOT_VERSION = "999-SNAPSHOT";
+    private static final String QUARKUS_SNAPSHOT_VERSION = "3.999-SNAPSHOT";
     private static final ConditionEvaluationResult ENABLED_BY_DEFAULT = ConditionEvaluationResult.enabled(
             "@DisabledOnQuarkusSnapshot is not present");
 

--- a/quarkus-test-core/src/test/resources/quarkus-app-pom.xml
+++ b/quarkus-test-core/src/test/resources/quarkus-app-pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <maven.compiler.release>17</maven.compiler.release>
     <surefire-plugin.version>3.5.4</surefire-plugin.version>
-    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+    <quarkus.platform.version>3.999-SNAPSHOT</quarkus.platform.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <failsafe-plugin.version>3.5.4</failsafe-plugin.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>


### PR DESCRIPTION
### Summary

Moving the full FW to 3.x base of Quarkus. The part of this was resolved in https://github.com/quarkus-qe/quarkus-test-framework/pull/1934

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Dependency update
- [x] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against Kubernetes (use `run kubernetes` phrase in comment)
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)