### PR TITLE
Enable QuarkusCliClientIT#shouldCreateExtension as the Quarkus 3.35 is released

### DIFF
--- a/examples/quarkus-cli/src/test/java/io/quarkus/qe/QuarkusCliClientIT.java
+++ b/examples/quarkus-cli/src/test/java/io/quarkus/qe/QuarkusCliClientIT.java
@@ -20,7 +20,6 @@ import jakarta.inject.Inject;
 import org.apache.commons.io.FileUtils;
 import org.apache.http.HttpStatus;
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -101,8 +100,6 @@ public class QuarkusCliClientIT {
     }
 
     @TestQuarkusCli
-    // TODO: re-enable this once https://github.com/quarkusio/quarkus/pull/53251 is in release, otherwise this breaks the API for extension tests between 3.34 and 3.35
-    @Disabled("https://github.com/quarkusio/quarkus/pull/53251 introduces breaking change in main tests compared to Quarkus release in registry")
     public void shouldCreateExtension(QuarkusVersionAwareCliClient cliClient) {
         // Create extension
         QuarkusCliDefaultService app = cliClient.createExtension("extension-abc");


### PR DESCRIPTION
### Summary

Enable QuarkusCliClientIT#shouldCreateExtension as the Quarkus 3.35 is released


Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against Kubernetes (use `run kubernetes` phrase in comment)
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)