### PR TITLE
Reverting the workaround for https://issues.apache.org/jira/browse/KAFKA-18281

### DIFF
--- a/examples/kafka/src/test/resources/strimzi-custom-server-ssl.properties
+++ b/examples/kafka/src/test/resources/strimzi-custom-server-ssl.properties
@@ -35,8 +35,7 @@ controller.quorum.voters=1@localhost:9094
 #   EXAMPLE:
 #     listeners = PLAINTEXT://your.host.name:9092
 #listeners=PLAINTEXT://:9092
-# TODO switch to listeners=BROKER://0.0.0.0:9093,SSL://0.0.0.0:9092,CONTROLLER://0.0.0.0:9094 when this issue is fixed - https://github.com/apache/kafka/pull/18387
-listeners=BROKER://:9093,SSL://:9092,CONTROLLER://:9094
+listeners=BROKER://0.0.0.0:9093,SSL://0.0.0.0:9092,CONTROLLER://0.0.0.0:9094
 
 # Name of listener used for communication between brokers.
 inter.broker.listener.name=BROKER

--- a/quarkus-test-service-kafka/src/main/resources/strimzi-default-server-sasl-ssl.properties
+++ b/quarkus-test-service-kafka/src/main/resources/strimzi-default-server-sasl-ssl.properties
@@ -35,8 +35,7 @@ controller.quorum.voters=1@localhost:9094
 #   EXAMPLE:
 #     listeners = PLAINTEXT://your.host.name:9092
 #listeners=PLAINTEXT://:9092
-# TODO switch to listeners=BROKER://0.0.0.0:9093,SSL://0.0.0.0:9092,CONTROLLER://0.0.0.0:9094 when this issue is fixed - https://github.com/apache/kafka/pull/18387
-listeners=BROKER://:9093,SASL_SSL://:9092,CONTROLLER://:9094
+listeners=BROKER://0.0.0.0:9093,SASL_SSL://0.0.0.0:9092,CONTROLLER://0.0.0.0:9094
 
 # Name of listener used for communication between brokers.
 inter.broker.listener.name=BROKER

--- a/quarkus-test-service-kafka/src/main/resources/strimzi-default-server-sasl.properties
+++ b/quarkus-test-service-kafka/src/main/resources/strimzi-default-server-sasl.properties
@@ -39,8 +39,7 @@ controller.quorum.voters=1@localhost:9094
 #     listeners = listener_name://host_name:port
 #   EXAMPLE:
 #     listeners = PLAINTEXT://your.host.name:9092
-# TODO switch to listeners=BROKER://0.0.0.0:9093,SSL://0.0.0.0:9092,CONTROLLER://0.0.0.0:9094 when this issue is fixed - https://github.com/apache/kafka/pull/18387
-listeners=BROKER://:9093,SASL_PLAINTEXT://:9092,CONTROLLER://:9094
+listeners=BROKER://0.0.0.0:9093,SASL_PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9094
 
 # Name of listener used for communication between brokers.
 inter.broker.listener.name=BROKER

--- a/quarkus-test-service-kafka/src/main/resources/strimzi-default-server-ssl.properties
+++ b/quarkus-test-service-kafka/src/main/resources/strimzi-default-server-ssl.properties
@@ -35,8 +35,7 @@ controller.quorum.voters=1@localhost:9094
 #   EXAMPLE:
 #     listeners = PLAINTEXT://your.host.name:9092
 #listeners=PLAINTEXT://:9092
-# TODO switch to listeners=BROKER://0.0.0.0:9093,SSL://0.0.0.0:9092,CONTROLLER://0.0.0.0:9094 when this issue is fixed - https://github.com/apache/kafka/pull/18387
-listeners=BROKER://:9093,SSL://:9092,CONTROLLER://:9094
+listeners=BROKER://0.0.0.0:9093,SSL://0.0.0.0:9092,CONTROLLER://0.0.0.0:9094
 
 # Name of listener used for communication between brokers.
 inter.broker.listener.name=BROKER


### PR DESCRIPTION
### Summary

Finishing this TODO as the issue was fixed in 2025. This is related to this PR which introduced it https://github.com/quarkus-qe/quarkus-test-framework/pull/1465


Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against Kubernetes (use `run kubernetes` phrase in comment)
- [x] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)