### PR TITLE
Switch main branch from Quarkus 3.x to 3.39 as 3.x was deleted

### DIFF
--- a/.github/actions/prepare-quarkus-cli/action.yml
+++ b/.github/actions/prepare-quarkus-cli/action.yml
@@ -1,5 +1,5 @@
-name: 'Create Quarkus CLI 3.999-SNAPSHOT'
-description: 'Creates Quarkus CLI based on the current Quarkus main (3.999-SNAPSHOT version)'
+name: 'Create Quarkus CLI 3.39.999-SNAPSHOT'
+description: 'Creates Quarkus CLI based on the current Quarkus main (3.39.999-SNAPSHOT version)'
 runs:
   using: "composite"
   steps:
@@ -8,7 +8,7 @@ runs:
       run: |
         cat <<EOF > ./quarkus-dev-cli
         #!/bin/bash
-        java -jar ~/.m2/repository/io/quarkus/quarkus-cli/3.999-SNAPSHOT/quarkus-cli-3.999-SNAPSHOT-runner.jar "\$@"
+        java -jar ~/.m2/repository/io/quarkus/quarkus-cli/3.39.999-SNAPSHOT/quarkus-cli-3.39.999-SNAPSHOT-runner.jar "\$@"
         EOF
         chmod +x ./quarkus-dev-cli
         ./quarkus-dev-cli version

--- a/.github/workflows/build-quarkus.yml
+++ b/.github/workflows/build-quarkus.yml
@@ -30,16 +30,16 @@ jobs:
           echo "LOCAL_REPO=$(pwd)/maven-repository" >> $GITHUB_ENV
       - name: Build Quarkus core
         run: |
-          git clone -b 3.x https://github.com/quarkusio/quarkus.git && cd quarkus && ./mvnw -B --no-transfer-progress -s .github/mvn-settings.xml clean install -Dquickly -Dno-test-modules -Prelocations -Dmaven.repo.local=${{ env.LOCAL_REPO }}
+          git clone -b 3.39 https://github.com/quarkusio/quarkus.git && cd quarkus && ./mvnw -B --no-transfer-progress -s .github/mvn-settings.xml clean install -Dquickly -Dno-test-modules -Prelocations -Dmaven.repo.local=${{ env.LOCAL_REPO }}
       - name: Build Quarkus Platform
         run: |
           git clone https://github.com/quarkusio/quarkus-platform.git && cd quarkus-platform
           # TODO remove versions:set when moved to testing 999-SNAPSHOT (Quarkus 4)
-          ./mvnw versions:set -DnewVersion=999-core-3.x-SNAPSHOT -Dmaven.repo.local=${{ env.LOCAL_REPO }} -DgenerateBackupPoms=false
+          ./mvnw versions:set -DnewVersion=999-core-3.39-SNAPSHOT -Dmaven.repo.local=${{ env.LOCAL_REPO }} -DgenerateBackupPoms=false
           wget -O minimise_platform.xsl "https://github.com/quarkus-qe/quarkus-test-suite/raw/refs/heads/main/.github/minimise_platform.xsl"
           xsltproc -o pom.xml minimise_platform.xsl pom.xml
-          ./mvnw -Dsync  -Dquarkus.version=3.999-SNAPSHOT -Dmaven.repo.local=${{ env.LOCAL_REPO }}
-          ./mvnw install -Dquarkus.version=3.999-SNAPSHOT -DskipTests -DskipITs -Dmaven.repo.local=${{ env.LOCAL_REPO }}
+          ./mvnw -Dsync  -Dquarkus.version=3.39.999-SNAPSHOT -Dmaven.repo.local=${{ env.LOCAL_REPO }}
+          ./mvnw install -Dquarkus.version=3.39.999-SNAPSHOT -DskipTests -DskipITs -Dmaven.repo.local=${{ env.LOCAL_REPO }}
       - name: Cache Build Outputs
         uses: actions/cache/save@v6
         with:

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        quarkus-version: ["999-core-3.x-SNAPSHOT"]
+        quarkus-version: ["999-core-3.39-SNAPSHOT"]
         java: [ 21, 25 ]
     steps:
       - uses: actions/checkout@v7
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        quarkus-version: ["999-core-3.x-SNAPSHOT"]
+        quarkus-version: ["999-core-3.39-SNAPSHOT"]
         java: [ 25 ]
     steps:
       - uses: actions/checkout@v7
@@ -76,7 +76,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - quarkus-version: "999-core-3.x-SNAPSHOT"
+          - quarkus-version: "999-core-3.39-SNAPSHOT"
             java: 21
             extra-maven-args: ''
     steps:
@@ -120,7 +120,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        quarkus-version: ["999-core-3.x-SNAPSHOT"]
+        quarkus-version: ["999-core-3.39-SNAPSHOT"]
         java: [21]
     steps:
       - uses: actions/checkout@v7
@@ -164,7 +164,7 @@ jobs:
     strategy:
       matrix:
         java: [ 21, 25 ]
-        quarkus-version: ["999-core-3.x-SNAPSHOT"]
+        quarkus-version: ["999-core-3.39-SNAPSHOT"]
     steps:
       - uses: actions/checkout@v7
       - name: Install JDK ${{ matrix.java }}
@@ -196,7 +196,7 @@ jobs:
     strategy:
       matrix:
         java: [ 21 ]
-        quarkus-version: ["999-core-3.x-SNAPSHOT"]
+        quarkus-version: ["999-core-3.39-SNAPSHOT"]
         graalvm-version: ["mandrel-latest"]
         graalvm-java: ["25"]
     steps:

--- a/.github/workflows/kube-pr.yml
+++ b/.github/workflows/kube-pr.yml
@@ -47,7 +47,7 @@ jobs:
     needs: write-comment
     strategy:
       matrix:
-        quarkus-version: ["999-core-3.x-SNAPSHOT"]
+        quarkus-version: ["999-core-3.39-SNAPSHOT"]
         java: [21]
     steps:
       - uses: actions/checkout@v7
@@ -94,7 +94,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - quarkus-version: "999-core-3.x-SNAPSHOT"
+          - quarkus-version: "999-core-3.39-SNAPSHOT"
             java: 21
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -28,7 +28,7 @@ jobs:
     needs: validate-format
     strategy:
       matrix:
-        quarkus-version: ["999-core-3.x-SNAPSHOT"]
+        quarkus-version: ["999-core-3.39-SNAPSHOT"]
         java: [ 21 ]
     outputs:
       has-flaky-tests: ${{steps.flaky-test-detector.outputs.has-flaky-tests}}
@@ -79,7 +79,7 @@ jobs:
     needs: validate-format
     strategy:
       matrix:
-        quarkus-version: [ "999-core-3.x-SNAPSHOT" ]
+        quarkus-version: [ "999-core-3.39-SNAPSHOT" ]
         java: [ 21 ]
     outputs:
       has-flaky-tests: ${{steps.flaky-test-detector.outputs.has-flaky-tests}}
@@ -131,7 +131,7 @@ jobs:
     strategy:
       matrix:
         java: [ 21 ]
-        quarkus-version: ["999-core-3.x-SNAPSHOT"]
+        quarkus-version: ["999-core-3.39-SNAPSHOT"]
     outputs:
       has-flaky-tests: ${{steps.flaky-test-detector.outputs.has-flaky-tests}}
     steps:

--- a/.github/workflows/weekly-jacoco.yml
+++ b/.github/workflows/weekly-jacoco.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        quarkus-version: ["999-core-3.x-SNAPSHOT"]
+        quarkus-version: ["999-core-3.39-SNAPSHOT"]
         java: [ 17 ]
     steps:
       - uses: actions/checkout@v7

--- a/examples/external-applications/src/test/java/io/quarkus/qe/BareMetalQuickstartUsingDefaultsIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/BareMetalQuickstartUsingDefaultsIT.java
@@ -12,7 +12,7 @@ import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 public class BareMetalQuickstartUsingDefaultsIT extends QuickstartUsingDefaultsIT {
 
     @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git",
-            contextDir = "getting-started", branch = "3.x")
+            contextDir = "getting-started", branch = "3.39")
     static final RestService app = new RestService();
 
     @Override

--- a/examples/external-applications/src/test/java/io/quarkus/qe/DevModeQuickstartUsingDefaultsIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/DevModeQuickstartUsingDefaultsIT.java
@@ -14,7 +14,7 @@ import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 public class DevModeQuickstartUsingDefaultsIT {
 
     @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git",
-            contextDir = "getting-started", devMode = true, branch = "3.x")
+            contextDir = "getting-started", devMode = true, branch = "3.39")
     static final RestService app = new RestService();
 
     @Test

--- a/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftContainerRegistryQuickstartUsingDefaultsIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftContainerRegistryQuickstartUsingDefaultsIT.java
@@ -8,7 +8,7 @@ import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 @OpenShiftScenario(deployment = OpenShiftDeploymentStrategy.UsingContainerRegistry)
 public class OpenShiftContainerRegistryQuickstartUsingDefaultsIT extends QuickstartUsingDefaultsIT {
     @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git",
-            contextDir = "getting-started", branch = "3.x")
+            contextDir = "getting-started", branch = "3.39")
     static final RestService app = new RestService();
 
     @Override

--- a/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftS2iQuickstartUsingDefaultsIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftS2iQuickstartUsingDefaultsIT.java
@@ -8,7 +8,7 @@ import io.quarkus.test.services.GitRepositoryQuarkusApplication;
 public class OpenShiftS2iQuickstartUsingDefaultsIT extends QuickstartUsingDefaultsIT {
 
     @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git",
-            contextDir = "getting-started", branch = "3.x")
+            contextDir = "getting-started", branch = "3.39")
     static final RestService app = new RestService();
 
     @Override

--- a/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftS2iQuickstartUsingUberJarIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/OpenShiftS2iQuickstartUsingUberJarIT.java
@@ -16,7 +16,7 @@ public class OpenShiftS2iQuickstartUsingUberJarIT {
      * Package type is set in the custom template.
      */
     @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git",
-            contextDir = "getting-started", branch = "3.x")
+            contextDir = "getting-started", branch = "3.39")
     static final RestService appuberjar = new RestService();
 
     @Test

--- a/examples/external-applications/src/test/java/io/quarkus/qe/QuickstartUsingUsingUberJarIT.java
+++ b/examples/external-applications/src/test/java/io/quarkus/qe/QuickstartUsingUsingUberJarIT.java
@@ -18,7 +18,7 @@ public class QuickstartUsingUsingUberJarIT {
     @GitRepositoryQuarkusApplication(repo = "https://github.com/quarkusio/quarkus-quickstarts.git",
             contextDir = "getting-started",
             mavenArgs = "-Dquarkus.package.jar.type=uber-jar -DskipTests=true -Dquarkus.platform.group-id=${QUARKUS_PLATFORM_GROUP-ID} -Dquarkus.platform.version=${QUARKUS_PLATFORM_VERSION}",
-            branch = "3.x")
+            branch = "3.39")
     static final RestService app = new RestService();
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -50,10 +50,10 @@
         <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
         <quarkus.group-id>io.quarkus</quarkus.group-id>
         <quarkus.artifact-id>quarkus-bom</quarkus.artifact-id>
-        <quarkus.version>3.999-SNAPSHOT</quarkus.version>
+        <quarkus.version>3.39.999-SNAPSHOT</quarkus.version>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>${quarkus.artifact-id}</quarkus.platform.artifact-id>
-        <quarkus.platform.version>999-core-3.x-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>999-core-3.39-SNAPSHOT</quarkus.platform.version>
         <exclude.tests.with.tags>quarkus-cli</exclude.tests.with.tags>
         <include.tests>**/*IT.java</include.tests>
         <exclude.openshift.tests>**/OpenShift*IT.java</exclude.openshift.tests>

--- a/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/QuarkusCliClient.java
+++ b/quarkus-test-cli/src/main/java/io/quarkus/test/bootstrap/QuarkusCliClient.java
@@ -36,7 +36,7 @@ public class QuarkusCliClient {
      * doesn't make sense to request a service context.
      */
     static final String CLI_SERVICE_CONTEXT_KEY = "io.quarkus.test.bootstrap#cli-service-context";
-    private static final String QUARKUS_UPSTREAM_VERSION = "3.999-SNAPSHOT";
+    private static final String QUARKUS_UPSTREAM_VERSION = "3.39.999-SNAPSHOT";
     private static final String BUILD = "build";
     private static final String DEV = "dev";
     private static final String QUARKUS_REGISTRY_UNAVAILABLE_ERROR = "Failed to resolve the Quarkus extension registry"


### PR DESCRIPTION
### Summary

Switching to 3.39 for FW main branch until we move to Quarkus main branch (this needs some additional effort).

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [x] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against Kubernetes (use `run kubernetes` phrase in comment)
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)