### PR TITLE
Switch quickstarts to use 3.x branch not development branch as we currently testing with 3.x Quarkus branch

### DIFF
--- a/examples/external-applications/src/test/java/io/quarkus/qe/BareMetalQuickstartUsingDefaultsIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/BareMetalQuickstartUsingDefaultsIT.java
@@ -12,7 +12,7 @@ import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 public class BareMetalQuickstartUsingDefaultsIT extends QuickstartUsingDefaultsIT {
 
     @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git",
-            contextDir = "getting-started", branch = "development")
+            contextDir = "getting-started", branch = "3.x")
     static final RestService app = new RestService();
 
     @Override

--- a/examples/external-applications/src/test/java/io/quarkus/qe/DevModeQuickstartUsingDefaultsIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/DevModeQuickstartUsingDefaultsIT.java
@@ -14,7 +14,7 @@ import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 public class DevModeQuickstartUsingDefaultsIT {
 
     @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git",
-            contextDir = "getting-started", devMode = true, branch = "development")
+            contextDir = "getting-started", devMode = true, branch = "3.x")
     static final RestService app = new RestService();
 
     @Test

--- a/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftContainerRegistryQuickstartUsingDefaultsIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftContainerRegistryQuickstartUsingDefaultsIT.java
@@ -8,7 +8,7 @@ import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingContainerRegistry)
 public class OpenShiftContainerRegistryQuickstartUsingDefaultsIT extends QuickstartUsingDefaultsIT {
     @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git",
-            contextDir = "getting-started", branch = "development")
+            contextDir = "getting-started", branch = "3.x")
     static final RestService app = new RestService();
 
     @Override

--- a/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftS2iQuickstartUsingDefaultsIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftS2iQuickstartUsingDefaultsIT.java
@@ -8,7 +8,7 @@ import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 public class OpenShiftS2iQuickstartUsingDefaultsIT extends QuickstartUsingDefaultsIT {
 
     @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git",
-            contextDir = "getting-started", branch = "development")
+            contextDir = "getting-started", branch = "3.x")
     static final RestService app = new RestService();
 
     @Override

--- a/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftS2iQuickstartUsingUberJarIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftS2iQuickstartUsingUberJarIT.java
@@ -16,7 +16,7 @@ public class OpenShiftS2iQuickstartUsingUberJarIT {
      * Package type is set in the custom template.
      */
     @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git",
-            contextDir = "getting-started", branch = "development")
+            contextDir = "getting-started", branch = "3.x")
     static final RestService appuberjar = new RestService();
 
     @Test

--- a/examples/external-applications/src/test/java/io/quarkus/qe/QuickstartUsingUsingUberJarIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/QuickstartUsingUsingUberJarIT.java
@@ -18,7 +18,7 @@ public class QuickstartUsingUsingUberJarIT {
     @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git",
             contextDir = "getting-started",
             mavenArgs = "-Dquarkus.package.jar.type=uber-jar -DskipTests=true -Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus.platform.version=${QUARKUS_PLATFORM_VERSION}",
-            branch = "development")
+            branch = "3.x")
     static final RestService app = new RestService();
 
     @Test


### PR DESCRIPTION
### Summary

We builiding the Quarkus from 3.x branch, currently development branch of quickstarts is moved to java 21 and is for Quarkus main branch (4.x). We need to test with 3.x. Currently this broke the jacoco run https://github.com/quarkus-qe/quarkus-test-framework/actions/runs/31355447916 

Please check the relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against Kubernetes (use `run kubernetes` phrase in comment)
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)