### PR TITLE
Revert "Disable the OpenShiftMCPIT due to problem with platform build"

### DIFF
--- a/examples/platforms/src/test/java/io/quarkus/qe/mcp/OpenShiftMCPIT.java
+++ b/examples/platforms/src/test/java/io/quarkus/qe/mcp/OpenShiftMCPIT.java
@@ -1,7 +1,5 @@
 package io.quarkus.qe.mcp;
 
-import org.junit.jupiter.api.Disabled;
-
 import io.quarkus.test.bootstrap.Protocol;
 import io.quarkus.test.bootstrap.RestService;
 import io.quarkus.test.scenarios.OpenShiftScenario;
@@ -10,7 +8,6 @@ import io.quarkus.test.services.QuarkusApplication;
 import io.quarkus.test.services.quarkus.model.QuarkusProperties;
 
 @OpenShiftScenario
-@Disabled("Enable this test when platform build effort is finished for Jenkins")
 public class OpenShiftMCPIT extends BasicMCPIT {
 
     private static String workingFolder = QuarkusProperties.isNativeEnabled() ? "/home/quarkus" : "/deployments";


### PR DESCRIPTION
Reverts quarkus-qe/quarkus-test-framework#1921

Now the new platform is deployed on Jenkins regularly