### PR TITLE
Bump release version from 1.9 to 2.0 in preparation for Quarkus 4

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 name: Quarkus QE Test Framework
 release:
-  current-version: 1.9.0.Beta1
-  next-version: 1.9.0.Beta2
+  current-version: 2.0.0.Beta1
+  next-version: 2.0.0.Beta2


### PR DESCRIPTION
### Summary

Updating the values after the branching the FW for Quarkus 3.40. We could use the 1.10.z but I think the 2.0.0 is reasonable as the main branch will be now used for Quarkus 4

Please check the relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dependency update
- [ ] Refactoring
- [ ] Release (follows conventions described in the [RELEASE.md](https://github.com/quarkus-qe/quarkus-test-framework/blob/main/RELEASE.md))
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] This change requires execution against Kubernetes (use `run kubernetes` phrase in comment)
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [x] Example scenarios has been updated / added
- [x] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)